### PR TITLE
Rename evaluator

### DIFF
--- a/examples/dynamo/eg3/w3_solver_kernel_mod.F90
+++ b/examples/dynamo/eg3/w3_solver_kernel_mod.F90
@@ -35,7 +35,7 @@ type, public, extends(kernel_type) :: w3_solver_kernel_type
        func_type(W3, GH_BASIS),                                        &
        func_type(W0, GH_DIFF_BASIS)                                    &
        /)
-  integer :: evaluator_shape = quadrature_XYoZ
+  integer :: gh_shape = gh_quadrature_XYoZ
   integer :: iterates_over = CELLS
 contains
   procedure, nopass ::solver_w3_code

--- a/src/dynamo0p3.py
+++ b/src/dynamo0p3.py
@@ -629,7 +629,7 @@ class DynKernMetadata(KernelType):
         # Query the meta-data for the evaluator shape (only required if
         # kernel uses quadrature or an evaluator). If it is not
         # present then eval_shape will be None.
-        self._eval_shape = self.get_integer_variable('evaluator_shape')
+        self._eval_shape = self.get_integer_variable('gh_shape')
 
         # parse the arg_type metadata
         self._arg_descriptors = []
@@ -688,14 +688,14 @@ class DynKernMetadata(KernelType):
                             "In the dynamo0.3 API any kernel requiring "
                             "quadrature or an evaluator ({0}) must also "
                             "supply the shape of that evaluator by setting "
-                            "'evaluator_shape' in the kernel meta-data but "
+                            "'gh_shape' in the kernel meta-data but "
                             "this is missing for kernel '{1}'".
                             format(VALID_EVALUATOR_NAMES, self.name))
                     if self._eval_shape not in VALID_EVALUATOR_SHAPES:
                         raise ParseError(
                             "In the dynamo0.3 API a kernel requiring either "
                             "quadrature or an evaluator must request a valid "
-                            "evaluator shape (one of {0}) but got '{1}' for "
+                            "gh_shape (one of {0}) but got '{1}' for "
                             "kernel '{2}'".
                             format(VALID_EVALUATOR_SHAPES, self._eval_shape,
                                    self.name))

--- a/src/dynamo0p3.py
+++ b/src/dynamo0p3.py
@@ -72,7 +72,7 @@ VALID_FUNCTION_SPACE_NAMES = VALID_FUNCTION_SPACES + VALID_ANY_SPACE_NAMES
 VALID_EVALUATOR_NAMES = ["gh_basis", "gh_diff_basis"]
 VALID_METAFUNC_NAMES = VALID_EVALUATOR_NAMES + ["gh_orientation"]
 
-VALID_EVALUATOR_SHAPES = ["quadrature_xyoz", "evaluator_xyz"]
+VALID_EVALUATOR_SHAPES = ["gh_quadrature_xyoz", "gh_evaluator"]
 
 VALID_SCALAR_NAMES = ["gh_real", "gh_integer"]
 VALID_OPERATOR_NAMES = ["gh_operator", "gh_columnwise_operator"]
@@ -678,7 +678,7 @@ class DynKernMetadata(KernelType):
                     "meta_funcs must be unique, but '{0}' is replicated."
                     .format(fs_name))
 
-            # Check that a valid evaluator shape has been specified if
+            # Check that a valid shape has been specified if
             # this function space requires a basis or differential basis
             for name in descriptor.operator_names:
                 if name in VALID_EVALUATOR_NAMES:
@@ -727,11 +727,11 @@ class DynKernMetadata(KernelType):
                              "argument that is updated (written to) but "
                              "found none for kernel {0}".format(self.name))
 
-        # Check that no evaluator shape has been supplied if no basis or
+        # Check that no shape has been supplied if no basis or
         # differential basis functions are required for the kernel
         if not need_evaluator and self._eval_shape:
             raise ParseError(
-                "Kernel '{0}' specifies an evaluator shape ({1}) but does not "
+                "Kernel '{0}' specifies a gh_shape ({1}) but does not "
                 "need an evaluator because no basis or differential basis "
                 "functions are required".format(self.name, self._eval_shape))
 

--- a/src/tests/dynamo0p3_test.py
+++ b/src/tests/dynamo0p3_test.py
@@ -95,7 +95,7 @@ module testkern_qr
              func_type(w3, gh_basis, gh_diff_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_qr_code
   end type testkern_qr_type
@@ -470,24 +470,24 @@ def test_fsdesc_fs_not_in_argdesc():
         'meta_args' in str(excinfo)
 
 
-def test_missing_evaluator_shape_both():  # pylint: disable=invalid-name
+def test_missing_shape_both():  # pylint: disable=invalid-name
     ''' Check that we raise the correct error if a kernel requiring
     quadrature/evaluator fails to specify the shape of the evaluator '''
     fparser.logging.disable('CRITICAL')
     # Remove the line specifying the shape of the evaluator
     code = CODE.replace(
-        "     integer, parameter :: evaluator_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     assert ("must also supply the shape of that evaluator by setting "
-            "'evaluator_shape' in the kernel meta-data but this is missing "
+            "'gh_shape' in the kernel meta-data but this is missing "
             "for kernel 'testkern_qr_type'" in str(excinfo))
 
 
-def test_missing_evaluator_shape_basis_only():  # pylint: disable=invalid-name
+def test_missing_shape_basis_only():  # pylint: disable=invalid-name
     ''' Check that we raise the correct error if a kernel specifying
     that it needs gh_basis fails to specify the shape of the evaluator '''
     fparser.logging.disable('CRITICAL')
@@ -501,14 +501,14 @@ def test_missing_evaluator_shape_basis_only():  # pylint: disable=invalid-name
         "          (/ func_type(w1, gh_basis)                &\n", 1)
     # Remove the line specifying the shape of the evaluator
     code = code1.replace(
-        "     integer, parameter :: evaluator_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     assert ("must also supply the shape of that evaluator by setting "
-            "'evaluator_shape' in the kernel meta-data but this is missing "
+            "'gh_shape' in the kernel meta-data but this is missing "
             "for kernel 'testkern_qr_type'" in str(excinfo))
 
 
@@ -526,36 +526,36 @@ def test_missing_eval_shape_diff_basis_only():  # pylint: disable=invalid-name
         "          (/ func_type(w1, gh_diff_basis)           &\n", 1)
     # Remove the line specifying the shape of the evaluator
     code = code1.replace(
-        "     integer, parameter :: evaluator_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     assert ("must also supply the shape of that evaluator by setting "
-            "'evaluator_shape' in the kernel meta-data but this is missing "
+            "'gh_shape' in the kernel meta-data but this is missing "
             "for kernel 'testkern_qr_type'" in str(excinfo))
 
 
-def test_invalid_evaluator_shape():
+def test_invalid_shape():
     ''' Check that we raise the correct error if a kernel requiring
     quadrature/evaluator specifies an unrecognised shape for the evaluator '''
     fparser.logging.disable('CRITICAL')
     # Specify an invalid shape for the evaluator
     code = CODE.replace(
-        "evaluator_shape = quadrature_XYoZ",
-        "evaluator_shape = quadrature_wrong", 1)
+        "gh_shape = quadrature_XYoZ",
+        "gh_shape = quadrature_wrong", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     print str(excinfo)
     assert ("request a valid evaluator shape (one of ['quadrature_xyoz', "
-            "'evaluator_xyz']) but got 'quadrature_wrong' for kernel "
+            "'gh_xyz']) but got 'quadrature_wrong' for kernel "
             "'testkern_qr_type'" in str(excinfo))
 
 
-def test_unecessary_eval_shape():
+def test_unecessary_shape():
     ''' Check that we raise the correct error if a kernel meta-data specifies
     an evaluator shape but does not require quadrature or an evaluator '''
     fparser.logging.disable('CRITICAL')
@@ -3188,7 +3188,7 @@ module dummy_mod
              func_type(w2v, gh_basis)     &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_xyoz
+     integer, parameter :: gh_shape = quadrature_xyoz
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3287,7 +3287,7 @@ module dummy_mod
           (/ func_type(any_space_1, gh_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3332,7 +3332,7 @@ module dummy_mod
              func_type(w2v, gh_diff_basis)     &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3431,7 +3431,7 @@ module dummy_mod
           (/ func_type(any_space_1, gh_diff_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type

--- a/src/tests/dynamo0p3_test.py
+++ b/src/tests/dynamo0p3_test.py
@@ -550,8 +550,8 @@ def test_invalid_shape():
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     print str(excinfo)
-    assert ("request a valid evaluator shape (one of ['quadrature_xyoz', "
-            "'gh_xyz']) but got 'quadrature_wrong' for kernel "
+    assert ("request a valid gh_shape (one of ['quadrature_xyoz', "
+            "'evaluator_xyz']) but got 'quadrature_wrong' for kernel "
             "'testkern_qr_type'" in str(excinfo))
 
 

--- a/src/tests/dynamo0p3_test.py
+++ b/src/tests/dynamo0p3_test.py
@@ -95,7 +95,7 @@ module testkern_qr
              func_type(w3, gh_basis, gh_diff_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_qr_code
   end type testkern_qr_type
@@ -476,7 +476,7 @@ def test_missing_shape_both():  # pylint: disable=invalid-name
     fparser.logging.disable('CRITICAL')
     # Remove the line specifying the shape of the evaluator
     code = CODE.replace(
-        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = gh_quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -501,7 +501,7 @@ def test_missing_shape_basis_only():  # pylint: disable=invalid-name
         "          (/ func_type(w1, gh_basis)                &\n", 1)
     # Remove the line specifying the shape of the evaluator
     code = code1.replace(
-        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = gh_quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -526,7 +526,7 @@ def test_missing_eval_shape_diff_basis_only():  # pylint: disable=invalid-name
         "          (/ func_type(w1, gh_diff_basis)           &\n", 1)
     # Remove the line specifying the shape of the evaluator
     code = code1.replace(
-        "     integer, parameter :: gh_shape = quadrature_XYoZ\n",
+        "     integer, parameter :: gh_shape = gh_quadrature_XYoZ\n",
         "", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -543,15 +543,15 @@ def test_invalid_shape():
     fparser.logging.disable('CRITICAL')
     # Specify an invalid shape for the evaluator
     code = CODE.replace(
-        "gh_shape = quadrature_XYoZ",
+        "gh_shape = gh_quadrature_XYoZ",
         "gh_shape = quadrature_wrong", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     print str(excinfo)
-    assert ("request a valid gh_shape (one of ['quadrature_xyoz', "
-            "'evaluator_xyz']) but got 'quadrature_wrong' for kernel "
+    assert ("request a valid gh_shape (one of ['gh_quadrature_xyoz', "
+            "'gh_evaluator']) but got 'quadrature_wrong' for kernel "
             "'testkern_qr_type'" in str(excinfo))
 
 
@@ -572,8 +572,8 @@ def test_unecessary_shape():
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
     print str(excinfo)
-    assert ("Kernel 'testkern_qr_type' specifies an evaluator shape "
-            "(quadrature_xyoz) but does not need an evaluator because no "
+    assert ("Kernel 'testkern_qr_type' specifies a gh_shape "
+            "(gh_quadrature_xyoz) but does not need an evaluator because no "
             "basis or differential basis functions are required"
             in str(excinfo))
 
@@ -3188,7 +3188,7 @@ module dummy_mod
              func_type(w2v, gh_basis)     &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_xyoz
+     integer, parameter :: gh_shape = gh_quadrature_xyoz
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3287,7 +3287,7 @@ module dummy_mod
           (/ func_type(any_space_1, gh_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3332,7 +3332,7 @@ module dummy_mod
              func_type(w2v, gh_diff_basis)     &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type
@@ -3431,7 +3431,7 @@ module dummy_mod
           (/ func_type(any_space_1, gh_diff_basis) &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => dummy_code
   end type dummy_type

--- a/src/tests/test_files/dynamo0p3/assemble_weak_derivative_w3_w2_kernel_mod.f90
+++ b/src/tests/test_files/dynamo0p3/assemble_weak_derivative_w3_w2_kernel_mod.f90
@@ -15,7 +15,7 @@ module assemble_weak_derivative_w3_w2_kernel_mod
          func_type(W2, GH_DIFF_BASIS, GH_ORIENTATION)          &
          /)
     integer :: iterates_over = CELLS
-    integer, parameter :: gh_shape = quadrature_XYoZ
+    integer, parameter :: gh_shape = gh_quadrature_XYoZ
   contains
     procedure, nopass :: assemble_weak_derivative_w3_w2_kernel_code
   end type

--- a/src/tests/test_files/dynamo0p3/assemble_weak_derivative_w3_w2_kernel_mod.f90
+++ b/src/tests/test_files/dynamo0p3/assemble_weak_derivative_w3_w2_kernel_mod.f90
@@ -15,7 +15,7 @@ module assemble_weak_derivative_w3_w2_kernel_mod
          func_type(W2, GH_DIFF_BASIS, GH_ORIENTATION)          &
          /)
     integer :: iterates_over = CELLS
-    integer, parameter :: evaluator_shape = quadrature_XYoZ
+    integer, parameter :: gh_shape = quadrature_XYoZ
   contains
     procedure, nopass :: assemble_weak_derivative_w3_w2_kernel_code
   end type

--- a/src/tests/test_files/dynamo0p3/ru_kernel_mod.f90
+++ b/src/tests/test_files/dynamo0p3/ru_kernel_mod.f90
@@ -16,7 +16,7 @@ type, public, extends(kernel_type) :: ru_kernel_type
        func_type(W0, GH_BASIS, GH_DIFF_BASIS)                          &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: evaluator_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = quadrature_XYoZ
 contains
   procedure, nopass ::ru_code
 end type

--- a/src/tests/test_files/dynamo0p3/ru_kernel_mod.f90
+++ b/src/tests/test_files/dynamo0p3/ru_kernel_mod.f90
@@ -16,7 +16,7 @@ type, public, extends(kernel_type) :: ru_kernel_type
        func_type(W0, GH_BASIS, GH_DIFF_BASIS)                          &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: gh_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = gh_quadrature_XYoZ
 contains
   procedure, nopass ::ru_code
 end type

--- a/src/tests/test_files/dynamo0p3/testkern_any_space_1_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_any_space_1_mod.f90
@@ -17,7 +17,7 @@ type, public, extends(kernel_type) ::testkern_any_space_1_type
        FUNC_TYPE(W0,          GH_DIFF_BASIS)                           &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: evaluator_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = quadrature_XYoZ
 
 contains
   procedure, public, nopass :: testkern_any_space_1_code

--- a/src/tests/test_files/dynamo0p3/testkern_any_space_1_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_any_space_1_mod.f90
@@ -17,7 +17,7 @@ type, public, extends(kernel_type) ::testkern_any_space_1_type
        FUNC_TYPE(W0,          GH_DIFF_BASIS)                           &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: gh_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = gh_quadrature_XYoZ
 
 contains
   procedure, public, nopass :: testkern_any_space_1_code

--- a/src/tests/test_files/dynamo0p3/testkern_any_space_4_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_any_space_4_mod.f90
@@ -18,7 +18,7 @@ type, public, extends(kernel_type) :: testkern_any_space_4_type
        func_type(ANY_SPACE_4, GH_BASIS, GH_DIFF_BASIS)                 &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: evaluator_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = quadrature_XYoZ
 contains
   procedure, public, nopass :: testkern_any_space_4_code
 end type testkern_any_space_4_type

--- a/src/tests/test_files/dynamo0p3/testkern_any_space_4_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_any_space_4_mod.f90
@@ -18,7 +18,7 @@ type, public, extends(kernel_type) :: testkern_any_space_4_type
        func_type(ANY_SPACE_4, GH_BASIS, GH_DIFF_BASIS)                 &
        /)
   integer :: iterates_over = CELLS
-  integer, parameter :: gh_shape = quadrature_XYoZ
+  integer, parameter :: gh_shape = gh_quadrature_XYoZ
 contains
   procedure, public, nopass :: testkern_any_space_4_code
 end type testkern_any_space_4_type

--- a/src/tests/test_files/dynamo0p3/testkern_anyw2_operator_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_anyw2_operator_mod.f90
@@ -41,7 +41,7 @@ module testkern_anyw2_operator_mod
           (/ func_type(any_w2, gh_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_anyw2_operator_code
   end type testkern_anyw2_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_anyw2_operator_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_anyw2_operator_mod.f90
@@ -41,7 +41,7 @@ module testkern_anyw2_operator_mod
           (/ func_type(any_w2, gh_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_anyw2_operator_code
   end type testkern_anyw2_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_anyw2_vector.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_anyw2_vector.f90
@@ -38,7 +38,7 @@ module testkern_anyw2_vector_mod
      type(func_type), dimension(1) :: meta_funcs = &
           (/ func_type(any_w2,gh_basis,gh_diff_basis) /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_anyw2_vector_code
   end type testkern_anyw2_vector_type

--- a/src/tests/test_files/dynamo0p3/testkern_anyw2_vector.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_anyw2_vector.f90
@@ -38,7 +38,7 @@ module testkern_anyw2_vector_mod
      type(func_type), dimension(1) :: meta_funcs = &
           (/ func_type(any_w2,gh_basis,gh_diff_basis) /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_anyw2_vector_code
   end type testkern_anyw2_vector_type

--- a/src/tests/test_files/dynamo0p3/testkern_multi_anyw2_basis.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_multi_anyw2_basis.f90
@@ -38,7 +38,7 @@ module testkern_multi_anyw2_basis_mod
      type(func_type), dimension(1) :: meta_funcs = &
           (/ func_type(any_w2,gh_basis,gh_diff_basis) /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_multi_anyw2_basis_code
   end type testkern_multi_anyw2_basis_type

--- a/src/tests/test_files/dynamo0p3/testkern_multi_anyw2_basis.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_multi_anyw2_basis.f90
@@ -38,7 +38,7 @@ module testkern_multi_anyw2_basis_mod
      type(func_type), dimension(1) :: meta_funcs = &
           (/ func_type(any_w2,gh_basis,gh_diff_basis) /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_multi_anyw2_basis_code
   end type testkern_multi_anyw2_basis_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_mod
           (/ func_type(w0, gh_basis, gh_diff_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_mod
           (/ func_type(w0, gh_basis, gh_diff_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_nofield_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_nofield_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_nofield_mod
              func_type(w0, gh_diff_basis)           &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_nofield_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_nofield_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_nofield_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_nofield_mod
              func_type(w0, gh_diff_basis)           &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_nofield_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_nofield_scalar_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_nofield_scalar_mod.f90
@@ -16,7 +16,7 @@ module testkern_operator_nofield_scalar_mod
           (/ func_type(w2, gh_basis)                &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_nofield_scalar_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_nofield_scalar_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_nofield_scalar_mod.f90
@@ -16,7 +16,7 @@ module testkern_operator_nofield_scalar_mod
           (/ func_type(w2, gh_basis)                &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_nofield_scalar_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_orient_2_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_orient_2_mod.f90
@@ -18,7 +18,7 @@ module testkern_operator_orient_2_mod
              func_type(W2, gh_orientation)            &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_orient_2_code
   end type testkern_operator_orient_2_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_orient_2_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_orient_2_mod.f90
@@ -18,7 +18,7 @@ module testkern_operator_orient_2_mod
              func_type(W2, gh_orientation)            &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_orient_2_code
   end type testkern_operator_orient_2_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_orient_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_orient_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_orient_mod
              func_type(W1, gh_basis, gh_orientation) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_orient_code
   end type testkern_operator_orient_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_orient_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_orient_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_orient_mod
              func_type(W1, gh_basis, gh_orientation) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_orient_code
   end type testkern_operator_orient_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_read_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_read_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_read_mod
           (/ func_type(w0, gh_basis, gh_diff_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_operator_read_mod.f90
+++ b/src/tests/test_files/dynamo0p3/testkern_operator_read_mod.f90
@@ -17,7 +17,7 @@ module testkern_operator_read_mod
           (/ func_type(w0, gh_basis, gh_diff_basis) &
           /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_operator_code
   end type testkern_operator_type

--- a/src/tests/test_files/dynamo0p3/testkern_orientation.F90
+++ b/src/tests/test_files/dynamo0p3/testkern_orientation.F90
@@ -20,7 +20,7 @@ module testkern_orientation_mod
          func_type(W0, GH_BASIS, GH_DIFF_BASIS)                          &
          /)
     integer :: iterates_over = CELLS
-    integer, parameter :: gh_shape = quadrature_XYoZ
+    integer, parameter :: gh_shape = gh_quadrature_XYoZ
   contains
     procedure() :: code => testkern_orientation_code
   end type testkern_orientation_type

--- a/src/tests/test_files/dynamo0p3/testkern_orientation.F90
+++ b/src/tests/test_files/dynamo0p3/testkern_orientation.F90
@@ -20,7 +20,7 @@ module testkern_orientation_mod
          func_type(W0, GH_BASIS, GH_DIFF_BASIS)                          &
          /)
     integer :: iterates_over = CELLS
-    integer, parameter :: evaluator_shape = quadrature_XYoZ
+    integer, parameter :: gh_shape = quadrature_XYoZ
   contains
     procedure() :: code => testkern_orientation_code
   end type testkern_orientation_type

--- a/src/tests/test_files/dynamo0p3/testkern_qr.F90
+++ b/src/tests/test_files/dynamo0p3/testkern_qr.F90
@@ -22,7 +22,7 @@ module testkern_qr_mod
              func_type(w3, gh_basis, gh_diff_basis)  &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: evaluator_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = quadrature_XYoZ
    contains
      procedure() :: code => testkern_qr_code
   end type testkern_qr_type

--- a/src/tests/test_files/dynamo0p3/testkern_qr.F90
+++ b/src/tests/test_files/dynamo0p3/testkern_qr.F90
@@ -22,7 +22,7 @@ module testkern_qr_mod
              func_type(w3, gh_basis, gh_diff_basis)  &
            /)
      integer, parameter :: iterates_over = cells
-     integer, parameter :: gh_shape = quadrature_XYoZ
+     integer, parameter :: gh_shape = gh_quadrature_XYoZ
    contains
      procedure() :: code => testkern_qr_code
   end type testkern_qr_type

--- a/src/tests/test_files/dynamo0p3/weighted_proj_theta2_kernel_mod.F90
+++ b/src/tests/test_files/dynamo0p3/weighted_proj_theta2_kernel_mod.F90
@@ -14,7 +14,7 @@ module weighted_proj_theta2_kernel_mod
 use kernel_mod,              only : kernel_type
 use argument_mod,            only : arg_type, func_type,                     &
                                     GH_OPERATOR, GH_FIELD, GH_READ, GH_WRITE,&
-                                    ANY_SPACE_9, W2,                                  &
+                                    ANY_SPACE_9, W2,                         &
                                     GH_BASIS, GH_DIFF_BASIS,                 &
                                     CELLS
 use constants_mod,           only : r_def, i_def
@@ -28,15 +28,15 @@ implicit none
 type, public, extends(kernel_type) :: weighted_proj_theta2_kernel_type
   private
   type(arg_type) :: meta_args(2) = (/                                  &
-       arg_type(GH_OPERATOR, GH_WRITE, ANY_SPACE_9, W2),                        &
-       arg_type(GH_FIELD,    GH_READ,  ANY_SPACE_9)                             &
+       arg_type(GH_OPERATOR, GH_WRITE, ANY_SPACE_9, W2),               &
+       arg_type(GH_FIELD,    GH_READ,  ANY_SPACE_9)                    &
        /)
   type(func_type) :: meta_funcs(2) = (/                                &
-       func_type(ANY_SPACE_9, GH_BASIS, GH_DIFF_BASIS),                         &
+       func_type(ANY_SPACE_9, GH_BASIS, GH_DIFF_BASIS),                &
        func_type(W2, GH_BASIS)                                         &
        /)
   integer :: iterates_over = CELLS
-  integer :: evaluator_shape = QUADRATURE_XYoZ
+  integer :: gh_shape = QUADRATURE_XYoZ
 
 contains
   procedure, nopass ::weighted_proj_theta2_code

--- a/src/tests/test_files/dynamo0p3/weighted_proj_theta2_kernel_mod.F90
+++ b/src/tests/test_files/dynamo0p3/weighted_proj_theta2_kernel_mod.F90
@@ -36,7 +36,7 @@ type, public, extends(kernel_type) :: weighted_proj_theta2_kernel_type
        func_type(W2, GH_BASIS)                                         &
        /)
   integer :: iterates_over = CELLS
-  integer :: gh_shape = QUADRATURE_XYoZ
+  integer :: gh_shape = GH_QUADRATURE_XYoZ
 
 contains
   procedure, nopass ::weighted_proj_theta2_code


### PR DESCRIPTION
This pull request completes issue #45 and is simply a matter of re-naming meta-data quantities relating to evaluators/quadrature. It is required by SRS issue 1070.