### PR TITLE
Dynamo example3

### DIFF
--- a/examples/dynamo/eg3/colouring_and_omp.py
+++ b/examples/dynamo/eg3/colouring_and_omp.py
@@ -17,11 +17,12 @@ def trans(psy):
         print "Transforming invoke '"+invoke.name+"'..."
         schedule = invoke.schedule
 
-        # Colour all of the loops unless they are on W3
+        # Colour all of the loops over cells unless they are on W3
         cschedule = schedule
         for child in schedule.children:
-            if isinstance(child, Loop) and child.field_space != "w3":
-                cschedule, _ = ctrans.apply(child)
+             if isinstance(child, Loop) and child.field_space != "w3" \
+                and child.iteration_space == "cells":
+                 cschedule, _ = ctrans.apply(child)
 
         # Then apply OpenMP to each of the colour loops
         schedule = cschedule

--- a/examples/dynamo/eg3/solver_mod.x90
+++ b/examples/dynamo/eg3/solver_mod.x90
@@ -148,37 +148,33 @@ contains
 
     ! the scalars
     ! the greeks - standard BiCGStab
-    real(kind=r_def)                   :: rho,alpha,omega,beta, norm
-    real(kind=r_def)                   :: ts,tt
+    real(kind=r_def)                   :: rho, alpha, omega, beta, norm
+    real(kind=r_def)                   :: ts, tt
     ! others
-    real(kind=r_def)                   :: err,sc_err, init_err
+    real(kind=r_def)                   :: err, sc_err, init_err
     integer                            :: iter
+    real(kind=r_def)                   :: const
     integer                            :: rhs_fs
     type(function_space_type)          :: fs
 
     ! compute the residual this is a global sum to the PSy ---
-    !PSY call invoke ( inner_prod(rhs,rhs,sc_err))
-    call invoke_inner_prod(rhs,rhs,sc_err)
+    call invoke( inner_self_product(rhs, sc_err) )
     sc_err = max(sqrt(sc_err), 0.1_r_def)
     write( log_scratch_space, '(A,E15.8)' ) &
          "solver_algorithm: bicgstab starting ... ||b|| = ", sc_err
     call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
-    !PSY call invoke ( set_field_scalar(0.0_r_def, lhs))
-    call invoke_set_field_scalar(0.0_r_def, lhs)
+    call invoke( set_field_scalar(0.0_r_def, lhs) )
 
     rhs_fs = rhs%which_function_space()
     v = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
-    call invoke_set_field_scalar(0.0_r_def, v)
-    call invoke_set_field_scalar(0.0_r_def, v)
+    call invoke( set_field_scalar(0.0_r_def, v) )
     call invoke( matrix_vector_kernel_mm_type(v,lhs,mm) )
 
 
     res = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
-    !PSY call invoke ( minus_field_data(rhs,v,res))
-    call invoke_minus_field_data(rhs,v,res)
+    call invoke( minus_fields(rhs,v,res) )
 
-    !PSY call invoke ( inner_prod(res,res,err))
-    call invoke_inner_prod(res,res,err)
+    call invoke( inner_self_product(res, err) )
     err = sqrt(err)/sc_err
     init_err=err
     if (err < SOLVER_TOL) then
@@ -196,12 +192,10 @@ contains
 
     cr = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
-    !PSY call invoke ( copy_field_data(res,cr))
-    call invoke_copy_field_data(res,cr)
+    call invoke( copy_field(res, cr) )
 
     p = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
-    !PSY call invoke ( set_field_scalar(0.0_r_def, p))
-    call invoke_set_field_scalar(0.0_r_def, p)
+    call invoke( set_field_scalar(0.0_r_def, p) )
 
     t = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
@@ -209,55 +203,46 @@ contains
 
     cs = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
-    !PSY call invoke ( set_field_scalar(0.0_r_def, v))
-    call invoke_set_field_scalar(0.0_r_def, v)
+    call invoke( set_field_scalar(0.0_r_def, v) )
 
     do iter = 1, MAX_ITER
 
-      !PSY call invoke ( inner_prod(cr,res,rho))
-      call invoke_inner_prod(cr,res,rho)
+      call invoke( inner_product(cr, res, rho) )
       beta = (rho/norm) * (alpha/omega)
-      !PSY call invoke ( axpy((-beta*omega),v,res,t))
-      call invoke_axpy((-beta*omega),v,res,t)
+      const = -beta*omega
+      call invoke( axpy(const, v, res, t) )
 
       call preconditioner( s, t, NO_PRE_COND )
 
-      !PSY call invoke ( axpy(beta,p,s,p))
-      call invoke_axpy(beta,p,s,p)
+      call invoke( inc_axpy(beta, p, s) )
 
-      call invoke_set_field_scalar(0.0_r_def,v)
+      call invoke( set_field_scalar(0.0_r_def, v) )
       call invoke( matrix_vector_kernel_mm_type(v,p,mm) )
 
-      !PSY call invoke ( inner_prod(cr,v,norm))
-      call invoke_inner_prod(cr,v,norm)
+      call invoke( inner_product(cr, v, norm) )
       alpha = rho/norm
-      !PSY call invoke ( axpy(-alpha,v,res,s))
-      call invoke_axpy(-alpha,v,res,s)
+      const = -alpha
+      call invoke( axpy(const, v, res, s) )
 
       call preconditioner( cs, s, NO_PRE_COND )
 
-      call invoke_set_field_scalar(0.0_r_def,t)
+      call invoke( set_field_scalar(0.0_r_def, t) )
       call invoke( matrix_vector_kernel_mm_type(t,cs,mm) )
 
-      !PSY call invoke ( inner_prod(t,t,tt), &
-      !PSY               inner_prod(t,s,ts))
-      call invoke_inner_prod(t,t,tt)
-      call invoke_inner_prod(t,s,ts)
+      call invoke( inner_self_product(t, tt), &
+                   inner_product(t, s, ts) )
 
       omega = ts/tt
 
+      const = -omega
       !      lhs = lhs + omega * s + alpha * p
-      !PSY call invoke ( axpy(omega,s,lhs,lhs)
-      !PSY             , axpy(alpha,p,lhs,lhs)
-      !PSY             , axpy(-omega,t,s,res) )
-      call invoke_axpy(omega,s,lhs,lhs)
-      call invoke_axpy(alpha,p,lhs,lhs)
-      call invoke_axpy(-omega,t,s,res)
+      call invoke( inc_xpby(lhs, omega, s), &
+                   inc_xpby(lhs, alpha, p), &
+                   axpy(const, t, s, res) )
       norm = rho
 
       ! check for convergence
-      !PSY call invoke ( inner_prod(res,res,err))
-      call invoke_inner_prod(res,res,err)
+      call invoke( inner_self_product(res, err) )
       err = sqrt(err)/sc_err
 
       write( log_scratch_space, '(A,I2,A, E15.8)' ) "solver_algorithm[", iter, &
@@ -305,12 +290,13 @@ contains
     real(kind=r_def)                   :: alpha, beta
     real(kind=r_def)                   :: rs_new, rs_old
     ! others
-    real(kind=r_def)                   :: err,sc_err, init_err
+    real(kind=r_def)                   :: err, sc_err, init_err
+    real(kind=r_def)                   :: const
     integer                            :: iter
     integer                            :: rhs_fs
     type(function_space_type)          :: fs
 
-    call invoke_inner_prod( rhs, rhs, rs_old )
+    call invoke( inner_self_product(rhs, rs_old) )
 
     ! compute the residual this is a global sum to the PSy ---
 
@@ -321,20 +307,15 @@ contains
     Ap   = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
 !! First guess: lhs = rhs
-!    !PSY call invoke ( copy_field_data(rhs,lhs))
+!    !PSY call invoke ( copy_field(rhs, lhs) )
 !    call invoke_copy_field_data(rhs,lhs)
 ! First guess: lhs = 0
-    !PSY call invoke ( set_field_scalar(0.0_r_def, lhs))
-    call invoke_set_field_scalar(0.0_r_def, lhs)
-
-    call invoke( matrix_vector_kernel_mm_type(Ap,lhs,mm) )
-
-    !PSY call invoke ( minus_field_data(rhs,Ap,res))
-    call invoke_minus_field_data( rhs, Ap, res )
-    !PSY call invoke ( copy_field_data(res,p))
-    call invoke_copy_field_data( res, p )
-    !PSY call invoke ( inner_prod(res,res,rs_old))
-    call invoke_inner_prod( res, res, rs_old )
+    call invoke( name = "CG_first_guess",                   &
+                 set_field_scalar(0.0_r_def, lhs),          &
+                 matrix_vector_kernel_mm_type(Ap, lhs, mm), &
+                 minus_fields(rhs, Ap, res),                &
+                 copy_field(res, p),                        &
+                 inner_self_product(res, rs_old) )
 
     err = sqrt(rs_old)
     sc_err = max(err, 0.1_r_def)
@@ -352,21 +333,18 @@ contains
     end if
 
     do iter = 1, MAX_ITER
-       call invoke_set_field_scalar(0.0_r_def, Ap)
-       call invoke( matrix_vector_kernel_mm_type(Ap,p,mm) )
+      call invoke( set_field_scalar(0.0_r_def, Ap) )
+      call invoke( matrix_vector_kernel_mm_type(Ap,p,mm) )
 
-      !PSY call invoke ( inner_prod(p,Ap,rs_new))
-      call invoke_inner_prod( p, Ap, rs_new )
+      call invoke( inner_product(p, Ap, rs_new) )
       alpha = rs_old/rs_new
 
-      !PSY call invoke ( axpy(alpha,p,lhs,lhs))
-      call invoke_axpy( alpha, p, lhs, lhs )
-      !PSY call invoke ( axpy(-alpha,Ap,res,res))
-      call invoke_axpy( -alpha, Ap, res, res )
+      const = -alpha
+      call invoke( inc_xpby(lhs, alpha, p) )
+      call invoke( inc_xpby(res, const, Ap) )
 
       ! check for convergence
-      !PSY call invoke ( inner_prod(res,res,err))
-      call invoke_inner_prod(res,res,rs_new)
+      call invoke( inner_self_product(res, err) )
       err = sqrt(rs_new)/sc_err
 
       write( log_scratch_space, '(A, I2, A, E15.8)' ) &
@@ -383,8 +361,7 @@ contains
 
       beta = rs_new/rs_old
       rs_old = rs_new
-      !PSY call invoke ( axpy(beta,p,res,p))
-      call invoke_axpy(beta,p,res,p)
+      call invoke( inc_axpy(beta, p, res) )
 
     end do
 
@@ -434,27 +411,21 @@ contains
   res = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
 ! Compute mass lump
-  !PSY call invoke ( set_field_scalar(1.0_r_def, Ax))
-  call invoke_set_field_scalar(1.0_r_def, Ax)
-  call invoke( matrix_vector_kernel_mm_type(lumped_weight,Ax,mm) )
-
-  !PSY call invoke ( divide_fields(rhs, lumped_weight, lhs))
-  call invoke_divide_field( rhs, lumped_weight, lhs )
+  call invoke( name = "Jacobi_mass_lump",                           &
+               set_field_scalar(1.0_r_def, Ax),                     &
+               matrix_vector_kernel_mm_type(lumped_weight, Ax, mm), &
+               divide_fields(rhs, lumped_weight, lhs) )
 
 ! initial guess
-  !PSY call invoke ( set_field_scalar(0.0_r_def, lhs))
-  call invoke_set_field_scalar(0.0_r_def, lhs)
+  call invoke( set_field_scalar(0.0_r_def, lhs) )
 
   do iter = 1,n_iter
-    call invoke_set_field_scalar(0.0_r_def, Ax)
+    call invoke( set_field_scalar(0.0_r_def, Ax) )
     call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
 
-    !PSY call invoke ( minus_field_data(rhs,Ax,res))
-    call invoke_minus_field_data( rhs, Ax, res )
-    !PSY call invoke ( divide_fields(res, lumped_weight, res))
-    call invoke_divide_field( res, lumped_weight, res )
-    !PSY call invoke ( axpy(MU,res,lhs,lhs))
-    call invoke_axpy( MU, res, lhs, lhs )
+    call invoke( minus_fields(rhs, Ax, res) )
+    call invoke( inc_divide_field(res, lumped_weight) )
+    call invoke( inc_xpby(lhs, MU, res) )
 
 ! Ready for next iteration
   end do
@@ -490,6 +461,7 @@ contains
     real(kind=r_def)                   :: beta, si, ci, nrm, h1, h2, p, q
     ! others
     real(kind=r_def)                   :: err, sc_err, init_err
+    real(kind=r_def)                   :: const
     integer                            :: iter, i, j, k, m
     integer                            :: rhs_fs
     type(function_space_type)          :: fs
@@ -505,8 +477,7 @@ contains
       v(iter) = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
     end do
 
-    !PSY call invoke ( inner_prod(rhs,rhs,err))
-    call invoke_inner_prod( rhs, rhs, err )
+    call invoke( inner_self_product(rhs, err) )
     sc_err = max( sqrt(err), 0.01_r_def )
     init_err = sc_err
 
@@ -518,22 +489,19 @@ contains
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
       return
     end if
-    call invoke_set_field_scalar(0.0_r_def, Ax)
+    call invoke( set_field_scalar(0.0_r_def, Ax) )
     call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
 
-    !PSY call invoke ( minus_field_data(rhs,Ax,r))
-    call invoke_minus_field_data( rhs, Ax, r )
+    call invoke( minus_fields(rhs, Ax, r) )
 
 !    call Precon(s,r,preit,precnd)
-    !PSY call invoke ( copy_field_data(r,s))
-    call invoke_copy_field_data(r, s)
+    call invoke( copy_field(r, s) )
 
-    !PSY call invoke ( inner_prod(s,s,err))
-    call invoke_inner_prod( s, s, err )
+    call invoke( inner_self_product(s, err) )
     beta = sqrt(err)
 
-    !PSY call invoke ( copy_field_data(s,v(1)))
-    call invoke_copy_scaled_field_data( 1.0_r_def/beta, s, v(1) )
+    const = 1.0_r_def/beta
+    call invoke( copy_scaled_field(const, s, v(1)) )
 
 
     h(:,:) = 0.0_r_def
@@ -546,20 +514,18 @@ contains
 
 ! This is the correct settings => call Precon(w,v(:,:,j),pstit,pstcnd)
         call preconditioner( w, v(j), NO_PRE_COND )
-        call invoke_set_field_scalar(0.0_r_def, s)
+        call invoke( set_field_scalar(0.0_r_def, s) )
         call invoke( matrix_vector_kernel_mm_type(s,w,mm) )
 
 ! This is the correct settings => call Precon(w,s,preit,precnd)
         call preconditioner( w, s, NO_PRE_COND )
 
         do k = 1, j
-          !PSY call invoke ( inner_prod(v(k),w,h(k,j)))
-          call invoke_inner_prod( v(k), w, h(k,j)  )
+          call invoke( inner_product(v(k), w, h(k,j)) )
           !PSY call invoke ( axpy(-h(k,j),v(k),w,w))
           call invoke_axpy( -h(k,j), v(k), w, w )
         end do
-        !PSY call invoke ( inner_prod(w,w,err))
-        call invoke_inner_prod( w, w, err  )
+        call invoke( inner_self_product(w, err) )
         h(j+1,j) = sqrt( err )
         if( j < GCRk ) then
           !PSY call invoke ( copy_scaled_field_data(1.0_r_def/h(j+1,j),w,v(j+1)))
@@ -596,18 +562,16 @@ contains
       do i = 1, GCRK
 !  This is the correct settings => call Precon(s,v(:,:,i),pstit,pstcnd)
         call preconditioner( s, v(i), NO_PRE_COND )
-        !PSY call invoke ( axpy(u(i), s, lhs, lhs))
-        call invoke_axpy( u(i), s, lhs, lhs )
+        call invoke( inc_xpby(lhs, u(i), s) )
       end do
 
 ! Check for convergence
-      call invoke_set_field_scalar(0.0_r_def, Ax)
-      call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
-     !PSY call invoke ( minus_field_data(rhs,Ax,r))
-      call invoke_minus_field_data( rhs, Ax, r )
+      call invoke( name = "GMRES_check_convergence",          &
+                   set_field_scalar(0.0_r_def, Ax),           &
+                   matrix_vector_kernel_mm_type(Ax, lhs, mm), &
+                   minus_fields(rhs, Ax, r),                  &
+                   inner_self_product(r, err) )
 
-     !PSY call invoke ( inner_prod(r,r,err))
-      call invoke_inner_prod(r, r, err )
       beta = sqrt(err)
 
       err = beta/sc_err
@@ -622,8 +586,8 @@ contains
 
 !  This is the correct settings => call Precon(s,r,preit,precnd)
       call preconditioner( s, r, NO_PRE_COND )
-      !PSY call invoke ( copy_scaled_field_data(1.0_r_def/beta,s,v(1)))
-      call invoke_copy_scaled_field_data(1.0_r_def/beta, s, v(1))
+      const = 1.0_r_def/beta
+      call invoke( copy_scaled_field(const, s, v(1)) )
 
       g(:) = 0.0_r_def
       g(1) = beta
@@ -667,6 +631,7 @@ contains
     real(kind=r_def)                   :: alpha
     ! others
     real(kind=r_def)                   :: err, sc_err, init_err
+    real(kind=r_def)                   :: const
     integer                            :: iter, m, n
     integer                            :: rhs_fs
     type(function_space_type)          :: fs
@@ -682,8 +647,7 @@ contains
 
       v(iter)  = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
     end do
-    !PSY call invoke ( inner_prod(rhs,rhs,err))
-    call invoke_inner_prod( rhs, rhs, err )
+    call invoke( inner_self_product(rhs, err) )
     sc_err = max( sqrt(err), 0.01_r_def )
     init_err = sc_err
 
@@ -695,46 +659,41 @@ contains
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
       return
     end if
-    call invoke_set_field_scalar(0.0_r_def, Ax)
-    call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
 
-    !PSY call invoke ( minus_field_data(rhs,Ax,r))
-    call invoke_minus_field_data( rhs, Ax, r )
+    call invoke( name = "GCR_init_rhs_lhs",                 &
+                 set_field_scalar(0.0_r_def, Ax),           &
+                 matrix_vector_kernel_mm_type(Ax, lhs, mm), &
+                 minus_fields(rhs, Ax, r) )
 
     do iter = 1, MAX_ITER
       do m = 1, GCRk
 ! This is the correct settings -> call Precon(s(:,:,m),r,prit,prec)
         call preconditioner( s(m), r, NO_PRE_COND )
-        call invoke_set_field_scalar(0.0_r_def, v(m))
-        call invoke( matrix_vector_kernel_mm_type(v(m),s(m),mm) )
-
+        call invoke( set_field_scalar(0.0_r_def, v(m)) )
+        call invoke( matrix_vector_kernel_mm_type(v(m), s(m), mm) )
+     
 
         do n = 1, m-1
-          !PSY call invoke ( inner_prod(v(m),v(n),alpha) )
-          call invoke_inner_prod( v(m), v(n), alpha )
-          !PSY call invoke ( axpy( -alpha, v(n), v(m), v(m))
-          call invoke_axpy( -alpha, v(n), v(m), v(m))
-          !PSY call invoke ( axpy( -alpha, s(n), s(m), s(m))
-          call invoke_axpy( -alpha, s(n), s(m), s(m))
+          call invoke( inner_product(v(m), v(n), alpha) )
+          const = -alpha
+          call invoke( inc_xpby( v(m), const, v(n)) )
+          call invoke( inc_xpby( s(m), const, s(n)) )
+! ! ! ! !           call invoke_axpy( -alpha, v(n), v(m), v(m))  ! This would require INC_XMBY (x = x - b*y)
+! ! ! ! !           call invoke_axpy( -alpha, s(n), s(m), s(m))  ! This would require INC_XMBY (x = x - b*y)
         end do
-        !PSY call invoke ( inner_prod(v(m),v(m),err) )
-        call invoke_inner_prod( v(m), v(m), err )
+        call invoke( inner_self_product(v(m), err) )
         alpha = sqrt(err)
-        !PSY call invoke ( copy_scaled_field_data(1.0_r_def/alpha, v(m), v(m)) )
-        call invoke_copy_scaled_field_data( 1.0_r_def/alpha, v(m), v(m) )
-        !PSY call invoke ( copy_scaled_field_data(1.0_r_def/alpha, s(m), s(m)) )
-        call invoke_copy_scaled_field_data( 1.0_r_def/alpha, s(m), s(m) )
+        const = 1.0_r_def/alpha
+        call invoke( scale_field(const, v(m)), &
+                     scale_field(const, s(m)), &
+                     inner_product(r, v(m), alpha) )
 
-        !PSY call invoke ( inner_prod(r,v(m),alpha) )
-        call invoke_inner_prod( r, v(m), alpha )
-        !PSY call invoke ( axpy( alpha, s(m), lhs, lhs)
-        call invoke_axpy( alpha, s(m), lhs, lhs )
-        !PSY call invoke ( axpy( -alpha, v(m), r, r)
-        call invoke_axpy( -alpha, v(m), r, r )
+        const = -alpha
+        call invoke( inc_xpby( lhs, alpha, s(m)), &
+                     inc_xpby( r, const, v(m)) )
       end do
 
-      !PSY call invoke ( inner_prod(r,r,err) )
-      call invoke_inner_prod( r, r, err )
+      call invoke( inner_self_product(r, err) )
       err = sqrt( err )/sc_err
       if( err <  SOLVER_TOL ) then
         write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
@@ -778,8 +737,7 @@ end subroutine gcr_solver_algorithm
         call log_event( log_scratch_space, LOG_LEVEL_ERROR )
       case default
 ! Default - do nothing
-        !PSY call invoke ( copy_field_data(x, y) )
-        call invoke_copy_field_data( x, y )
+        call invoke( copy_field(x, y) )
     end select
 
     return

--- a/examples/dynamo/eg3/solver_mod.x90
+++ b/examples/dynamo/eg3/solver_mod.x90
@@ -14,7 +14,7 @@
 !! solve a number of iterative solver algorithms are possible or for
 !! discontinuous systems an exact solver can be used
 module solver_mod
-  use constants_mod,           only : r_def, str_def, MAX_ITER, SOLVER_TOL, &
+  use constants_mod,           only : r_def, str_def, MAX_ITER, SOLVER_TOL,  &
                                       CG_SOLVER, BICG_SOLVER, JACOBI_SOLVER, &
                                       GMRES_SOLVER, GCR_SOLVER, NO_PRE_COND
   use log_mod,                 only : log_event,         &
@@ -24,14 +24,8 @@ module solver_mod
                                       LOG_LEVEL_DEBUG,   &
                                       LOG_LEVEL_TRACE
   use field_mod,               only : field_type
-  use function_space_mod,      only : function_space_type, W0, W1, W2, W3, Wtheta, W2V, W2H
-  use psy,             only : invoke_inner_prod,              &
-                              invoke_axpy,                    &
-                              invoke_minus_field_data,        &
-                              invoke_copy_field_data,         &
-                              invoke_set_field_scalar,        &
-                              invoke_divide_field,            &
-                              invoke_copy_scaled_field_data
+  use function_space_mod,      only : function_space_type, W0, W1, W2, W3, &
+                                      Wtheta, W2V, W2H
   use w3_solver_kernel_mod, only: w3_solver_kernel_type
   use matrix_vector_mm_mod, only: matrix_vector_kernel_mm_type
 
@@ -90,15 +84,17 @@ contains
        ! quadrature present, only for W3
        if( (fs_l == W3) .and. (fs_r == W3) ) then
           ! we are on the right space
-          call invoke( w3_solver_kernel_type(lhs,rhs,chi,ascalar,qr) )
+          call invoke( w3_solver_kernel_type(lhs, rhs, chi, ascalar, qr) )
        else
-          write( log_scratch_space, '(A,I3,",",I3)' )  'quadrature required for w3 solver, stopping',fs_l,fs_r
+          write( log_scratch_space, '(A,I3,",",I3)' )  &
+                 "quadrature required for w3 solver, stopping",fs_l,fs_r
           call log_event( log_scratch_space, LOG_LEVEL_ERROR )
        end if
     else if( .not.present(qr) .and. present(mm) ) then
        ! mass matrix
        if(fs_l == W3) then
-          write(log_scratch_space,'(A)') "solver_algorithm: mass-matrix not implemented for W3, stopping"
+          write( log_scratch_space,'(A)' ) &
+                 "Solver_algorithm: mass-matrix not implemented for W3, stopping"
           call log_event(log_scratch_space, LOG_LEVEL_ERROR)
        else
        select case ( solver_type )
@@ -113,17 +109,22 @@ contains
           case ( GCR_SOLVER )
             call gcr_solver_algorithm(lhs, rhs, mm, mesh)
           case default
-            write( log_scratch_space, '(A)' )  'Invalid linear solver choice, stopping'
+            write( log_scratch_space, '(A)' )  &
+                   "Invalid linear solver choice, stopping"
             call log_event( log_scratch_space, LOG_LEVEL_ERROR )
         end select
        end if
     else if( present(qr) .and. present(mm) ) then
        ! both - bork
-       write( log_scratch_space, '(A)' )  'quadrature OR mass matrix required for solver not both. Whats a guy to do?, stopping'
+       write( log_scratch_space, '(A)' )                               &
+              "Quadrature OR mass matrix required for solver not both. &
+               Whats a guy to do?, stopping"
        call log_event( log_scratch_space, LOG_LEVEL_ERROR )
     else
        ! neither - bork
-       write( log_scratch_space, '(A)' )  'quadrature OR mass matrix required for solver. Gimme something to work with, stopping'
+       write( log_scratch_space, '(A)' )                      &
+              "Quadrature OR mass matrix required for solver. &
+               Gimme something to work with, stopping"
     end if
 
   end subroutine solver_algorithm
@@ -167,14 +168,16 @@ contains
 
     rhs_fs = rhs%which_function_space()
     v = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
-    call invoke( set_field_scalar(0.0_r_def, v) )
-    call invoke( matrix_vector_kernel_mm_type(v,lhs,mm) )
-
+    call invoke( name = "BICG_group1",           &
+                 set_field_scalar(0.0_r_def, v), &
+                 matrix_vector_kernel_mm_type(v, lhs, mm) )
 
     res = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
-    call invoke( minus_fields(rhs,v,res) )
 
-    call invoke( inner_self_product(res, err) )
+    call invoke( name = "BICG_group2",      &
+                 minus_fields(rhs, v, res), &
+                 inner_self_product(res, err) )
+
     err = sqrt(err)/sc_err
     init_err=err
     if (err < SOLVER_TOL) then
@@ -214,31 +217,31 @@ contains
 
       call preconditioner( s, t, NO_PRE_COND )
 
-      call invoke( inc_axpy(beta, p, s) )
+      call invoke( name = "BICG_iter_group1",              &
+                   inc_axpy(beta, p, s),                   &
+                   set_field_scalar(0.0_r_def, v),         &
+                   matrix_vector_kernel_mm_type(v, p, mm), &
+                   inner_product(cr, v, norm) )
 
-      call invoke( set_field_scalar(0.0_r_def, v) )
-      call invoke( matrix_vector_kernel_mm_type(v,p,mm) )
-
-      call invoke( inner_product(cr, v, norm) )
       alpha = rho/norm
       const = -alpha
       call invoke( axpy(const, v, res, s) )
 
       call preconditioner( cs, s, NO_PRE_COND )
 
-      call invoke( set_field_scalar(0.0_r_def, t) )
-      call invoke( matrix_vector_kernel_mm_type(t,cs,mm) )
-
-      call invoke( inner_self_product(t, tt), &
+      call invoke( name = "BICG_iter_group2",               &
+                   set_field_scalar(0.0_r_def, t),          &
+                   matrix_vector_kernel_mm_type(t, cs, mm), &
+                   inner_self_product(t, tt),               &
                    inner_product(t, s, ts) )
 
       omega = ts/tt
-
       const = -omega
       !      lhs = lhs + omega * s + alpha * p
-      call invoke( inc_xpby(lhs, omega, s), &
-                   inc_xpby(lhs, alpha, p), &
-                   axpy(const, t, s, res) )
+      call invoke(  name = "BICG_iter_group3", &
+                    inc_xpby(lhs, omega, s),   &
+                    inc_xpby(lhs, alpha, p),   &
+                    axpy(const, t, s, res) )
       norm = rho
 
       ! check for convergence
@@ -333,18 +336,19 @@ contains
     end if
 
     do iter = 1, MAX_ITER
-      call invoke( set_field_scalar(0.0_r_def, Ap) )
-      call invoke( matrix_vector_kernel_mm_type(Ap,p,mm) )
+      call invoke( name = "CG_iter_group1",                 &
+                   set_field_scalar(0.0_r_def, Ap),         &
+                   matrix_vector_kernel_mm_type(Ap, p, mm), &
+                   inner_product(p, Ap, rs_new) )
 
-      call invoke( inner_product(p, Ap, rs_new) )
       alpha = rs_old/rs_new
-
       const = -alpha
-      call invoke( inc_xpby(lhs, alpha, p) )
-      call invoke( inc_xpby(res, const, Ap) )
 
+      call invoke( name = "CG_iter_group2",  &
+                   inc_xpby(lhs, alpha, p),  &
+                   inc_xpby(res, const, Ap), & 
       ! check for convergence
-      call invoke( inner_self_product(res, err) )
+                   inner_self_product(res, err) )
       err = sqrt(rs_new)/sc_err
 
       write( log_scratch_space, '(A, I2, A, E15.8)' ) &
@@ -420,13 +424,13 @@ contains
   call invoke( set_field_scalar(0.0_r_def, lhs) )
 
   do iter = 1,n_iter
-    call invoke( set_field_scalar(0.0_r_def, Ax) )
-    call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
 
-    call invoke( minus_fields(rhs, Ax, res) )
-    call invoke( inc_divide_field(res, lumped_weight) )
-    call invoke( inc_xpby(lhs, MU, res) )
-
+    call invoke( name = "Jacobi_iter",                      &
+                 set_field_scalar(0.0_r_def, Ax),           &
+                 matrix_vector_kernel_mm_type(Ax, lhs, mm), &
+                 minus_fields(rhs, Ax, res),                &
+                 inc_divide_field(res, lumped_weight),      &
+                 inc_xpby(lhs, MU, res) )
 ! Ready for next iteration
   end do
 
@@ -489,15 +493,15 @@ contains
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
       return
     end if
-    call invoke( set_field_scalar(0.0_r_def, Ax) )
-    call invoke( matrix_vector_kernel_mm_type(Ax,lhs,mm) )
 
-    call invoke( minus_fields(rhs, Ax, r) )
-
+    call invoke( name = "GMRES_group1",                     &
+                 set_field_scalar(0.0_r_def, Ax),           &
+                 matrix_vector_kernel_mm_type(Ax, lhs, mm), &
+                 minus_fields(rhs, Ax, r),                  &
 !    call Precon(s,r,preit,precnd)
-    call invoke( copy_field(r, s) )
+                 copy_field(r, s),                          &
+                 inner_self_product(s, err) )
 
-    call invoke( inner_self_product(s, err) )
     beta = sqrt(err)
 
     const = 1.0_r_def/beta
@@ -514,8 +518,9 @@ contains
 
 ! This is the correct settings => call Precon(w,v(:,:,j),pstit,pstcnd)
         call preconditioner( w, v(j), NO_PRE_COND )
-        call invoke( set_field_scalar(0.0_r_def, s) )
-        call invoke( matrix_vector_kernel_mm_type(s,w,mm) )
+        call invoke( name = "GMRES_iter_group1",     &
+                     set_field_scalar(0.0_r_def, s), &
+                     matrix_vector_kernel_mm_type(s, w, mm) )
 
 ! This is the correct settings => call Precon(w,s,preit,precnd)
         call preconditioner( w, s, NO_PRE_COND )
@@ -531,7 +536,6 @@ contains
         if( j < GCRk ) then
           const = 1.0_r_def/h(j+1,j)
           call invoke( copy_scaled_field(const, w, v(j+1)) )
-! ! ! ! !           call invoke_copy_scaled_field_data(1.0_r_def/h(j+1,j), w, v(j+1)) 
         end if
       end do
 
@@ -568,7 +572,7 @@ contains
       end do
 
 ! Check for convergence
-      call invoke( name = "GMRES_check_convergence",          &
+      call invoke( name = "GMRES_iter_group2",                &
                    set_field_scalar(0.0_r_def, Ax),           &
                    matrix_vector_kernel_mm_type(Ax, lhs, mm), &
                    minus_fields(rhs, Ax, r),                  &
@@ -662,7 +666,7 @@ contains
       return
     end if
 
-    call invoke( name = "GCR_init_rhs_lhs",                 &
+    call invoke( name = "GCR_group1",                       &
                  set_field_scalar(0.0_r_def, Ax),           &
                  matrix_vector_kernel_mm_type(Ax, lhs, mm), &
                  minus_fields(rhs, Ax, r) )
@@ -671,27 +675,32 @@ contains
       do m = 1, GCRk
 ! This is the correct settings -> call Precon(s(:,:,m),r,prit,prec)
         call preconditioner( s(m), r, NO_PRE_COND )
-        call invoke( set_field_scalar(0.0_r_def, v(m)) )
-        call invoke( matrix_vector_kernel_mm_type(v(m), s(m), mm) )
-     
+
+        call invoke( name = "GCR_iter_group1",          &
+                     set_field_scalar(0.0_r_def, v(m)), &
+                     matrix_vector_kernel_mm_type(v(m), s(m), mm) )
 
         do n = 1, m-1
           call invoke( inner_product(v(m), v(n), alpha) )
           const = -alpha
-          call invoke( inc_xpby( v(m), const, v(n)) )
-          call invoke( inc_xpby( s(m), const, s(n)) )
+          call invoke( name = "GCR_iter_group2",     &
+                       inc_xpby( v(m), const, v(n)), &
+                       inc_xpby( s(m), const, s(n)) )
 ! ! ! ! !           call invoke_axpy( -alpha, v(n), v(m), v(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
 ! ! ! ! !           call invoke_axpy( -alpha, s(n), s(m), s(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
         end do
         call invoke( inner_self_product(v(m), err) )
         alpha = sqrt(err)
         const = 1.0_r_def/alpha
-        call invoke( scale_field(const, v(m)), &
+
+        call invoke( name = "GCR_iter_group3", &
+                     scale_field(const, v(m)), &
                      scale_field(const, s(m)), &
                      inner_product(r, v(m), alpha) )
 
         const = -alpha
-        call invoke( inc_xpby( lhs, alpha, s(m)), &
+        call invoke( name = "GCR_iter_group4",    &
+                     inc_xpby( lhs, alpha, s(m)), &
                      inc_xpby( r, const, v(m)) )
       end do
 

--- a/examples/dynamo/eg3/solver_mod.x90
+++ b/examples/dynamo/eg3/solver_mod.x90
@@ -522,14 +522,16 @@ contains
 
         do k = 1, j
           call invoke( inner_product(v(k), w, h(k,j)) )
-          !PSY call invoke ( axpy(-h(k,j),v(k),w,w))
-          call invoke_axpy( -h(k,j), v(k), w, w )
+          const = -h(k,j)
+          call invoke( inc_xpby(w, const, v(k)) )
+! ! ! ! !           call invoke_axpy( -h(k,j), v(k), w, w ) ! This requires inc_X_minus_bY (x = x - b*y) 
         end do
         call invoke( inner_self_product(w, err) )
         h(j+1,j) = sqrt( err )
         if( j < GCRk ) then
-          !PSY call invoke ( copy_scaled_field_data(1.0_r_def/h(j+1,j),w,v(j+1)))
-          call invoke_copy_scaled_field_data(1.0_r_def/h(j+1,j), w, v(j+1))
+          const = 1.0_r_def/h(j+1,j)
+          call invoke( copy_scaled_field(const, w, v(j+1)) )
+! ! ! ! !           call invoke_copy_scaled_field_data(1.0_r_def/h(j+1,j), w, v(j+1)) 
         end if
       end do
 
@@ -678,8 +680,8 @@ contains
           const = -alpha
           call invoke( inc_xpby( v(m), const, v(n)) )
           call invoke( inc_xpby( s(m), const, s(n)) )
-! ! ! ! !           call invoke_axpy( -alpha, v(n), v(m), v(m))  ! This would require INC_XMBY (x = x - b*y)
-! ! ! ! !           call invoke_axpy( -alpha, s(n), s(m), s(m))  ! This would require INC_XMBY (x = x - b*y)
+! ! ! ! !           call invoke_axpy( -alpha, v(n), v(m), v(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
+! ! ! ! !           call invoke_axpy( -alpha, s(n), s(m), s(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
         end do
         call invoke( inner_self_product(v(m), err) )
         alpha = sqrt(err)

--- a/examples/dynamo/eg3/solver_mod.x90
+++ b/examples/dynamo/eg3/solver_mod.x90
@@ -79,22 +79,23 @@ contains
 
     fs_l = lhs%which_function_space()
     fs_r = rhs%which_function_space()
-    ! check the arguments qr .or. mm not both or neither
+    ! Check the arguments qr .or. mm not both or neither
     if( present(qr) .and. .not.present(mm) ) then
-       ! quadrature present, only for W3
+       ! Quadrature present, only for W3
        if( (fs_l == W3) .and. (fs_r == W3) ) then
-          ! we are on the right space
+          ! We are on the right space
           call invoke( w3_solver_kernel_type(lhs, rhs, chi, ascalar, qr) )
        else
           write( log_scratch_space, '(A,I3,",",I3)' )  &
-                 "quadrature required for w3 solver, stopping",fs_l,fs_r
+               "Quadrature required for w3 solver, stopping",fs_l,fs_r
           call log_event( log_scratch_space, LOG_LEVEL_ERROR )
        end if
     else if( .not.present(qr) .and. present(mm) ) then
-       ! mass matrix
+       ! Mass matrix
        if(fs_l == W3) then
-          write( log_scratch_space,'(A)' ) &
-                 "Solver_algorithm: mass-matrix not implemented for W3, stopping"
+          write( log_scratch_space,'(A)' )                             &
+               "Solver_algorithm: mass-matrix not implemented for W3," &
+               " stopping"
           call log_event(log_scratch_space, LOG_LEVEL_ERROR)
        else
        select case ( solver_type )
@@ -109,22 +110,22 @@ contains
           case ( GCR_SOLVER )
             call gcr_solver_algorithm(lhs, rhs, mm, mesh)
           case default
-            write( log_scratch_space, '(A)' )  &
-                   "Invalid linear solver choice, stopping"
+            write( log_scratch_space, '(A)' ) &
+                 "Invalid linear solver choice, stopping"
             call log_event( log_scratch_space, LOG_LEVEL_ERROR )
         end select
        end if
     else if( present(qr) .and. present(mm) ) then
-       ! both - bork
-       write( log_scratch_space, '(A)' )                               &
-              "Quadrature OR mass matrix required for solver not both. &
-               Whats a guy to do?, stopping"
+       ! Both - bork
+       write( log_scratch_space, '(A)' )                              &
+            "Quadrature OR mass matrix required for solver not both." &
+            " Whats a guy to do?, stopping"
        call log_event( log_scratch_space, LOG_LEVEL_ERROR )
     else
-       ! neither - bork
-       write( log_scratch_space, '(A)' )                      &
-              "Quadrature OR mass matrix required for solver. &
-               Gimme something to work with, stopping"
+       ! Neither - bork
+       write( log_scratch_space, '(A)' )                     &
+            "Quadrature OR mass matrix required for solver." &
+            " Gimme something to work with, stopping"
     end if
 
   end subroutine solver_algorithm
@@ -147,22 +148,22 @@ contains
     ! The temporary fields
     type(field_type)                   :: res, cr, p, v, s, t, cs
 
-    ! the scalars
-    ! the greeks - standard BiCGStab
+    ! The scalars
+    ! The greeks - standard BiCGStab
     real(kind=r_def)                   :: rho, alpha, omega, beta, norm
     real(kind=r_def)                   :: ts, tt
-    ! others
+    ! Others
     real(kind=r_def)                   :: err, sc_err, init_err
     integer                            :: iter
     real(kind=r_def)                   :: const
     integer                            :: rhs_fs
     type(function_space_type)          :: fs
 
-    ! compute the residual this is a global sum to the PSy ---
+    ! Compute the residual this is a global sum to the PSy ---
     call invoke( inner_self_product(rhs, sc_err) )
     sc_err = max(sqrt(sc_err), 0.1_r_def)
     write( log_scratch_space, '(A,E15.8)' ) &
-         "solver_algorithm: bicgstab starting ... ||b|| = ", sc_err
+         "Solver_algorithm: BICGstab starting ... ||b|| = ", sc_err
     call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
     call invoke( set_field_scalar(0.0_r_def, lhs) )
 
@@ -182,8 +183,8 @@ contains
     init_err=err
     if (err < SOLVER_TOL) then
       write( log_scratch_space, '(A, I2,A,E12.4,A,E15.8)') &
-           "solver_algorithm:converged in ", 0, &
-           " iters, init=", init_err, &
+           "BICG solver_algorithm: converged in ", 0,      &
+           " iters, init=", init_err,                      &
            " final=", err
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
       return
@@ -217,7 +218,7 @@ contains
 
       call preconditioner( s, t, NO_PRE_COND )
 
-      call invoke( name = "BICG_iter_group1",              &
+      call invoke( name = "BICG_iterloop_group1",          &
                    inc_axpy(beta, p, s),                   &
                    set_field_scalar(0.0_r_def, v),         &
                    matrix_vector_kernel_mm_type(v, p, mm), &
@@ -229,7 +230,7 @@ contains
 
       call preconditioner( cs, s, NO_PRE_COND )
 
-      call invoke( name = "BICG_iter_group2",               &
+      call invoke( name = "BICG_iterloop_group2",           &
                    set_field_scalar(0.0_r_def, t),          &
                    matrix_vector_kernel_mm_type(t, cs, mm), &
                    inner_self_product(t, tt),               &
@@ -238,13 +239,13 @@ contains
       omega = ts/tt
       const = -omega
       !      lhs = lhs + omega * s + alpha * p
-      call invoke(  name = "BICG_iter_group3", &
-                    inc_xpby(lhs, omega, s),   &
-                    inc_xpby(lhs, alpha, p),   &
+      call invoke(  name = "BICG_iterloop_group3", &
+                    inc_xpby(lhs, omega, s),       &
+                    inc_xpby(lhs, alpha, p),       &
                     axpy(const, t, s, res) )
       norm = rho
 
-      ! check for convergence
+      ! Check for convergence
       call invoke( inner_self_product(res, err) )
       err = sqrt(err)/sc_err
 
@@ -254,8 +255,8 @@ contains
 
       if (err < SOLVER_TOL) then
         write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-             "solver_algorithm:converged in ", iter, &
-             " iters, init=", init_err, &
+             "BICG solver_algorithm: converged in ", iter,        &
+             " iters, init=", init_err,                           &
              " final=", err
         call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
         exit
@@ -263,8 +264,8 @@ contains
     end do
 
     if(iter >= MAX_ITER) then
-      write(log_scratch_space, '(A, I3, A, E15.8)') &
-           "solver_algorithm: NOT converged in", iter, " iters, Res=", err
+      write( log_scratch_space, '(A, I3, A, E15.8)') &
+           "BICG solver_algorithm: NOT converged in", iter, " iters, Res=", err
       call log_event( log_scratch_space, LOG_LEVEL_ERROR )
     end if
 
@@ -289,10 +290,10 @@ contains
     ! The temporary fields
     type(field_type)                   :: res, p, Ap
 
-    ! the scalars
+    ! The scalars
     real(kind=r_def)                   :: alpha, beta
     real(kind=r_def)                   :: rs_new, rs_old
-    ! others
+    ! Others
     real(kind=r_def)                   :: err, sc_err, init_err
     real(kind=r_def)                   :: const
     integer                            :: iter
@@ -301,7 +302,7 @@ contains
 
     call invoke( inner_self_product(rhs, rs_old) )
 
-    ! compute the residual this is a global sum to the PSy ---
+    ! Compute the residual this is a global sum to the PSy ---
 
     rhs_fs = rhs%which_function_space()
 
@@ -309,10 +310,7 @@ contains
     p   = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
     Ap   = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
-!! First guess: lhs = rhs
-!    !PSY call invoke ( copy_field(rhs, lhs) )
-!    call invoke_copy_field_data(rhs,lhs)
-! First guess: lhs = 0
+    ! First guess: lhs = 0
     call invoke( name = "CG_first_guess",                   &
                  set_field_scalar(0.0_r_def, lhs),          &
                  matrix_vector_kernel_mm_type(Ap, lhs, mm), &
@@ -324,11 +322,11 @@ contains
     sc_err = max(err, 0.1_r_def)
     init_err=sc_err
     write( log_scratch_space, '(A,E15.8)' ) &
-         "cg solver_algorithm: starting ... ||b|| = ", sc_err
+         "CG solver_algorithm: starting ... ||b|| = ", sc_err
     call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
     if (err < SOLVER_TOL) then
       write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-           "cg solver_algorithm:converged in ", 0,              &
+           "CG solver_algorithm: converged in ", 0,             &
            " iters, init=", init_err,                           &
            " final=", err
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
@@ -336,7 +334,7 @@ contains
     end if
 
     do iter = 1, MAX_ITER
-      call invoke( name = "CG_iter_group1",                 &
+      call invoke( name = "CG_iterloop_group1",             &
                    set_field_scalar(0.0_r_def, Ap),         &
                    matrix_vector_kernel_mm_type(Ap, p, mm), &
                    inner_product(p, Ap, rs_new) )
@@ -344,19 +342,19 @@ contains
       alpha = rs_old/rs_new
       const = -alpha
 
-      call invoke( name = "CG_iter_group2",  &
-                   inc_xpby(lhs, alpha, p),  &
-                   inc_xpby(res, const, Ap), & 
-      ! check for convergence
+      call invoke( name = "CG_iterloop_group2",  &
+                   inc_xpby(lhs, alpha, p),      &
+                   inc_xpby(res, const, Ap),     & 
+      ! Check for convergence
                    inner_self_product(res, err) )
       err = sqrt(rs_new)/sc_err
 
       write( log_scratch_space, '(A, I2, A, E15.8)' ) &
-           "cg solver_algorithm[", iter, "]: res = ", err
+           "CG solver_algorithm[", iter, "]: res = ", err
       call log_event( log_scratch_space, LOG_LEVEL_TRACE )
       if (err < SOLVER_TOL) then
         write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-             "cg solver_algorithm:converged in ", iter,           &
+             "CG solver_algorithm: converged in ", iter,          &
              " iters, init=", init_err,                           &
              " final=", err
         call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
@@ -371,7 +369,7 @@ contains
 
     if(iter >= MAX_ITER) then
       write( log_scratch_space, '(A, I3, A, E15.8)' ) &
-           "cg solver_algorithm: NOT converged in", iter, " iters, Res=", err
+           "CG solver_algorithm: NOT converged in", iter, " iters, Res=", err
       call log_event( log_scratch_space, LOG_LEVEL_ERROR )
     end if
 
@@ -414,24 +412,24 @@ contains
   lumped_weight = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
   res = field_type(vector_space = fs%get_instance(mesh, rhs_fs) )
 
-! Compute mass lump
+  ! Compute mass lump
   call invoke( name = "Jacobi_mass_lump",                           &
                set_field_scalar(1.0_r_def, Ax),                     &
                matrix_vector_kernel_mm_type(lumped_weight, Ax, mm), &
                divide_fields(rhs, lumped_weight, lhs) )
 
-! initial guess
+  ! Initial guess
   call invoke( set_field_scalar(0.0_r_def, lhs) )
 
   do iter = 1,n_iter
 
-    call invoke( name = "Jacobi_iter",                      &
+    call invoke( name = "Jacobi_iterloop",                  &
                  set_field_scalar(0.0_r_def, Ax),           &
                  matrix_vector_kernel_mm_type(Ax, lhs, mm), &
                  minus_fields(rhs, Ax, res),                &
                  inc_divide_field(res, lumped_weight),      &
                  inc_xpby(lhs, MU, res) )
-! Ready for next iteration
+  ! Ready for next iteration
   end do
 
   end subroutine jacobi_solver_algorithm
@@ -460,10 +458,10 @@ contains
     ! The temporary fields
     type(field_type)                   :: Ax, r, s, w, v(GCRK)
 
-    ! the scalars
+    ! The scalars
     real(kind=r_def)                   :: h(GCRK+1, GCRK), u(GCRK), g(GCRK+1)
     real(kind=r_def)                   :: beta, si, ci, nrm, h1, h2, p, q
-    ! others
+    ! Others
     real(kind=r_def)                   :: err, sc_err, init_err
     real(kind=r_def)                   :: const
     integer                            :: iter, i, j, k, m
@@ -487,7 +485,7 @@ contains
 
     if (err < SOLVER_TOL) then
       write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-           "gmres solver_algorithm:converged in ", 0,           &
+           "GMRES solver_algorithm: converged in ", 0,          &
            " iters, init=", init_err,                           &
            " final=", err
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
@@ -498,7 +496,6 @@ contains
                  set_field_scalar(0.0_r_def, Ax),           &
                  matrix_vector_kernel_mm_type(Ax, lhs, mm), &
                  minus_fields(rhs, Ax, r),                  &
-!    call Precon(s,r,preit,precnd)
                  copy_field(r, s),                          &
                  inner_self_product(s, err) )
 
@@ -516,20 +513,19 @@ contains
 
       do j = 1, GCRk
 
-! This is the correct settings => call Precon(w,v(:,:,j),pstit,pstcnd)
+        ! This is the correct settings => call Precon(w,v(:,:,j),pstit,pstcnd)
         call preconditioner( w, v(j), NO_PRE_COND )
-        call invoke( name = "GMRES_iter_group1",     &
+        call invoke( name = "GMRES_iterloop_group1", &
                      set_field_scalar(0.0_r_def, s), &
                      matrix_vector_kernel_mm_type(s, w, mm) )
 
-! This is the correct settings => call Precon(w,s,preit,precnd)
+        ! This is the correct settings => call Precon(w,s,preit,precnd)
         call preconditioner( w, s, NO_PRE_COND )
 
         do k = 1, j
           call invoke( inner_product(v(k), w, h(k,j)) )
           const = -h(k,j)
           call invoke( inc_xpby(w, const, v(k)) )
-! ! ! ! !           call invoke_axpy( -h(k,j), v(k), w, w ) ! This requires inc_X_minus_bY (x = x - b*y) 
         end do
         call invoke( inner_self_product(w, err) )
         h(j+1,j) = sqrt( err )
@@ -539,7 +535,7 @@ contains
         end if
       end do
 
-! Solve (7.23) of Wesseling (see Saad's book)
+      ! Solve (7.23) of Wesseling (see Saad's book)
       do m = 1, GCRK
         nrm    = sqrt( h(m,m)*h(m,m) + h(m+1,m)*h(m+1,m) )
         si     = h(m+1,m)/nrm
@@ -566,13 +562,13 @@ contains
       end do
 
       do i = 1, GCRK
-!  This is the correct settings => call Precon(s,v(:,:,i),pstit,pstcnd)
+        !  This is the correct settings => call Precon(s,v(:,:,i),pstit,pstcnd)
         call preconditioner( s, v(i), NO_PRE_COND )
         call invoke( inc_xpby(lhs, u(i), s) )
       end do
 
-! Check for convergence
-      call invoke( name = "GMRES_iter_group2",                &
+      ! Check for convergence
+      call invoke( name = "GMRES_iterloop_group2",            &
                    set_field_scalar(0.0_r_def, Ax),           &
                    matrix_vector_kernel_mm_type(Ax, lhs, mm), &
                    minus_fields(rhs, Ax, r),                  &
@@ -583,14 +579,14 @@ contains
       err = beta/sc_err
       if( err <  SOLVER_TOL ) then
         write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-             "GMRES solver_algorithm:converged in ", iter,        &
+             "GMRES solver_algorithm: converged in ", iter,       &
              " iters, init=", init_err,                           &
              " final=", err
         call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
         exit
       end if
 
-!  This is the correct settings => call Precon(s,r,preit,precnd)
+      !  This is the correct settings => call Precon(s,r,preit,precnd)
       call preconditioner( s, r, NO_PRE_COND )
       const = 1.0_r_def/beta
       call invoke( copy_scaled_field(const, s, v(1)) )
@@ -633,9 +629,9 @@ contains
     ! The temporary fields
     type(field_type)                   :: Ax, r, s(GCRK), v(GCRK)
 
-    ! the scalars
+    ! The scalars
     real(kind=r_def)                   :: alpha
-    ! others
+    ! Others
     real(kind=r_def)                   :: err, sc_err, init_err
     real(kind=r_def)                   :: const
     integer                            :: iter, m, n
@@ -659,7 +655,7 @@ contains
 
     if (err < SOLVER_TOL) then
       write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-           "gcr solver_algorithm:converged in ", 0,             &
+           "GCR solver_algorithm: converged in ", 0,            &
            " iters, init=", init_err,                           &
            " final=", err
       call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
@@ -673,34 +669,32 @@ contains
 
     do iter = 1, MAX_ITER
       do m = 1, GCRk
-! This is the correct settings -> call Precon(s(:,:,m),r,prit,prec)
+        ! This is the correct settings -> call Precon(s(:,:,m),r,prit,prec)
         call preconditioner( s(m), r, NO_PRE_COND )
 
-        call invoke( name = "GCR_iter_group1",          &
+        call invoke( name = "GCR_iterloop_group1",      &
                      set_field_scalar(0.0_r_def, v(m)), &
                      matrix_vector_kernel_mm_type(v(m), s(m), mm) )
 
         do n = 1, m-1
           call invoke( inner_product(v(m), v(n), alpha) )
           const = -alpha
-          call invoke( name = "GCR_iter_group2",     &
+          call invoke( name = "GCR_iterloop_group2", &
                        inc_xpby( v(m), const, v(n)), &
                        inc_xpby( s(m), const, s(n)) )
-! ! ! ! !           call invoke_axpy( -alpha, v(n), v(m), v(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
-! ! ! ! !           call invoke_axpy( -alpha, s(n), s(m), s(m))   ! This requires inc_X_minus_bY (x = x - b*y) 
         end do
         call invoke( inner_self_product(v(m), err) )
+
         alpha = sqrt(err)
         const = 1.0_r_def/alpha
-
-        call invoke( name = "GCR_iter_group3", &
-                     scale_field(const, v(m)), &
-                     scale_field(const, s(m)), &
+        call invoke( name = "GCR_iterloop_group3", &
+                     scale_field(const, v(m)),     &
+                     scale_field(const, s(m)),     &
                      inner_product(r, v(m), alpha) )
 
         const = -alpha
-        call invoke( name = "GCR_iter_group4",    &
-                     inc_xpby( lhs, alpha, s(m)), &
+        call invoke( name = "GCR_iterloop_group4", &
+                     inc_xpby( lhs, alpha, s(m)),  &
                      inc_xpby( r, const, v(m)) )
       end do
 
@@ -708,7 +702,7 @@ contains
       err = sqrt( err )/sc_err
       if( err <  SOLVER_TOL ) then
         write( log_scratch_space, '(A, I2, A, E12.4, A, E15.8)' ) &
-             "GCR solver_algorithm:converged in ", iter,          &
+             "GCR solver_algorithm: converged in ", iter,         &
              " iters, init=", init_err,                           &
              " final=", err
         call log_event( log_scratch_space, LOG_LEVEL_DEBUG )
@@ -742,12 +736,12 @@ end subroutine gcr_solver_algorithm
 
     select case ( pre_cond_type )
       case ( DIAGONAL_PRE_COND )
-! Diagonal preconditioner
+        ! Diagonal preconditioner
         write( log_scratch_space, '(A)' ) &
              "Diagonal preconditioner not implemented yet"
         call log_event( log_scratch_space, LOG_LEVEL_ERROR )
       case default
-! Default - do nothing
+        ! Default - do nothing
         call invoke( copy_field(x, y) )
     end select
 


### PR DESCRIPTION
I adjusted the code to use PSyclone built-ins as much as possible with the current infrastructure. Some remarks for the future are below.

- This example of `solver_mod.x90` is quite old. After renaming built-ins and creating new ones it would be best to provide a more recent example. What is the situation with copyrights and moving the code from LFRic to PSyclone repository?

- Meaningful names for groups of invokes require knowledge of what the code is doing. I did the best I could for now, but this should be discussed with MO GungHo/LFRic scientists who created algorithms. I will open an LFRic Design discussion ticket for that purpose.

- Built-ins calls with arithmetic expressions. Examples: negative variables (`-alpha`, `-h(k,j))`, multiplying two constants (`omega*alpha`), inverted variables (`1.0_r_def/1.0_r_def/h(j+1,j)`). For now I defined auxiliary constants, but this unnecessarily breaks grouping of invokes. These cases are relatively easily solvable by adding more built-ins, however the question is how many more special cases if built-ins will be needed. This merits another LFRic Design discussion ticket.  Examples are below.

  1. `invoke_axpy(-alpha,v,res,s)`   is operation _Z = -aX + Y_ which can be written as _Z = X - bY_.     A new built-in `X_minus_bY(Field3, Field1, scalar2, Field2)` is required.

  2. `invoke_axpy( -h(k,j), v(k), w, w )`   is operation _Y = -aX + Y_ which can be written as  _X = X - bY_.     A new built-in `inc_X_minus_bY(Field1, scalar2, Field2)` is required.

  3. `invoke_copy_scaled_field_data( 1.0_r_def/beta, s, v(1) )`  is a possible subcategory of proposed  `X_times_a(Field2, Field1, scalar1)`. A separate built-in `X_times_ainv(Field2, Field1, scalar1)` would be required which performs `1/scalar1` before copying scaled field. 

  4. `invoke_copy_scaled_field_data( 1.0_r_def/alpha, v(m), v(m) )`  is a possible subcategory of proposed  `inc_X_times_a(Field1, scalar1)`. A separate built-in `inc_X_times_ainv(Field1, scalar1)` would be required which performs `1/scalar1` before scaling field. 



