### PR TITLE
Add support for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@
 language: python
 python:
   - 2.7
+  - 3.6
 # The env section allows us to specify multiple, different environments
 # in which the test suite must be run. The environment variables set
 # here are picked up in the bin/install_optional.sh script.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -60,7 +60,8 @@ copyright = u'2017, STFC Daresbury Laboratory'
 # src/psyclone
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
 BASE_PATH = os.path.dirname(BASE_PATH)
-execfile(os.path.join(BASE_PATH, "src", "psyclone", "version.py"))
+with open(os.path.join(BASE_PATH, "src", "psyclone", "version.py")) as f:
+    exec(f.read())
 version = __SHORT_VERSION__
 release = __VERSION__
 

--- a/doc/getting_going.rst
+++ b/doc/getting_going.rst
@@ -48,7 +48,7 @@ Dependencies
 ------------
 
 PSyclone is written in Python so needs Python to be installed on the
-target machine. PSyclone has been tested under Python 2.6.5 and 2.7.3.
+target machine. PSyclone has been tested under Python 2.6.5, 2.7.3 and 3.6.
 
 .. warning:: As of version 1.6, PSyclone requires version 0.0.7 or greater of fparser.
 
@@ -57,14 +57,9 @@ PSyclone immediately relies on two external Python packages;
 ``py.test`` is required. The easiest way to satisfy the Python
 dependencies is to use the Python Package Index (pypi.org) and
 ``pip``. See https://packaging.python.org/installing/ for more
-information.  Note that some Linux distributions install pip only for
-python 3 by default. In this case it is necessary to install pip for
-python 2. For example in openSUSE 42.2:
+information.
 
-``> zypper install python-pip``
-
-and then use pip2.7 instead of pip. If everything is working correctly
-then using pip to install PSyclone:
+If everything is working correctly then using pip to install PSyclone:
 
 ``> pip install psyclone``
 

--- a/doc/system_specific_setup.rst
+++ b/doc/system_specific_setup.rst
@@ -52,18 +52,11 @@ package in addition to the Python bindings.
 Installing dependencies on OpenSUSE
 +++++++++++++++++++++++++++++++++++
 
-While the vanilla OpenSUSE installation includes ``pip``,
-the installed version only works for Python 3. So the
-python 2 version of PIP still needs to be installed. Note
-that the graphviz package is installed by default.
+The vanilla OpenSUSE installation includes ``pip`` for Python 3.
+Note that the graphviz package is installed by default.
 ::
 
     > sudo zypper install python-pip
-
-.. warning::
-    PIP for python2 on OpenSUSE is called ``pip2.7``. So you need
-    to replace the ``pip`` command with ``pip2.7`` in all commands in
-    the following sections. 
 
 
 
@@ -94,10 +87,6 @@ To avoid warnings during the dependency installation, it is recommended to updat
 to the latest version::
 
     > sudo pip install --upgrade pip
-
-.. warning::
-    As mentioned in :ref:`opensuse_user`: on OpenSUSE this commands needs to be
-    ``sudo pip2.7 install --upgrade pip``.
 
 Next you need to install the ``fparser`` and ``pyparsing`` packages::
 

--- a/examples/dynamo/eg1/runme.py
+++ b/examples/dynamo/eg1/runme.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 
@@ -19,10 +20,10 @@ ast,invokeInfo=parse("dynamo.F90",api=api)
 # Create the PSy-layer object using the invokeInfo
 psy=PSyFactory(api).create(invokeInfo)
 # Generate the Fortran code for the PSy layer
-print psy.gen
+print(psy.gen)
 
 # List the invokes that the PSy layer has
-print psy.invokes.names
+print(psy.invokes.names)
 
 # Examine the 'schedule' (e.g. loop structure) that each
 # invoke has

--- a/examples/dynamo/eg1/runme_openmp.py
+++ b/examples/dynamo/eg1/runme_openmp.py
@@ -6,6 +6,7 @@
 #-------------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 api="dynamo0.1"
@@ -17,10 +18,10 @@ ast,invokeInfo=parse("dynamo.F90",api=api)
 # Create the PSy-layer object using the invokeInfo
 psy=PSyFactory(api).create(invokeInfo)
 # Generate the Fortran code for the PSy layer
-print psy.gen
+print(psy.gen)
 
 # List the various invokes that the PSy layer contains
-print psy.invokes.names
+print(psy.invokes.names)
 
 # Get the loop schedule associated with one of these
 # invokes
@@ -30,7 +31,7 @@ schedule.view()
 # Get the list of possible loop transformations
 from psyclone.psyGen import TransInfo
 t=TransInfo()
-print t.list
+print(t.list)
 
 # Create an OpenMPLoop-transformation object
 ol=t.get_trans_name('OMPParallelLoopTrans')
@@ -43,7 +44,7 @@ new_schedule.view()
 # with the new, transformed schedule 
 psy.invokes.get('invoke_0_v3_kernel_type').schedule=new_schedule
 # Generate the Fortran code for the new PSy layer
-print psy.gen
+print(psy.gen)
 
 schedule=psy.invokes.get('invoke_1_v3_solver_kernel_type').schedule
 schedule.view()
@@ -52,4 +53,4 @@ new_schedule,memento=ol.apply(schedule.children[0])
 new_schedule.view()
 
 psy.invokes.get('invoke_1_v3_solver_kernel_type').schedule=new_schedule
-print psy.gen
+print(psy.gen)

--- a/examples/dynamo/eg2/runme.py
+++ b/examples/dynamo/eg2/runme.py
@@ -6,14 +6,15 @@
 #-------------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 api="dynamo0.1"
 ast,invokeInfo=parse("dynamo_algorithm_mod.F90",api=api)
 psy=PSyFactory(api).create(invokeInfo)
-print psy.gen
+print(psy.gen)
 
-print psy.invokes.names
+print(psy.invokes.names)
 
 schedule=psy.invokes.get('invoke_0').schedule
 schedule.view()

--- a/examples/dynamo/eg2/runme_loop_fuse.py
+++ b/examples/dynamo/eg2/runme_loop_fuse.py
@@ -6,21 +6,22 @@
 #-------------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 api="dynamo0.1"
 ast,invokeInfo=parse("dynamo_algorithm_mod.F90",api=api)
 psy=PSyFactory(api).create(invokeInfo)
-print psy.gen
+print(psy.gen)
 
-print psy.invokes.names
+print(psy.invokes.names)
 
 schedule=psy.invokes.get('invoke_0').schedule
 schedule.view()
 
 from psyclone.psyGen import TransInfo
 t=TransInfo()
-print t.list
+print(t.list)
 
 lf=t.get_trans_name('LoopFuse')
 
@@ -29,4 +30,4 @@ new_schedule,memento=lf.apply(schedule.children[0],schedule.children[1])
 new_schedule.view()
 
 psy.invokes.get('invoke_0').schedule=new_schedule
-print psy.gen
+print(psy.gen)

--- a/examples/dynamo/eg2/runme_openmp.py
+++ b/examples/dynamo/eg2/runme_openmp.py
@@ -9,18 +9,19 @@
 '''Example script showing how to apply OpenMP transformations to
 dynamo code'''
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 API = "dynamo0.1"
 _, INVOKEINFO = parse("dynamo_algorithm_mod.F90", api=API)
 PSY = PSyFactory(API).create(INVOKEINFO)
-print PSY.gen
+print(PSY.gen)
 
-print PSY.invokes.names
+print(PSY.invokes.names)
 
 from psyclone.psyGen import TransInfo
 TRANS = TransInfo()
-print TRANS.list
+print(TRANS.list)
 
 LOOP_FUSE = TRANS.get_trans_name('LoopFuse')
 OMP_PAR = TRANS.get_trans_name('OMPParallelLoopTrans')
@@ -51,4 +52,4 @@ OMP_SCHEDULE.view()
 
 PSY.invokes.get('invoke_2_v1_kernel_type').schedule = OMP_SCHEDULE
 
-print PSY.gen
+print(PSY.gen)

--- a/examples/dynamo/eg3/colouring_and_omp.py
+++ b/examples/dynamo/eg3/colouring_and_omp.py
@@ -38,6 +38,7 @@
 ''' File containing a PSyclone transformation script for the Dynamo0p3
 API to apply colouring and OpenMP generically. This can be applied via
 the -s option in the generator.py script. '''
+from __future__ import print_function
 from psyclone.transformations import Dynamo0p3ColourTrans, \
     DynamoOMPParallelLoopTrans
 from psyclone.psyGen import Loop
@@ -53,7 +54,7 @@ def trans(psy):
     # Loop over all of the Invokes in the PSy object
     for invoke in psy.invokes.invoke_list:
 
-        print "Transforming invoke '"+invoke.name+"'..."
+        print("Transforming invoke '"+invoke.name+"'...")
         schedule = invoke.schedule
 
         # Colour all of the loops over cells unless they are on

--- a/examples/dynamo/eg9/colouring_and_omp.py
+++ b/examples/dynamo/eg9/colouring_and_omp.py
@@ -38,6 +38,7 @@
 ''' File containing a PSyclone transformation script for the Dynamo0p3
 API to apply colouring and OpenMP generically. This can be applied via
 the -s option in the generator.py script. '''
+from __future__ import print_function
 from psyclone.transformations import Dynamo0p3ColourTrans, \
     DynamoOMPParallelLoopTrans
 from psyclone.psyGen import Loop
@@ -53,7 +54,7 @@ def trans(psy):
     # Loop over all of the Invokes in the PSy object
     for invoke in psy.invokes.invoke_list:
 
-        print "Transforming invoke '"+invoke.name+"'..."
+        print("Transforming invoke '"+invoke.name+"'...")
         schedule = invoke.schedule
 
         # Colour all of the loops over cells unless they are on

--- a/examples/gocean/runme.py
+++ b/examples/gocean/runme.py
@@ -32,6 +32,7 @@ Schedules:
 
 '''
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
 
@@ -40,10 +41,10 @@ _, INVOKEINFO = parse("shallow_alg.f90", api=API)
 PSY = PSyFactory(API).create(INVOKEINFO)
 
 # Print the 'vanilla' generated Fortran
-print PSY.gen
+print(PSY.gen)
 
 # Print a list of all of the invokes found
-print PSY.invokes.names
+print(PSY.invokes.names)
 
 # Print the Schedule of each of these Invokes
 SCHEDULE = PSY.invokes.get('invoke_0').schedule

--- a/examples/gocean/runme_dag.py
+++ b/examples/gocean/runme_dag.py
@@ -64,6 +64,7 @@ This prints a textual view of the Schedule of the first invoke:
 and then writes the DAG of the schedule to file.
 '''
 
+from __future__ import print_function
 import os
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
@@ -75,7 +76,7 @@ PSY = PSyFactory(API).create(INVOKEINFO)
 # Print the Schedule of the first Invoke
 SCHEDULE = PSY.invokes.get('invoke_0').schedule
 SCHEDULE.view()
-print "\n"
+print("\n")
 
 # Generate a DAG for it. If graphviz is not available this call just
 # returns without doing anything.
@@ -83,7 +84,7 @@ DAG_NAME = "invoke_0_dag"
 SCHEDULE.dag(file_name=DAG_NAME, file_format="png")
 DAG_NAME += ".png"
 if os.path.isfile(os.path.join(os.getcwd(), DAG_NAME)):
-    print "Wrote DAG to file: {0}".format(DAG_NAME)
+    print("Wrote DAG to file: {0}".format(DAG_NAME))
 else:
     print("Failed to generate DAG image. Do you have the graphviz library "
           "and Python\nbindings installed?")

--- a/examples/gocean/runme_loop_fuse.py
+++ b/examples/gocean/runme_loop_fuse.py
@@ -36,6 +36,7 @@ Fortran. In subroutine invoke_0 you will see the loop-fused code:
 
 '''
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory, TransInfo
 
@@ -43,14 +44,14 @@ API = "gocean1.0"
 _, INVOKEINFO = parse("shallow_alg.f90", api=API)
 PSY = PSyFactory(API).create(INVOKEINFO)
 # Print the vanilla, generated Fortran
-print PSY.gen
+print(PSY.gen)
 
-print PSY.invokes.names
+print(PSY.invokes.names)
 SCHEDULE = PSY.invokes.get('invoke_0').schedule
 SCHEDULE.view()
 
 TRANS_INFO = TransInfo()
-print TRANS_INFO.list
+print(TRANS_INFO.list)
 FUSE_TRANS = TRANS_INFO.get_trans_name('LoopFuse')
 
 # fuse all outer loops
@@ -72,4 +73,4 @@ LF6_SCHED, _ = FUSE_TRANS.apply(LF5_SCHED.children[0].children[0],
 LF6_SCHED.view()
 
 PSY.invokes.get('invoke_0').schedule = LF6_SCHED
-print PSY.gen
+print(PSY.gen)

--- a/examples/gocean/runme_openmp.py
+++ b/examples/gocean/runme_openmp.py
@@ -40,20 +40,21 @@ been loop-fused and then parallelised:
 
 '''
 
+from __future__ import print_function
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory, TransInfo
 
 API = "gocean1.0"
 _, INVOKEINFO = parse("shallow_alg.f90", api=API)
 PSY = PSyFactory(API).create(INVOKEINFO)
-print PSY.gen
+print(PSY.gen)
 
-print PSY.invokes.names
+print(PSY.invokes.names)
 SCHEDULE = PSY.invokes.get('invoke_0').schedule
 SCHEDULE.view()
 
 TRANS_INFO = TransInfo()
-print TRANS_INFO.list
+print(TRANS_INFO.list)
 FUSE_TRANS = TRANS_INFO.get_trans_name('LoopFuse')
 OMP_TRANS = TRANS_INFO.get_trans_name('GOceanOMPParallelLoopTrans')
 
@@ -80,4 +81,4 @@ OL_SCHEDULE, _ = OMP_TRANS.apply(LF6_SCHEDULE.children[0])
 OL_SCHEDULE.view()
 
 PSY.invokes.get('invoke_0').schedule = OL_SCHEDULE
-print PSY.gen
+print(PSY.gen)

--- a/examples/line_length/runme.py
+++ b/examples/line_length/runme.py
@@ -1,4 +1,5 @@
 ''' Script to demonstrate the use on the line wrapping support in PSyclone'''
+from __future__ import print_function
 from psyclone.generator import generate
 from psyclone.line_length import FortLineLength
 # long_lines=True checks whether the input fortran conforms to the 132 line
@@ -9,6 +10,6 @@ ALG, PSY = generate(
     line_length=True)
 LINE_LENGTH = FortLineLength()
 ALG_STR = LINE_LENGTH.process(str(ALG))
-print ALG_STR
+print(ALG_STR)
 PSY_STR = LINE_LENGTH.process(str(PSY))
-print PSY_STR
+print(PSY_STR)

--- a/examples/transformations/inline/module_inline_example.py
+++ b/examples/transformations/inline/module_inline_example.py
@@ -1,4 +1,5 @@
 ''' example showing the use of the module-inline transformation '''
+from __future__ import print_function
 
 
 def inline():
@@ -15,7 +16,7 @@ def inline():
                     api="dynamo0.1")
     psy = PSyFactory("dynamo0.1").create(info)
     invokes = psy.invokes
-    print psy.invokes.names
+    print(psy.invokes.names)
     invoke = invokes.get("invoke_0_testkern_type")
     schedule = invoke.schedule
     schedule.view()
@@ -30,7 +31,7 @@ def inline():
     # setting module inline via a transformation
     schedule, _ = trans.apply(kern)
     schedule.view()
-    print str(psy.gen)
+    print(str(psy.gen))
 
 if __name__ == "__main__":
     inline()

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ CLASSIFIERS = [
 # Rather than importing it (which would require that PSyclone already be
 # installed), we read it using execfile().
 BASE_PATH = os.path.dirname(os.path.abspath(__file__))
-execfile(os.path.join(BASE_PATH, "src", "psyclone", "version.py"))
+with open(os.path.join(BASE_PATH, "src", "psyclone", "version.py")) as f:
+    exec(f.read())
 VERSION = __VERSION__
 
 if __name__ == '__main__':
@@ -97,6 +98,6 @@ if __name__ == '__main__':
         classifiers=CLASSIFIERS,
         packages=PACKAGES,
         package_dir={"": "src"},
-        install_requires=['pyparsing', 'fparser>=0.0.7'],
+        install_requires=['pyparsing', 'fparser>=0.0.7', 'six'],
         include_package_data=True,
         scripts=['bin/psyclone', 'bin/genkernelstub'])

--- a/src/psyclone/dynamo0p1.py
+++ b/src/psyclone/dynamo0p1.py
@@ -11,8 +11,8 @@
     Arguments and Argument). '''
 
 from __future__ import absolute_import
-from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
-                   Argument, GenerationError
+from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, \
+        Arguments, Argument, GenerationError
 
 class DynamoPSy(PSy):
     ''' The Dynamo specific PSy class. This creates a Dynamo specific

--- a/src/psyclone/dynamo0p1.py
+++ b/src/psyclone/dynamo0p1.py
@@ -10,7 +10,8 @@
     required base classes (PSy, Invokes, Invoke, Schedule, Loop, Kern,
     Arguments and Argument). '''
 
-from psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
+from __future__ import absolute_import
+from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
                    Argument, GenerationError
 
 class DynamoPSy(PSy):
@@ -29,7 +30,7 @@ class DynamoPSy(PSy):
         :rtype: ast
 
         '''
-        from f2pygen import ModuleGen, UseGen
+        from psyclone.f2pygen import ModuleGen, UseGen
 
         # create an empty PSy layer module
         psy_module = ModuleGen(self.name)
@@ -65,7 +66,7 @@ class DynInvoke(Invoke):
             by the associated invoke call in the algorithm layer). This
             consists of the PSy invocation subroutine and the declaration of
             its arguments.'''
-        from f2pygen import SubroutineGen, TypeDeclGen
+        from psyclone.f2pygen import SubroutineGen, TypeDeclGen
         # create the subroutine
         invoke_sub = SubroutineGen(parent, name = self.name,
                                    args = self.psy_unique_var_names)
@@ -174,7 +175,7 @@ class DynKern(Kern):
     def gen_code(self, parent):
         ''' Generates dynamo version 0.1 specific psy code for a call to
             the dynamo kernel instance. '''
-        from f2pygen import CallGen, DeclGen, AssignGen, UseGen
+        from psyclone.f2pygen import CallGen, DeclGen, AssignGen, UseGen
 
         # TODO: we simply choose the first field as the lookup for the moment
         field_name = self.arguments.args[0].name

--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -977,7 +977,7 @@ class DynKernMetadata(KernelType):
         # Dictionary of meshes associated with arguments (for inter-grid
         # kernels). Keys are the meshes, values are lists of function spaces
         # of the corresponding field arguments.
-        mesh_dict = {}
+        mesh_dict = OrderedDict()
         # Whether or not any field args are missing the mesh_arg specifier
         missing_mesh = False
         # If this is an inter-grid kernel then it must only have field
@@ -1555,7 +1555,7 @@ class DynInvokeDofmaps(object):
         #              argument
         # "direction" - whether the dofmap is required for the "to" for
         #               "from" function space of the operator.
-        self._unique_cbanded_maps = {}
+        self._unique_cbanded_maps = OrderedDict()
         # A dictionary of required CMA indirection dofmaps. As with the
         # column-banded dofmaps, each entry is itself a dictionary with
         # "argument" and "direction" entries.

--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -42,6 +42,7 @@
     Loop, Kern, Inf, Arguments and Argument). '''
 
 # Imports
+from __future__ import print_function
 import os
 import fparser
 from psyclone.parse import Descriptor, KernelType, ParseError
@@ -50,6 +51,7 @@ from psyclone import psyGen, config
 from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, \
     Arguments, KernelArgument, NameSpaceFactory, GenerationError, \
     FieldNotFoundError, HaloExchange, GlobalSum, FORTRAN_INTENT_NAMES
+from collections import OrderedDict
 
 # First section : Parser specialisations and classes
 
@@ -1022,7 +1024,7 @@ class DynKernMetadata(KernelType):
                 "Inter-grid kernels in the Dynamo 0.3 API must have at least "
                 "one field argument on each of the mesh types ({0}). However, "
                 "kernel {1} has arguments only on {2}".format(
-                    VALID_MESH_TYPES, self.name, mesh_list))
+                    VALID_MESH_TYPES, self.name, list(mesh_list)))
         # Inter-grid kernels must only have field arguments
         if non_field_arg_types:
             raise ParseError(
@@ -1052,7 +1054,7 @@ class DynKernMetadata(KernelType):
                 "kernels must be on different function spaces if they are "
                 "on different meshes. However kernel {0} has a field on "
                 "function space(s) {1} on each of the mesh types {2}.".
-                format(self.name, list(fs_common), mesh_list))
+                format(self.name, list(fs_common), list(mesh_list)))
         # Finally, record that this is a valid inter-grid kernel
         self._is_intergrid = True
 
@@ -1546,7 +1548,7 @@ class DynInvokeDofmaps(object):
         # of the unique function spaces involved.
         # We create a dictionary whose keys are the map names and entries
         # are the corresponding field objects.
-        self._unique_fs_maps = {}
+        self._unique_fs_maps = OrderedDict()
         # We also create a dictionary of column-banded dofmaps. Entries
         # in this one are themselves dictionaries containing two entries:
         # "argument" - the object holding information on the CMA kernel
@@ -1557,7 +1559,7 @@ class DynInvokeDofmaps(object):
         # A dictionary of required CMA indirection dofmaps. As with the
         # column-banded dofmaps, each entry is itself a dictionary with
         # "argument" and "direction" entries.
-        self._unique_indirection_maps = {}
+        self._unique_indirection_maps = OrderedDict()
 
         for call in schedule.calls():
             # We only need a dofmap if the kernel iterates over cells
@@ -1677,7 +1679,7 @@ class DynInvokeDofmaps(object):
 
         # Function space dofmaps
         decl_map_names = \
-            [dmap+"(:,:) => null()" for dmap in self._unique_fs_maps]
+            [dmap+"(:,:) => null()" for dmap in sorted(self._unique_fs_maps)]
 
         if decl_map_names:
             parent.add(DeclGen(parent, datatype="integer", pointer=True,
@@ -1929,7 +1931,7 @@ class DynMeshes(object):
                     root_name=mesh_name, context="PSyVars", label=mesh_name))
 
         # Convert the set of mesh names to a list and store
-        self._mesh_names = list(_name_set)
+        self._mesh_names = sorted(_name_set)
 
     def declarations(self, parent):
         '''
@@ -2573,7 +2575,7 @@ class DynInvokeBasisFns(object):
         if loop_var_list:
             # Declare any loop variables
             parent.add(DeclGen(parent, datatype="integer",
-                               entity_decls=list(loop_var_list)))
+                               entity_decls=sorted(loop_var_list)))
 
     def deallocate(self, parent):
         '''
@@ -2609,7 +2611,7 @@ class DynInvokeBasisFns(object):
 
         if func_space_var_names:
             # add the required deallocate call
-            parent.add(DeallocateGen(parent, list(func_space_var_names)))
+            parent.add(DeallocateGen(parent, sorted(func_space_var_names)))
 
 
 class DynInvoke(Invoke):
@@ -3093,8 +3095,8 @@ class DynSchedule(Schedule):
         '''a method implemented by all classes in a schedule which display the
         tree in a textual form. This method overrides the default view
         method to include distributed memory information '''
-        print self.indent(indent) + self.coloured_text + "[invoke='" + \
-            self.invoke.name + "' dm="+str(config.DISTRIBUTED_MEMORY)+"]"
+        print(self.indent(indent) + self.coloured_text + "[invoke='" + \
+            self.invoke.name + "' dm="+str(config.DISTRIBUTED_MEMORY)+"]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -3479,12 +3481,12 @@ class DynHaloExchange(HaloExchange):
         ''' Class specific view  '''
         _, known = self.required()
         runtime_check = not known
-        print self.indent(indent) + (
+        print(self.indent(indent) + (
             "{0}[field='{1}', type='{2}', depth={3}, "
             "check_dirty={4}]".format(self.coloured_text, self._field.name,
                                       self._compute_stencil_type(),
                                       self._compute_halo_depth(),
-                                      runtime_check))
+                                      runtime_check)))
 
     def gen_code(self, parent):
         ''' Dynamo specific code generation for this class '''

--- a/src/psyclone/dynamo0p3_builtins.py
+++ b/src/psyclone/dynamo0p3_builtins.py
@@ -87,7 +87,7 @@ class DynBuiltInCallFactory(object):
             raise ParseError(
                 "Unrecognised built-in call. Found '{0}' but expected "
                 "one of '{1}'".format(call.func_name,
-                                      BUILTIN_MAP_CAPITALISED.keys()))
+                                      list(BUILTIN_MAP_CAPITALISED.keys())))
 
         # Use our dictionary to get the correct Python object for
         # this built-in.
@@ -172,7 +172,7 @@ class DynBuiltIn(BuiltIn):
             raise ParseError(
                 "All field arguments to a built-in in the Dynamo 0.3 API "
                 "must be on the same space. However, found spaces {0} for "
-                "arguments to {1}".format([x for x in spaces], self.name))
+                "arguments to {1}".format(sorted(spaces), self.name))
 
     def array_ref(self, fld_name):
         ''' Returns a string containing the array reference for a

--- a/src/psyclone/expression.py
+++ b/src/psyclone/expression.py
@@ -66,9 +66,9 @@ class BinaryOperator(ExpressionNode):
         i = iter(toks[0][1:])
         try:
             while True:
-                tok = i.next()
+                tok = next(i)
                 self.symbols.append(tok)
-                tok = i.next()
+                tok = next(i)
                 self.operands.append(tok)
         except StopIteration:
             pass
@@ -96,18 +96,18 @@ class Slicing(ExpressionNode):
         self.stride = ""
 
         tokiter = iter(toks)
-        tok = tokiter.next()
+        tok = next(tokiter)
         if tok != ":":
             self.start = tok
-            tok = tokiter.next()
+            tok = next(tokiter)
 
         try:
-            tok = tokiter.next()
+            tok = next(tokiter)
             if tok != ":":
                 self.stop = tok
-                tok = tokiter.next()
+                tok = next(tokiter)
 
-            tok = tokiter.next()
+            tok = next(tokiter)
             self.stride = tok
         except StopIteration:
             pass

--- a/src/psyclone/f2pygen.py
+++ b/src/psyclone/f2pygen.py
@@ -37,6 +37,7 @@
     provide routines which can be used to generate fortran code. This library
     includes pytest tests. '''
 
+from __future__ import absolute_import, print_function
 import fparser
 import fparser.one
 from fparser.common.readfortran import FortranStringReader
@@ -176,7 +177,7 @@ class BaseGen(object):
             try:
                 idx = index_of_object(self.root.content, position[1])
             except Exception as err:
-                print str(err)
+                print(str(err))
                 raise RuntimeError(
                     "Failed to find supplied object in existing content - "
                     "is it a child of the parent?")
@@ -212,11 +213,11 @@ class BaseGen(object):
         the index of that line in the content of the parent. '''
         from fparser.one.block_statements import Do
         if debug:
-            print "Entered before_parent_loop"
-            print "The type of the current node is {0}".format(
-                str(type(self.root)))
-            print ("If the current node is a Do loop then move up to the "
-                   "top of the do loop nest")
+            print("Entered before_parent_loop")
+            print("The type of the current node is {0}".format(
+                str(type(self.root))))
+            print(("If the current node is a Do loop then move up to the "
+                   "top of the do loop nest"))
 
         # First off, check that we do actually have an enclosing Do loop
         current = self.root
@@ -229,45 +230,45 @@ class BaseGen(object):
         local_current = self
         while isinstance(current.parent, Do):
             if debug:
-                print "Parent is a do loop so moving to the parent"
+                print("Parent is a do loop so moving to the parent")
             current = current.parent
             local_current = local_current.parent
         if debug:
-            print "The type of the current node is now " + str(type(current))
-            print "The type of parent is " + str(type(current.parent))
-            print "Finding the loops position in its parent ..."
+            print("The type of the current node is now " + str(type(current)))
+            print("The type of parent is " + str(type(current.parent)))
+            print("Finding the loops position in its parent ...")
         index = current.parent.content.index(current)
         if debug:
-            print "The loop's index is ", index
+            print("The loop's index is ", index)
         parent = current.parent
         local_current = local_current.parent
         if debug:
-            print "The type of the object at the index is " + \
-                str(type(parent.content[index]))
-            print "If preceding node is a directive then move back one"
+            print("The type of the object at the index is " + \
+                str(type(parent.content[index])))
+            print("If preceding node is a directive then move back one")
         if index == 0:
             if debug:
-                print "current index is 0 so finish"
+                print("current index is 0 so finish")
         elif isinstance(parent.content[index-1], OMPDirective):
             if debug:
-                print (
+                print(
                     "preceding node is a directive so find out what type ...\n"
                     "type is {0}\ndirective is {1}".
                     format(parent.content[index-1].position,
                            str(parent.content[index-1])))
             if parent.content[index-1].position == "begin":
                 if debug:
-                    print "type of directive is begin so move back one"
+                    print("type of directive is begin so move back one")
                 index -= 1
             else:
                 if debug:
-                    print "directive type is not begin so finish"
+                    print("directive type is not begin so finish")
         else:
             if debug:
-                print "preceding node is not a directive so finish"
+                print("preceding node is not a directive so finish")
         if debug:
-            print "type of final location ", type(parent.content[index])
-            print "code for final location ", str(parent.content[index])
+            print("type of final location ", type(parent.content[index]))
+            print("code for final location ", str(parent.content[index]))
         return local_current, parent.content[index]
 
 

--- a/src/psyclone/gen_kernel_stub.py
+++ b/src/psyclone/gen_kernel_stub.py
@@ -39,6 +39,7 @@
     call a stub) when presented with Kernel Metadata.
 '''
 
+from __future__ import print_function
 import os
 import sys
 import traceback
@@ -63,8 +64,8 @@ def generate(filename, api=""):
     if api == "":
         api = DEFAULTSTUBAPI
     if api not in SUPPORTEDSTUBAPIS:
-        print "Unsupported API '{0}' specified. Supported API's are {1}.".\
-              format(api, SUPPORTEDSTUBAPIS)
+        print("Unsupported API '{0}' specified. Supported API's are {1}.".\
+              format(api, SUPPORTEDSTUBAPIS))
         raise GenerationError(
             "generate: Unsupported API '{0}' specified. Supported types are "
             "{1}.".format(api, SUPPORTEDSTUBAPIS))
@@ -74,7 +75,7 @@ def generate(filename, api=""):
 
     # drop cache
     fparser.one.parsefortran.FortranParser.cache.clear()
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     try:
         ast = fparser.api.parse(filename, ignore_comments=False)
 
@@ -109,13 +110,13 @@ def run():
     try:
         stub = generate(args.filename, api=args.api)
     except (IOError, ParseError, GenerationError, RuntimeError) as error:
-        print "Error:", error
+        print("Error:", error)
         exit(1)
     except Exception as error:   # pylint: disable=broad-except
-        print "Error, unexpected exception:\n"
+        print("Error, unexpected exception:\n")
         exc_type, exc_value, exc_traceback = sys.exc_info()
-        print exc_type
-        print exc_value
+        print(exc_type)
+        print(exc_value)
         traceback.print_tb(exc_traceback)
         exit(1)
 
@@ -129,4 +130,4 @@ def run():
         my_file.write(stub_str)
         my_file.close()
     else:
-        print "Kernel stub code:\n", stub_str
+        print("Kernel stub code:\n", stub_str)

--- a/src/psyclone/generator.py
+++ b/src/psyclone/generator.py
@@ -19,6 +19,7 @@
     from within another Python program.
 '''
 
+from __future__ import absolute_import, print_function
 import argparse
 import sys
 import os
@@ -213,12 +214,12 @@ def main(args):
     args = parser.parse_args(args)
 
     if args.api not in SUPPORTEDAPIS:
-        print "Unsupported API '{0}' specified. Supported API's are "\
-            "{1}.".format(args.api, SUPPORTEDAPIS)
+        print("Unsupported API '{0}' specified. Supported API's are "\
+            "{1}.".format(args.api, SUPPORTEDAPIS))
         exit(1)
 
     if args.version:
-        print "PSyclone version: {0}".format(__VERSION__)
+        print("PSyclone version: {0}".format(__VERSION__))
 
     # pylint: disable=broad-except
     try:
@@ -229,7 +230,7 @@ def main(args):
                             distributed_memory=args.dist_mem)
     except NoInvokesError:
         _, exc_value, _ = sys.exc_info()
-        print "Warning: {0}".format(exc_value)
+        print("Warning: {0}".format(exc_value))
         # no invoke calls were found in the algorithm file so we need
         # not need to process it, or generate any psy layer code so
         # output the original algorithm file and set the psy file to
@@ -240,16 +241,16 @@ def main(args):
     except (OSError, IOError, ParseError, GenerationError,
             RuntimeError):
         _, exc_value, _ = sys.exc_info()
-        print exc_value
+        print(exc_value)
         exit(1)
     except Exception:
-        print "Error, unexpected exception, please report to the authors:"
+        print("Error, unexpected exception, please report to the authors:")
         exc_type, exc_value, exc_tb = sys.exc_info()
-        print "Description ..."
-        print exc_value
-        print "Type ..."
-        print exc_type
-        print "Stacktrace ..."
+        print("Description ...")
+        print(exc_value)
+        print("Type ...")
+        print(exc_type)
+        print("Stacktrace ...")
         traceback.print_tb(exc_tb, limit=10, file=sys.stdout)
         exit(1)
     if args.limit:
@@ -264,7 +265,7 @@ def main(args):
         my_file.write(alg_str)
         my_file.close()
     else:
-        print "Transformed algorithm code:\n", alg_str
+        print("Transformed algorithm code:\n%s"%alg_str)
 
     if not psy_str:
         # empty file so do not output anything
@@ -274,7 +275,7 @@ def main(args):
         my_file.write(psy_str)
         my_file.close()
     else:
-        print "Generated psy layer code:\n", psy_str
+        print("Generated psy layer code:\n", psy_str)
 
 
 if __name__ == "__main__":

--- a/src/psyclone/gocean0p1.py
+++ b/src/psyclone/gocean0p1.py
@@ -11,7 +11,8 @@
     the required base classes (PSy, Invokes, Invoke, Schedule, Loop, Kern,
     Arguments and KernelArgument). '''
 
-from psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
+from __future__ import absolute_import
+from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
     KernelArgument
 
 
@@ -32,7 +33,7 @@ class GOPSy(PSy):
         :rtype: ast
 
         '''
-        from f2pygen import ModuleGen, UseGen
+        from psyclone.f2pygen import ModuleGen, UseGen
 
         # create an empty PSy layer module
         psy_module = ModuleGen(self.name)
@@ -106,7 +107,7 @@ class GOInvoke(Invoke):
             by the associated invoke call in the algorithm layer). This
             consists of the PSy invocation subroutine and the declaration of
             its arguments.'''
-        from f2pygen import SubroutineGen, DeclGen, TypeDeclGen
+        from psyclone.f2pygen import SubroutineGen, DeclGen, TypeDeclGen
         # create the subroutine
         invoke_sub = SubroutineGen(parent, name=self.name,
                                    args=self.psy_unique_var_names)
@@ -158,7 +159,7 @@ class GOLoop(Loop):
     def gen_code(self, parent):
 
         if self.field_space == "every":
-            from f2pygen import DeclGen
+            from psyclone.f2pygen import DeclGen
             dim_var = DeclGen(parent, datatype="INTEGER",
                               entity_decls=[self._variable_name])
             parent.add(dim_var)
@@ -242,7 +243,7 @@ class GOKern(Kern):
     def gen_code(self, parent):
         ''' Generates GOcean specific psy code for a call to the dynamo
             kernel instance. '''
-        from f2pygen import CallGen, UseGen
+        from psyclone.f2pygen import CallGen, UseGen
         arguments = ["i", "j"]
         for arg in self._arguments.args:
             if arg.space.lower() == "r":

--- a/src/psyclone/gocean0p1.py
+++ b/src/psyclone/gocean0p1.py
@@ -12,8 +12,8 @@
     Arguments and KernelArgument). '''
 
 from __future__ import absolute_import
-from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, Arguments, \
-    KernelArgument
+from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, Loop, Kern, \
+    Arguments, KernelArgument
 
 
 class GOPSy(PSy):

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -43,6 +43,7 @@
 
 '''
 
+from __future__ import print_function
 from psyclone.parse import Descriptor, KernelType, ParseError
 from psyclone.psyGen import PSy, Invokes, Invoke, Schedule, \
     Loop, Kern, Arguments, Argument, KernelArgument, GenerationError
@@ -296,9 +297,9 @@ class GOSchedule(Schedule):
 
     def view(self, indent=0):
         ''' Print a representation of this GOSchedule '''
-        print self.indent(indent) + self.coloured_text + "[invoke='" + \
+        print(self.indent(indent) + self.coloured_text + "[invoke='" + \
             self.invoke.name + "',Constant loop bounds=" + \
-            str(self._const_loop_bounds) + "]"
+            str(self._const_loop_bounds) + "]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 

--- a/src/psyclone/parse.py
+++ b/src/psyclone/parse.py
@@ -38,6 +38,7 @@
 ''' Module implementing classes populated by parsing either kernel
     meta-data or invoke()'s in the Algorithm layer '''
 
+from __future__ import absolute_import
 import os
 from pyparsing import ParseException
 import fparser
@@ -51,7 +52,7 @@ from psyclone import config
 
 def check_api(api):
     ''' Check that the supplied API is valid '''
-    from config import SUPPORTEDAPIS
+    from psyclone.config import SUPPORTEDAPIS
     if api not in SUPPORTEDAPIS:
         raise ParseError(
             "check_api: Unsupported API '{0}' specified. "
@@ -423,7 +424,7 @@ class KernelTypeFactory(object):
 
     def __init__(self, api=""):
         if api == "":
-            from config import DEFAULTAPI
+            from psyclone.config import DEFAULTAPI
             self._type = DEFAULTAPI
         else:
             check_api(api)
@@ -895,7 +896,7 @@ def parse(alg_filename, api="", invoke_name="invoke", inf_name="inf",
 
     # drop cache
     fparser1.parsefortran.FortranParser.cache.clear()
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     if not os.path.isfile(alg_filename):
         raise IOError("File %s not found" % alg_filename)
     try:

--- a/src/psyclone/psyGen.py
+++ b/src/psyclone/psyGen.py
@@ -39,7 +39,9 @@
     and generation. The classes in this method need to be specialised for a
     particular API and implementation. '''
 
+from __future__ import print_function
 import abc
+import six
 from psyclone import config
 
 # We use the termcolor module (if available) to enable us to produce
@@ -1276,8 +1278,8 @@ class Schedule(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text + \
-            "[invoke='" + self.invoke.name + "']"
+        print(self.indent(indent) + self.coloured_text + \
+            "[invoke='" + self.invoke.name + "']")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1314,7 +1316,7 @@ class Directive(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text
+        print(self.indent(indent) + self.coloured_text)
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1350,7 +1352,7 @@ class OMPDirective(Directive):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text + "[OMP]"
+        print(self.indent(indent) + self.coloured_text + "[OMP]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1383,7 +1385,7 @@ class OMPParallelDirective(OMPDirective):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text + "[OMP parallel]"
+        print(self.indent(indent) + self.coloured_text + "[OMP parallel]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1547,8 +1549,8 @@ class OMPDoDirective(OMPDirective):
             reprod = "[reprod={0}]".format(self._reprod)
         else:
             reprod = ""
-        print self.indent(indent) + self.coloured_text + \
-            "[OMP do]{0}".format(reprod)
+        print(self.indent(indent) + self.coloured_text + \
+            "[OMP do]{0}".format(reprod))
 
         for entity in self._children:
             entity.view(indent=indent + 1)
@@ -1639,8 +1641,8 @@ class OMPParallelDoDirective(OMPParallelDirective, OMPDoDirective):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text + \
-            "[OMP parallel do]"
+        print(self.indent(indent) + self.coloured_text + \
+            "[OMP parallel do]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1709,14 +1711,14 @@ class GlobalSum(Node):
 
     def view(self, indent):
         '''
-        Print text describing this object to stdout and then
+        print(text describing this object to stdout and then)
         call the view() method of any children.
 
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + (
-            "{0}[scalar='{1}']".format(self.coloured_text, self._scalar.name))
+        print(self.indent(indent) + (
+            "{0}[scalar='{1}']".format(self.coloured_text, self._scalar.name)))
 
     @property
     def coloured_text(self):
@@ -1872,11 +1874,11 @@ class HaloExchange(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + (
+        print(self.indent(indent) + (
             "{0}[field='{1}', type='{2}', depth={3}, "
             "check_dirty={4}]".format(self.coloured_text, self._field.name,
                                       self._halo_type,
-                                      self._halo_depth, self._check_dirty))
+                                      self._halo_depth, self._check_dirty)))
 
     @property
     def coloured_text(self):
@@ -1958,9 +1960,9 @@ class Loop(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text + \
+        print(self.indent(indent) + self.coloured_text + \
             "[type='{0}',field_space='{1}',it_space='{2}']".\
-            format(self._loop_type, self._field_space, self.iteration_space)
+            format(self._loop_type, self._field_space, self.iteration_space))
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -2140,8 +2142,8 @@ class Call(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text, \
-            self.name + "(" + str(self.arguments.raw_arg_list) + ")"
+        print(self.indent(indent) + self.coloured_text, \
+            self.name + "(" + str(self.arguments.raw_arg_list) + ")")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -2319,7 +2321,7 @@ class Call(Node):
             raise GenerationError(
                 "unsupported reduction access '{0}' found in DynBuiltin:"
                 "reduction_sum_loop(). Expected one of '{1}'".
-                format(reduction_access, REDUCTION_OPERATOR_MAPPING.keys()))
+                format(reduction_access, list(REDUCTION_OPERATOR_MAPPING.keys())))
         do_loop = DoGen(parent, thread_idx, "1", nthreads)
         do_loop.add(AssignGen(do_loop, lhs=var_name, rhs=var_name +
                               reduction_operator + local_var_ref))
@@ -2433,9 +2435,9 @@ class Kern(Call):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print self.indent(indent) + self.coloured_text, \
+        print(self.indent(indent) + self.coloured_text, \
             self.name + "(" + str(self.arguments.raw_arg_list) + ")", \
-            "[module_inline=" + str(self._module_inline) + "]"
+            "[module_inline=" + str(self._module_inline) + "]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -2941,7 +2943,7 @@ class TransInfo(object):
 
     >>> from psyclone.psyGen import TransInfo
     >>> t = TransInfo()
-    >>> print t.list
+    >>> print(t.list)
     There is 1 transformation available:
       1: SwapTrans, A test transformation
     >>> # accessing a transformation by index
@@ -3024,10 +3026,10 @@ class TransInfo(object):
                 issubclass(cls, base_class) and cls is not base_class]
 
 
+@six.add_metaclass(abc.ABCMeta)
 class Transformation(object):
     ''' abstract baseclass for a transformation. Uses the abc module so it
         can not be instantiated. '''
-    __metaclass__ = abc.ABCMeta
 
     @abc.abstractproperty
     def name(self):

--- a/src/psyclone/psyGen.py
+++ b/src/psyclone/psyGen.py
@@ -1278,8 +1278,8 @@ class Schedule(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print(self.indent(indent) + self.coloured_text + \
-            "[invoke='" + self.invoke.name + "']")
+        print(self.indent(indent) + self.coloured_text +
+              "[invoke='" + self.invoke.name + "']")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1549,8 +1549,8 @@ class OMPDoDirective(OMPDirective):
             reprod = "[reprod={0}]".format(self._reprod)
         else:
             reprod = ""
-        print(self.indent(indent) + self.coloured_text + \
-            "[OMP do]{0}".format(reprod))
+        print(self.indent(indent) + self.coloured_text +
+              "[OMP do]{0}".format(reprod))
 
         for entity in self._children:
             entity.view(indent=indent + 1)
@@ -1641,8 +1641,8 @@ class OMPParallelDoDirective(OMPParallelDirective, OMPDoDirective):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print(self.indent(indent) + self.coloured_text + \
-            "[OMP parallel do]")
+        print(self.indent(indent) + self.coloured_text +
+              "[OMP parallel do]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -1711,7 +1711,7 @@ class GlobalSum(Node):
 
     def view(self, indent):
         '''
-        print(text describing this object to stdout and then)
+        Print text describing this object to stdout and then
         call the view() method of any children.
 
         :param indent: Depth of indent for output text
@@ -1960,9 +1960,9 @@ class Loop(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print(self.indent(indent) + self.coloured_text + \
-            "[type='{0}',field_space='{1}',it_space='{2}']".\
-            format(self._loop_type, self._field_space, self.iteration_space))
+        print(self.indent(indent) + self.coloured_text +
+              "[type='{0}',field_space='{1}',it_space='{2}']".
+              format(self._loop_type, self._field_space, self.iteration_space))
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -2142,8 +2142,8 @@ class Call(Node):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print(self.indent(indent) + self.coloured_text, \
-            self.name + "(" + str(self.arguments.raw_arg_list) + ")")
+        print(self.indent(indent) + self.coloured_text,
+              self.name + "(" + str(self.arguments.raw_arg_list) + ")")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -2321,7 +2321,8 @@ class Call(Node):
             raise GenerationError(
                 "unsupported reduction access '{0}' found in DynBuiltin:"
                 "reduction_sum_loop(). Expected one of '{1}'".
-                format(reduction_access, list(REDUCTION_OPERATOR_MAPPING.keys())))
+                format(reduction_access,
+                       list(REDUCTION_OPERATOR_MAPPING.keys())))
         do_loop = DoGen(parent, thread_idx, "1", nthreads)
         do_loop.add(AssignGen(do_loop, lhs=var_name, rhs=var_name +
                               reduction_operator + local_var_ref))
@@ -2435,9 +2436,9 @@ class Kern(Call):
         :param indent: Depth of indent for output text
         :type indent: integer
         '''
-        print(self.indent(indent) + self.coloured_text, \
-            self.name + "(" + str(self.arguments.raw_arg_list) + ")", \
-            "[module_inline=" + str(self._module_inline) + "]")
+        print(self.indent(indent) + self.coloured_text,
+              self.name + "(" + str(self.arguments.raw_arg_list) + ")",
+              "[module_inline=" + str(self._module_inline) + "]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 

--- a/src/psyclone/tests/alggen_test.py
+++ b/src/psyclone/tests/alggen_test.py
@@ -9,7 +9,7 @@
 ''' Tests for the algorithm generation (re-writing) as implemented
     in algGen.py '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.generator import generate, GenerationError
@@ -78,7 +78,7 @@ def test_multi_position_named_invoke():
                      "4.10_multi_position_named_invokes.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert "USE multikernel_invokes_7_psy, ONLY: invoke_name_first" in gen
     assert "USE multikernel_invokes_7_psy, ONLY: invoke_name_middle" in gen
     assert "USE multikernel_invokes_7_psy, ONLY: invoke_name_last" in gen
@@ -148,7 +148,7 @@ def test_multi_function_multi_invokes():
         os.path.join(BASE_PATH, "3.1_multi_functions_multi_invokes.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert "USE multi_functions_multi_invokes_psy, ONLY: invoke_1" in gen
     assert "USE multi_functions_multi_invokes_psy, ONLY: invoke_0" in gen
     assert "CALL invoke_0(a, f1, f2, m1, m2, istp, qr)" in gen
@@ -161,7 +161,7 @@ def test_multi_function_invoke_qr():
     alg, _ = generate(os.path.join(
         BASE_PATH, "1.3_multi_invoke_qr.f90"), api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert "USE testkern_qr, ONLY: testkern_qr_type" in gen
     assert "USE testkern, ONLY: testkern_type" in gen
     assert "CALL invoke_0(f1, f2, m1, a, m2, istp, m3, f3, qr)" in gen
@@ -172,7 +172,7 @@ def test_invoke_argnames():
     alg, _ = generate(os.path.join(
         BASE_PATH, "5_alg_field_array.f90"), api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert "USE single_function_psy, ONLY: invoke_0" in gen
     assert ("CALL invoke_0(f0(1), f1(1, 1), f1(2, index), b(1), "
             "f1(index, index2(index3)), iflag(2), a(index1), "
@@ -210,7 +210,7 @@ def test_deref_derived_type_args():
                      "1.6.2_single_invoke_1_int_from_derived_type.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert (
         "CALL invoke_0(f1, my_obj%iflag, f2, m1, m2, my_obj%get_flag(), "
         "my_obj%get_flag(switch), my_obj%get_flag(int_wrapper%data))"
@@ -226,7 +226,7 @@ def test_multi_deref_derived_type_args():
                      "1.6.3_single_invoke_multiple_derived_types.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert (
         "CALL invoke_0(f1, obj_a%iflag, f2, m1, m2, obj_b%iflag, "
         "obj_a%obj_b, obj_b%obj_a)"
@@ -242,7 +242,7 @@ def test_op_and_scalar_and_qr_derived_type_args():
                      "10.6.1_operator_no_field_scalar_deref.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert (
         "CALL invoke_0_testkern_operator_nofield_scalar_type("
         "opbox%my_mapping, box%b(1), qr%get_instance(qr3, 9, 3))" in gen)
@@ -258,7 +258,7 @@ def test_vector_field_arg_deref():
                      "8.1_vector_field_deref.f90"),
         api="dynamo0.3")
     gen = str(alg)
-    print gen
+    print(gen)
     assert "CALL invoke_0_testkern_chi_type(f1, box%chi, f2)" in gen
 
 
@@ -287,7 +287,7 @@ def test_single_stencil_xory1d():
     path = os.path.join(BASE_PATH, "19.3_single_stencil_xory1d.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_xory1d_type(f1, f2, "
             "f3, f4, f2_extent, f2_direction)") in output
 
@@ -308,7 +308,7 @@ def test_single_stencil_xory1d_literal():
         BASE_PATH, "19.5_single_stencil_xory1d_literal.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_xory1d_type(f1, f2, "
             "f3, f4)") in output
 
@@ -318,7 +318,7 @@ def test_multiple_stencils():
     path = os.path.join(BASE_PATH, "19.7_multiple_stencils.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_multi_type(f1, f2, "
             "f3, f4, f2_extent, f3_extent, f3_direction)") in output
 
@@ -329,7 +329,7 @@ def test_multiple_stencil_same_name_direction():
     path = os.path.join(BASE_PATH, "19.9_multiple_stencils_same_name.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_multi_2_type(f1, f2, "
             "f3, f4, extent, direction)") in output
 
@@ -339,7 +339,7 @@ def test_multiple_kernels_stencils():
     path = os.path.join(BASE_PATH, "19.10_multiple_kernels_stencils.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert "USE multiple_stencil_psy, ONLY: invoke_0" in output
     assert ("CALL invoke_0(f1, f2, f3, f4, f2_extent, f3_extent, extent, "
             "f3_direction, direction)") in output
@@ -352,7 +352,7 @@ def test_multiple_stencil_same_name_case():
         BASE_PATH, "19.11_multiple_stencils_mixed_case.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_multi_2_type(f1, f2, "
             "f3, f4, extent, direction)") in output
 
@@ -372,7 +372,7 @@ def test_multiple_stencil_same_name():
     path = os.path.join(BASE_PATH, "19.8_multiple_stencils_same_name.f90")
     alg, _ = generate(path, api="dynamo0.3")
     output = str(alg)
-    print output
+    print(output)
     assert ("CALL invoke_0_testkern_stencil_multi_type(f1, f2, "
             "f3, f4, extent, f3_direction)") in output
 

--- a/src/psyclone/tests/dynamo0p3_basis_test.py
+++ b/src/psyclone/tests/dynamo0p3_basis_test.py
@@ -37,7 +37,7 @@
 ''' Module containing py.test tests for functionality related to
 evaluators in the LFRic API '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 import fparser
@@ -76,7 +76,7 @@ end module testkern_eval
 
 def test_eval_mdata():
     ''' Check that we recognise "evaluator" as a valid gh_shape '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     dkm = DynKernMetadata(ast, name="testkern_eval_type")
     assert dkm.get_integer_variable('gh_shape') == 'gh_evaluator'
@@ -85,7 +85,7 @@ def test_eval_mdata():
 def test_single_updated_arg():
     ''' Check that we reject any kernel requiring an evaluator
     if it writes to more than one argument '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the access of the read-only argument
     code = CODE.replace("GH_READ", "GH_WRITE", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -108,7 +108,7 @@ def test_single_kern_eval(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -122,7 +122,7 @@ def test_single_kern_eval(tmpdir, f90, f90flags):
         "      TYPE(field_type), intent(inout) :: f0\n"
         "      TYPE(field_type), intent(in) :: f1\n"
         "      INTEGER cell\n"
-        "      INTEGER df_w1, df_w0, df_nodal\n"
+        "      INTEGER df_nodal, df_w0, df_w1\n"
         "      REAL(KIND=r_def), allocatable :: basis_w0_on_w0(:,:,:), "
         "diff_basis_w1_on_w0(:,:,:)\n"
         "      INTEGER ndf_nodal_w0, dim_w0, diff_dim_w1\n"
@@ -207,7 +207,7 @@ def test_single_kern_eval(tmpdir, f90, f90flags):
     )
     assert expected_code in gen_code
     dealloc_code = (
-        "      DEALLOCATE (diff_basis_w1_on_w0, basis_w0_on_w0)\n"
+        "      DEALLOCATE (basis_w0_on_w0, diff_basis_w1_on_w0)\n"
         "      !\n"
         "    END SUBROUTINE invoke_0_testkern_eval_type\n"
     )
@@ -222,7 +222,7 @@ def test_single_kern_eval_op(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -236,7 +236,7 @@ def test_single_kern_eval_op(tmpdir, f90, f90flags):
         "      TYPE(field_type), intent(in) :: f1\n"
         "      TYPE(operator_type), intent(inout) :: op1\n"
         "      INTEGER cell\n"
-        "      INTEGER df_w3, df_nodal, df_w2\n"
+        "      INTEGER df_nodal, df_w2, df_w3\n"
         "      REAL(KIND=r_def), allocatable :: basis_w2_on_w0(:,:,:), "
         "diff_basis_w3_on_w0(:,:,:)\n"
         "      INTEGER ndf_nodal_w0, dim_w2, diff_dim_w3\n"
@@ -287,7 +287,7 @@ def test_single_kern_eval_op(tmpdir, f90, f90flags):
         "diff_basis_w3_on_w0)\n"
         "      END DO \n")
     assert kern_call in gen_code
-    dealloc = ("      DEALLOCATE (diff_basis_w3_on_w0, basis_w2_on_w0)\n")
+    dealloc = ("      DEALLOCATE (basis_w2_on_w0, diff_basis_w3_on_w0)\n")
     assert dealloc in gen_code
 
 
@@ -299,7 +299,7 @@ def test_two_qr(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -334,8 +334,8 @@ def test_two_qr(tmpdir, f90, f90flags):
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, "
         "m2_proxy, g1_proxy, g2_proxy, n1_proxy, n2_proxy\n"
         "      TYPE(quadrature_xyoz_proxy_type) qr_proxy, qr2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
     )
     assert expected_declns in gen_code
     expected_code = (
@@ -424,9 +424,9 @@ def test_two_qr(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Deallocate basis arrays\n"
         "      !\n"
-        "      DEALLOCATE (basis_w3_qr2, diff_basis_w2_qr, diff_basis_w2_qr2, "
-        "basis_w1_qr2, basis_w3_qr, diff_basis_w3_qr2, diff_basis_w3_qr, "
-        "basis_w1_qr)\n"
+        "      DEALLOCATE (basis_w1_qr, basis_w1_qr2, basis_w3_qr, "
+        "basis_w3_qr2, diff_basis_w2_qr, diff_basis_w2_qr2, diff_basis_w3_qr, "
+        "diff_basis_w3_qr2)\n"
     )
     if expected_kern_call not in gen_code:
         utils.print_diffs(expected_kern_call, gen_code)
@@ -441,7 +441,7 @@ def test_two_identical_qr(tmpdir, f90, f90flags):
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -509,7 +509,7 @@ def test_two_identical_qr(tmpdir, f90, f90flags):
         "      END DO \n")
     assert expected_kern_call in gen_code
     expected_dealloc = (
-        "DEALLOCATE (diff_basis_w2_qr, basis_w1_qr, basis_w3_qr, "
+        "DEALLOCATE (basis_w1_qr, basis_w3_qr, diff_basis_w2_qr, "
         "diff_basis_w3_qr)")
     assert expected_dealloc in gen_code
 
@@ -524,7 +524,7 @@ def test_anyw2(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
 
         if utils.TEST_COMPILE:
             # Test that generated code compiles
@@ -576,7 +576,7 @@ def test_qr_plus_eval(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # Test that generated code compiles
@@ -595,7 +595,7 @@ def test_qr_plus_eval(tmpdir, f90, f90flags):
         "      TYPE(field_type), intent(in) :: f2, m1, m2\n"
         "      TYPE(quadrature_xyoz_type), intent(in) :: qr\n"
         "      INTEGER cell\n"
-        "      INTEGER df_w1, df_w0, df_nodal\n"
+        "      INTEGER df_nodal, df_w0, df_w1\n"
         "      REAL(KIND=r_def), allocatable :: basis_w0_on_w0(:,:,:), "
         "basis_w1_qr(:,:,:,:), basis_w3_qr(:,:,:,:), "
         "diff_basis_w1_on_w0(:,:,:), "
@@ -612,8 +612,8 @@ def test_qr_plus_eval(tmpdir, f90, f90flags):
         "      TYPE(field_proxy_type) f0_proxy, f1_proxy, f2_proxy, "
         "m1_proxy, m2_proxy\n"
         "      TYPE(quadrature_xyoz_proxy_type) qr_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w0(:,:) => null(), map_w1(:,:) => "
+        "      INTEGER, pointer :: map_w0(:,:) => null(), "
+        "map_w1(:,:) => null(), map_w2(:,:) => null(), map_w3(:,:) => "
         "null()\n")
     assert output_decls in gen_code
     output_setup = (
@@ -698,8 +698,8 @@ def test_qr_plus_eval(tmpdir, f90, f90flags):
         "      END DO \n")
     assert output_kern_call in gen_code
     output_dealloc = (
-        "      DEALLOCATE (diff_basis_w2_qr, basis_w0_on_w0, basis_w3_qr, "
-        "diff_basis_w3_qr, diff_basis_w1_on_w0, basis_w1_qr)\n")
+        "      DEALLOCATE (basis_w0_on_w0, basis_w1_qr, basis_w3_qr, "
+        "diff_basis_w1_on_w0, diff_basis_w2_qr, diff_basis_w3_qr)\n")
     assert output_dealloc in gen_code
 
 
@@ -711,7 +711,7 @@ def test_two_eval_same_space(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # Test that generated code compiles
@@ -782,7 +782,7 @@ def test_two_eval_diff_space(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -879,7 +879,7 @@ def test_two_eval_same_var_same_space(
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # Test that generated code compiles
@@ -921,7 +921,7 @@ def test_two_eval_op_to_space(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # Test that generated code compiles
@@ -1038,7 +1038,7 @@ def test_eval_diff_nodal_space(tmpdir, f90, f90flags):
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
 
     if utils.TEST_COMPILE:
         # Test that generated code compiles
@@ -1134,8 +1134,8 @@ def test_eval_diff_nodal_space(tmpdir, f90, f90flags):
         "      ! Deallocate basis arrays\n"
         "      !\n"
         "      DEALLOCATE ("
-        "diff_basis_w2_on_w3, diff_basis_w2_on_w0, diff_basis_w3_on_w3, "
-        "diff_basis_w3_on_w0, basis_w2_on_w3, basis_w2_on_w0)\n"
+        "basis_w2_on_w0, basis_w2_on_w3, diff_basis_w2_on_w0, "
+        "diff_basis_w2_on_w3, diff_basis_w3_on_w0, diff_basis_w3_on_w3)\n"
     )
     assert expected_dealloc in gen_code
 
@@ -1181,7 +1181,7 @@ def test_basis_evaluator():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     output_arg_list = (
         "    SUBROUTINE dummy_code(cell, nlayers, field_1_w0, op_2_ncell_3d, "
         "op_2, field_3_w2, op_4_ncell_3d, op_4, field_5_wtheta, "
@@ -1386,8 +1386,8 @@ def test_diff_basis():
         "      REAL(KIND=r_def), intent(in), dimension(np_z) :: weights_z\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
@@ -1432,7 +1432,7 @@ def test_diff_basis_eval():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     output_args = (
         "  MODULE dummy_mod\n"
         "    IMPLICIT NONE\n"

--- a/src/psyclone/tests/dynamo0p3_builtins_test.py
+++ b/src/psyclone/tests/dynamo0p3_builtins_test.py
@@ -39,7 +39,7 @@
     they iterate over DOFs. However this may change in the future. '''
 
 # imports
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.parse import parse, ParseError
@@ -249,8 +249,8 @@ def test_builtin_args_not_same_space():
         _ = PSyFactory("dynamo0.3",
                        distributed_memory=False).create(invoke_info)
     assert ("All field arguments to a built-in in the Dynamo 0.3 API "
-            "must be on the same space. However, found spaces ['any_space_2', "
-            "'any_space_1'] for arguments to " + test_builtin_name.lower() in
+            "must be on the same space. However, found spaces ['any_space_1', "
+            "'any_space_2'] for arguments to " + test_builtin_name.lower() in
             str(excinfo))
 
 
@@ -369,7 +369,7 @@ def test_X_plus_Y():
         assert str(kern) == "Built-in: Add fields"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f3_proxy = f3%get_proxy()\n"
@@ -408,7 +408,7 @@ def test_X_plus_Y():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -429,7 +429,7 @@ def test_inc_X_plus_Y():
         assert str(kern) == "Built-in: Increment field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      ndf_any_space_1_f1 = f1_proxy%vspace%get_ndf()\n"
@@ -475,7 +475,7 @@ def test_aX_plus_Y():
         assert str(kern) == "Built-in: aX_plus_Y"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, a, f1, f2)\n"
@@ -527,7 +527,7 @@ def test_aX_plus_Y():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -547,7 +547,7 @@ def test_inc_aX_plus_Y():
         assert str(kern) == "Built-in: inc_aX_plus_Y"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(a, f1, f2)\n"
@@ -598,7 +598,7 @@ def test_inc_aX_plus_Y():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -618,7 +618,7 @@ def test_inc_X_plus_bY():
         assert str(kern) == "Built-in: inc_X_plus_bY"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f1, b, f2)\n"
@@ -669,7 +669,7 @@ def test_inc_X_plus_bY():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -690,7 +690,7 @@ def test_aX_plus_bY():
         assert str(kern) == "Built-in: aX_plus_bY"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, a, f1, b, f2)\n"
@@ -742,7 +742,7 @@ def test_aX_plus_bY():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -764,7 +764,7 @@ def test_inc_aX_plus_bY():
         assert str(kern) == "Built-in: inc_aX_plus_bY"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(a, f1, b, f2)\n"
@@ -815,7 +815,7 @@ def test_inc_aX_plus_bY():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -838,7 +838,7 @@ def test_X_minus_Y():
         assert str(kern) == "Built-in: Subtract fields"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f3_proxy = f3%get_proxy()\n"
@@ -877,7 +877,7 @@ def test_X_minus_Y():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -899,7 +899,7 @@ def test_inc_X_minus_Y():
         assert str(kern) == "Built-in: Decrement field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f1_proxy = f1%get_proxy()\n"
@@ -954,7 +954,7 @@ def test_aX_minus_Y():
         assert str(kern) == "Built-in: aX_minus_Y"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, a, f1, f2)\n"
@@ -1006,7 +1006,7 @@ def test_aX_minus_Y():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1026,7 +1026,7 @@ def test_X_minus_bY():
         assert str(kern) == "Built-in: X_minus_bY"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, f1, b, f2)\n"
@@ -1078,7 +1078,7 @@ def test_X_minus_bY():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1098,7 +1098,7 @@ def test_inc_X_minus_bY():
         assert str(kern) == "Built-in: inc_X_minus_bY"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f1, b, f2)\n"
@@ -1149,7 +1149,7 @@ def test_inc_X_minus_bY():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1174,7 +1174,7 @@ def test_X_times_Y():
         assert str(kern) == "Built-in: Multiply fields"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, f1, f2)\n"
@@ -1241,7 +1241,7 @@ def test_inc_X_times_Y():
         assert str(kern) == "Built-in: Multiply field by another"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f1_proxy = f1%get_proxy()\n"
@@ -1279,7 +1279,7 @@ def test_inc_X_times_Y():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1299,7 +1299,7 @@ def test_inc_aX_times_Y():
         assert str(kern) == "Built-in: inc_aX_times_Y"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(a, f1, f2)\n"
@@ -1350,7 +1350,7 @@ def test_inc_aX_times_Y():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1374,7 +1374,7 @@ def test_a_times_X():
         assert str(kern) == "Built-in: Copy scaled field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f2_proxy = f2%get_proxy()\n"
@@ -1410,7 +1410,7 @@ def test_a_times_X():
                 "      !\n"
                 "      CALL f2_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1432,7 +1432,7 @@ def test_inc_a_times_X():
         assert str(kern) == "Built-in: Scale a field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(a, f1, b, f2, f3)\n"
@@ -1501,7 +1501,7 @@ def test_X_divideby_Y():
         assert str(kern) == "Built-in: Divide fields"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f3_proxy = f3%get_proxy()\n"
@@ -1540,7 +1540,7 @@ def test_X_divideby_Y():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1560,7 +1560,7 @@ def test_inc_X_divideby_Y():
         assert str(kern) == "Built-in: Divide one field by another"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      f1_proxy = f1%get_proxy()\n"
@@ -1598,7 +1598,7 @@ def test_inc_X_divideby_Y():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1623,7 +1623,7 @@ def test_inc_X_powreal_a():
         assert str(kern) == "Built-in: raise a field to a real power"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "      ndf_any_space_1_f1 = f1_proxy%vspace%get_ndf()\n"
@@ -1670,7 +1670,7 @@ def test_inc_X_powint_n(tmpdir, f90, f90flags):
         assert str(kern) == "Built-in: raise a field to an integer power"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
 
         if utils.TEST_COMPILE:
             # If compilation testing has been enabled
@@ -1724,7 +1724,7 @@ def test_setval_c():
         assert str(kern) == "Built-in: Set field to a scalar value"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f1, c)\n"
@@ -1769,7 +1769,7 @@ def test_setval_c():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1789,7 +1789,7 @@ def test_setval_X():
         assert str(kern) == "Built-in: Set a field equal to another field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f2, f1)\n"
@@ -1835,7 +1835,7 @@ def test_setval_X():
                 "      !\n"
                 "      CALL f2_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -1861,7 +1861,7 @@ def test_X_innerproduct_Y():
         assert str(kern) == "Built-in: X_innerproduct_Y"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         output = (
             "      !\n"
             "      ! Initialise field and/or operator proxies\n"
@@ -1939,7 +1939,7 @@ def test_X_innerproduct_X():
         assert str(kern) == "Built-in: X_innerproduct_X"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         output = (
             "      !\n"
             "      ! Initialise field and/or operator proxies\n"
@@ -2018,7 +2018,7 @@ def test_sum_X():
         assert str(kern) == "Built-in: sum a field"
         # Test code generation
         code = str(psy.gen)
-        print code
+        print(code)
         output = (
             "      !\n"
             "      ! Initialise field and/or operator proxies\n"
@@ -2105,7 +2105,7 @@ def test_X_times_Y_deduce_space():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         output = (
             "some fortran\n"
         )
@@ -2126,7 +2126,7 @@ def test_builtin_set(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
 
         if utils.TEST_COMPILE:
             # If compilation testing has been enabled
@@ -2162,7 +2162,7 @@ def test_builtin_set(tmpdir, f90, f90flags):
                 "      END DO \n"
                 "      !\n"
                 "    END SUBROUTINE invoke_0\n")
-            print output_seq
+            print(output_seq)
             assert output_seq in code
 
         if distmem:
@@ -2180,7 +2180,7 @@ def test_builtin_set(tmpdir, f90, f90flags):
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -2195,7 +2195,7 @@ def test_aX_plus_Y_by_value():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, f1, f2)\n"
@@ -2246,7 +2246,7 @@ def test_aX_plus_Y_by_value():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -2261,7 +2261,7 @@ def test_aX_plus_bY_by_value():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f3, f1, f2)\n"
@@ -2312,7 +2312,7 @@ def test_aX_plus_bY_by_value():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -2329,7 +2329,7 @@ def test_multiple_builtin_set():
         psy = PSyFactory(
             "dynamo0.3", distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         if not distmem:
             output = (
                 "    SUBROUTINE invoke_0(f1, fred, f2, f3, ginger)\n"
@@ -2411,7 +2411,7 @@ def test_multiple_builtin_set():
                 "      !\n"
                 "      CALL f3_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -2427,15 +2427,16 @@ def test_builtin_set_plus_normal():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
 
         dofmap_output = (
             "      !\n"
             "      ! Look-up dofmaps for each function space\n"
             "      !\n"
+            "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
             "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
             "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-            "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n")
+            )
         assert dofmap_output in code
 
         if not distmem:
@@ -2503,7 +2504,7 @@ def test_builtin_set_plus_normal():
                 "      !\n"
                 "      CALL f1_proxy%set_dirty()\n"
                 "      !\n")
-            print output_dm_2
+            print(output_dm_2)
             assert output_dm_2 in code
 
 
@@ -2522,7 +2523,7 @@ def test_multi_builtin_single_invoke():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert(
                 "    SUBROUTINE invoke_0(asum, f1, f2, b)\n"

--- a/src/psyclone/tests/dynamo0p3_cma_test.py
+++ b/src/psyclone/tests/dynamo0p3_cma_test.py
@@ -37,7 +37,7 @@
 ''' This module tests the support for Column-Matrix-Assembly operators in
 the Dynamo 0.3 API using pytest. '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 import fparser
@@ -79,7 +79,7 @@ end module testkern_cma
 def test_cma_mdata_assembly():
     ''' Check that we can parse meta-data entries relating to Column-Matrix
     Assembly '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_ASSEMBLE
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_cma_type"
@@ -91,7 +91,7 @@ def test_cma_mdata_assembly():
         "  access_descriptor[1]='gh_write'\n"
         "  function_space_to[2]='any_space_1'\n"
         "  function_space_from[3]='any_space_2'\n")
-    print dkm_str
+    print(dkm_str)
     assert expected in dkm_str
     assert dkm._cma_operation == "assembly"
 
@@ -100,7 +100,7 @@ def test_cma_mdata_assembly_missing_op():
     ''' Check that we raise the expected error if the supplied meta-data
     is assembling a gh_columnwise_operator but doesn't have a read-only
     gh_operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Remove  the (required) LMA operator
     code = CMA_ASSEMBLE.replace(
         "arg_type(gh_operator,gh_read, any_space_1, any_space_2),", "", 1)
@@ -118,7 +118,7 @@ def test_cma_mdata_assembly_missing_op():
 def test_cma_mdata_multi_writes():
     ''' Check that we raise the expected error if the supplied meta-data
     specifies more than one CMA operator that is written to '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Replace the field arg with another CMA operator that is written to
     for access in OP_WRITE_ACCESSES:
         cmaopstring = "arg_type(gh_columnwise_operator," + access + \
@@ -150,7 +150,7 @@ def test_cma_mdata_mutable_op():
     ''' Check that we raise the expected error if the supplied meta-data
     is assembling a gh_columnwise_operator but doesn't have a read-only
     gh_operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Make the LMA operator gh_write and gh_readwrite instead of gh_read
     for access in OP_WRITE_ACCESSES:
         opstring = "arg_type(gh_operator," + access + \
@@ -171,7 +171,7 @@ def test_cma_mdata_writes_lma_op():
     ''' Check that we raise the expected error if the supplied meta-data
     is assembling a gh_columnwise_operator but also writes to a
     gh_operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Add an additional LMA operator that has write or readwrite access
     for access in OP_WRITE_ACCESSES:
         opstring = "arg_type(gh_operator," + access + \
@@ -194,7 +194,7 @@ def test_cma_mdata_assembly_diff_spaces():
     ''' Check that we successfully parse the supplied meta-data if it
     is assembling a gh_columnwise_operator but the to/from spaces don't
     match those of the supplied gh_operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the to space of the LMA operator
     code = CMA_ASSEMBLE.replace(
         "arg_type(gh_operator,gh_read, any_space_1, any_space_2),",
@@ -216,7 +216,7 @@ def test_cma_mdata_assembly_diff_spaces():
 def test_cma_mdata_asm_vector_error():
     ''' Check that we raise the expected error if a kernel assembling a
     CMA operator has any vector arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the space of the field that is written
     code = CMA_ASSEMBLE.replace(
         "arg_type(gh_field,gh_read, any_space_1)",
@@ -240,7 +240,7 @@ def test_cma_mdata_asm_vector_error():
 def test_cma_mdata_asm_stencil_error():
     ''' Check that we raise the expected error if a kernel assembling a
     CMA operator specifies a stencil access on a field'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the space of the field that is written
     code = CMA_ASSEMBLE.replace(
         "arg_type(gh_field,gh_read, any_space_1)",
@@ -276,7 +276,7 @@ end module testkern_cma_apply
 def test_cma_mdata_apply():
     ''' Check that we can parse meta-data entries relating to the
     application of Column-Matrix operators '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_APPLY
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_cma_type"
@@ -287,7 +287,7 @@ def test_cma_mdata_apply():
         "  argument_type[0]='gh_field'\n"
         "  access_descriptor[1]='gh_read'\n"
         "  function_space[2]='any_space_2'\n")
-    print dkm_str
+    print(dkm_str)
     assert expected in dkm_str
     dkm_str = str(dkm.arg_descriptors[2])
     expected = (
@@ -303,7 +303,7 @@ def test_cma_mdata_apply():
 def test_cma_mdata_apply_too_many_ops():
     ''' Check that we raise the expected error if there are too-many
     CMA operators '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Add an additional read-only CMA operator to the argument list
     code = CMA_APPLY.replace(
         "ANY_SPACE_2),                        &\n",
@@ -322,7 +322,7 @@ def test_cma_mdata_apply_too_many_ops():
 def test_cma_mdata_apply_too_many_flds():
     ''' Check that we raise the expected error if there are too-many
     field args to a kernel that applies a CMA operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Add an additional read-only field to the argument list
     code = CMA_APPLY.replace(
         "ANY_SPACE_2),                        &\n",
@@ -341,7 +341,7 @@ def test_cma_mdata_apply_too_many_flds():
 def test_cma_mdata_apply_no_read_fld():
     ''' Check that we raise the expected error if there is no read-only
     field arg to a kernel that applies a CMA operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Make the read-only field gh_write instead
     code = CMA_APPLY.replace(
         "arg_type(GH_FIELD,    GH_READ, ANY_SPACE_2), ",
@@ -357,7 +357,7 @@ def test_cma_mdata_apply_no_read_fld():
 def test_cma_mdata_apply_no_write_fld():
     ''' Check that we raise the expected error if there is no written
     field arg to a kernel that applies a CMA operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Turn the written field into an operator instead
     code = CMA_APPLY.replace(
         "arg_type(GH_FIELD,    GH_INC,  ANY_SPACE_1), ",
@@ -374,7 +374,7 @@ def test_cma_mdata_apply_wrong_spaces():
     ''' Check that we raise the expected error if the function spaces of the
     read and write fields do not match the from and to function spaces of the
     CMA operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the space of the field that is written
     code = CMA_APPLY.replace("arg_type(GH_FIELD,    GH_INC,  ANY_SPACE_1)",
                              "arg_type(GH_FIELD,    GH_INC,  ANY_SPACE_3)", 1)
@@ -400,7 +400,7 @@ def test_cma_mdata_apply_wrong_spaces():
 def test_cma_mdata_apply_vector_error():
     ''' Check that we raise the expected error if the meta-data for a kernel
     that applies a CMA operator contains a vector argument '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_APPLY.replace("arg_type(GH_FIELD,    GH_INC,  ANY_SPACE_1)",
                              "arg_type(GH_FIELD*3,  GH_INC,  ANY_SPACE_1)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -423,7 +423,7 @@ def test_cma_mdata_apply_fld_stencil_error():
     ''' Check that we raise the expected error if the meta-data for a kernel
     that applies a CMA operator contains a field argument with a stencil
     access '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_APPLY.replace(
         "arg_type(GH_FIELD,    GH_READ, ANY_SPACE_2)",
         "arg_type(GH_FIELD,    GH_READ, ANY_SPACE_2, STENCIL(X1D))", 1)
@@ -459,7 +459,7 @@ end module testkern_cma_matrix_matrix
 def test_cma_mdata_matrix_prod():
     ''' Check that we can parse meta-data entries relating to a kernel
     that performs a product of two CMA operators '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_cma_type"
@@ -471,7 +471,7 @@ def test_cma_mdata_matrix_prod():
         "  access_descriptor[1]='gh_read'\n"
         "  function_space_to[2]='any_space_1'\n"
         "  function_space_from[3]='any_space_2'\n")
-    print dkm_str
+    print(dkm_str)
     assert expected in dkm_str
     assert dkm._cma_operation == "matrix-matrix"
 
@@ -479,7 +479,7 @@ def test_cma_mdata_matrix_prod():
 def test_cma_mdata_matrix_too_few_args():
     ''' Check that we raise the expected error when there are too few
     arguments specified in meta-data '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "       arg_type(GH_COLUMNWISE_OPERATOR, GH_READ, ANY_SPACE_1, "
         "ANY_SPACE_2),&\n", "", 2)
@@ -498,7 +498,7 @@ def test_cma_mdata_matrix_field_arg():
     reads from a field argument. Adding an argument that is not a CMA
     operator or scalar means that PSyclone attempts to identify this as an
     assembly kernel. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_READ, ANY_SPACE_1, "
         "ANY_SPACE_2)", "arg_type(GH_FIELD, GH_READ, ANY_SPACE_1)", 1)
@@ -514,7 +514,7 @@ def test_cma_mdata_matrix_field_arg():
 def test_cma_mdata_matrix_no_scalar_arg():
     ''' Check that we successfully parse meta-data for a matrix-matrix kernel
     that has no scalar arguments. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "arg_type(GH_REAL,                GH_READ)",
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_READ, ANY_SPACE_1, ANY_SPACE_2)",
@@ -528,12 +528,12 @@ def test_cma_mdata_matrix_no_scalar_arg():
 def test_cma_mdata_matrix_2_scalar_args():
     ''' Check that we successfully parse meta-data for a matrix-matrix kernel
     that has 2 scalar arguments. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_READ, ANY_SPACE_1, ANY_SPACE_2)",
         "arg_type(GH_REAL,                GH_READ)",
         1)
-    print code
+    print(code)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_cma_type"
     dkm = DynKernMetadata(ast, name=name)
@@ -543,7 +543,7 @@ def test_cma_mdata_matrix_2_scalar_args():
 def test_cma_mdata_matrix_2_writes():
     ''' Check that we raise the expected error when a matrix-matrix kernel
     writes (write and readwrite access) to more than one CMA operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     for access in OP_WRITE_ACCESSES:
         cmaopstring = "arg_type(GH_COLUMNWISE_OPERATOR," + access + \
                       ", ANY_SPACE_1, ANY_SPACE_2),&\n"
@@ -566,7 +566,7 @@ def test_cma_mdata_matrix_2_writes():
 def test_cma_mdata_stencil_invalid():
     ''' Check that we raise the expected error when a matrix-matrix kernel
     specifies a stencil '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_WRITE,ANY_SPACE_1, ANY_SPACE_2)",
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_WRITE,ANY_SPACE_1, "
@@ -592,7 +592,7 @@ def test_cma_mdata_stencil_invalid():
 def test_cma_mdata_matrix_vector_error():
     ''' Check that we raise the expected error when a matrix-matrix kernel
     contains a vector argument '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CMA_MATRIX.replace(
         "arg_type(GH_COLUMNWISE_OPERATOR, GH_WRITE,ANY_SPACE_1, ANY_SPACE_2)",
         "arg_type(GH_COLUMNWISE_OPERATOR*3,GH_WRITE,ANY_SPACE_1,ANY_SPACE_2)",
@@ -640,7 +640,7 @@ def test_cma_asm(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert ("USE operator_mod, ONLY: operator_type, operator_proxy_type, "
                 "columnwise_operator_type, columnwise_operator_proxy_type") \
             in code
@@ -680,7 +680,7 @@ def test_cma_asm_field():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert ("USE operator_mod, ONLY: operator_type, operator_proxy_type, "
                 "columnwise_operator_type, columnwise_operator_proxy_type") \
             in code
@@ -707,7 +707,7 @@ def test_cma_asm_field():
                     "cbanded_map_any_space_1_afield, "
                     "ndf_any_space_2_lma_op1, "
                     "cbanded_map_any_space_2_lma_op1)")
-        print expected
+        print(expected)
         assert expected in code
 
 
@@ -725,7 +725,7 @@ def test_cma_asm_scalar():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert ("USE operator_mod, ONLY: operator_type, operator_proxy_type, "
                 "columnwise_operator_type, columnwise_operator_proxy_type") \
             in code
@@ -750,7 +750,7 @@ def test_cma_asm_scalar():
                     "cbanded_map_any_space_1_lma_op1, "
                     "ndf_any_space_2_lma_op1, "
                     "cbanded_map_any_space_2_lma_op1)")
-        print expected
+        print(expected)
         assert expected in code
 
 
@@ -768,7 +768,7 @@ def test_cma_asm_field_same_fs():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert ("USE operator_mod, ONLY: operator_type, operator_proxy_type, "
                 "columnwise_operator_type, columnwise_operator_proxy_type") \
             in code
@@ -841,7 +841,7 @@ def test_cma_apply(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert "INTEGER ncell_2d" in code
         assert "TYPE(columnwise_operator_proxy_type) cma_op1_proxy" in code
         assert "ncell_2d = cma_op1_proxy%ncell_2d" in code
@@ -889,7 +889,7 @@ def test_cma_apply_discontinuous_spaces(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
 
         # Check w3
         assert "INTEGER ncell_2d" in code
@@ -907,8 +907,8 @@ def test_cma_apply_discontinuous_spaces(tmpdir, f90, f90flags):
         assert "TYPE(columnwise_operator_proxy_type) cma_op2_proxy" in code
         assert "ncell_2d = cma_op2_proxy%ncell_2d" in code
         assert ("INTEGER, pointer :: "
-                "cma_indirection_map_any_space_2_field_d(:) => null(), "
-                "cma_indirection_map_w2v(:) => null()\n") in code
+                "cma_indirection_map_w2v(:) => null(), "
+                "cma_indirection_map_any_space_2_field_d(:) => null()\n") in code
         assert ("ndf_w2v = field_c_proxy%vspace%get_ndf()\n"
                 "      undf_w2v = field_c_proxy%vspace%"
                 "get_undf()") in code
@@ -973,7 +973,7 @@ def test_cma_apply_same_space():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert "INTEGER ncell_2d" in code
         assert "TYPE(columnwise_operator_proxy_type) cma_op1_proxy" in code
         assert "ncell_2d = cma_op1_proxy%ncell_2d" in code
@@ -1010,7 +1010,7 @@ def test_cma_matrix_matrix(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert "INTEGER ncell_2d" in code
         assert "ncell_2d = cma_opc_proxy%ncell_2d" in code
 
@@ -1054,7 +1054,7 @@ def test_cma_matrix_matrix_2scalars(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert "INTEGER ncell_2d" in code
         assert "ncell_2d = cma_opc_proxy%ncell_2d" in code
 
@@ -1099,7 +1099,7 @@ def test_cma_multi_kernel(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=distmem).create(invoke_info)
         code = str(psy.gen)
-        print code
+        print(code)
         assert ("      afield_proxy = afield%get_proxy()\n"
                 "      lma_op1_proxy = lma_op1%get_proxy()\n"
                 "      cma_op1_proxy = cma_op1%get_proxy()\n"
@@ -1178,7 +1178,7 @@ def test_cma_asm_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_asm_kernel_mod.F90"),
                       api="dynamo0.3")
-    print str(result)
+    print(str(result))
     expected = (
         "  MODULE columnwise_op_asm_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1219,7 +1219,7 @@ def test_cma_asm_with_field_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_asm_field_kernel_mod.F90"),
                       api="dynamo0.3")
-    print str(result)
+    print(str(result))
     expected = (
         "  MODULE columnwise_op_asm_field_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1267,7 +1267,7 @@ def test_cma_asm_same_fs_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_asm_same_fs_kernel_mod.F90"),
                       api="dynamo0.3")
-    print str(result)
+    print(str(result))
     expected = (
         "  MODULE columnwise_op_asm_same_fs_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1308,7 +1308,7 @@ def test_cma_app_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_app_kernel_mod.F90"),
                       api="dynamo0.3")
-    print result
+    print(result)
     expected = (
         "  MODULE columnwise_op_app_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1358,7 +1358,7 @@ def test_cma_app_same_space_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_app_same_fs_kernel_mod.F90"),
                       api="dynamo0.3")
-    print result
+    print(result)
     expected = (
         "  MODULE columnwise_op_app_same_fs_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1399,7 +1399,7 @@ def test_cma_mul_stub_gen():
     result = generate(os.path.join(BASE_PATH,
                                    "columnwise_op_mul_kernel_mod.F90"),
                       api="dynamo0.3")
-    print result
+    print(result)
     expected = (
         "  MODULE columnwise_op_mul_kernel_mod\n"
         "    IMPLICIT NONE\n"
@@ -1441,7 +1441,7 @@ def test_cma_mul_with_scalars_stub_gen():
     result = generate(
         os.path.join(BASE_PATH, "columnwise_op_mul_2scalars_kernel_mod.F90"),
         api="dynamo0.3")
-    print result
+    print(result)
     expected = (
         "  MODULE columnwise_op_mul_2scalars_kernel_mod\n"
         "    IMPLICIT NONE\n"

--- a/src/psyclone/tests/dynamo0p3_multigrid_test.py
+++ b/src/psyclone/tests/dynamo0p3_multigrid_test.py
@@ -36,7 +36,7 @@
 ''' This module contains tests for the multi-grid part of the Dynamo 0.3 API
     using pytest. '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 # Since this is a file containing tests which often have to get in and
 # change the internal state of objects we disable pylint's warning
 # about such accesses
@@ -79,27 +79,27 @@ end module restrict_mod
 def test_invalid_mesh_type():
     ''' Check that we raise an error if an unrecognised name is supplied
     for the mesh associated with a field argument '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = RESTRICT_MDATA.replace("GH_COARSE", "GH_RUBBISH", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "restrict_kernel_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
-    print str(excinfo)
+    print(str(excinfo))
     assert ("mesh_arg must be one of [\\'gh_coarse\\', "
             "\\'gh_fine\\'] but got gh_rubbish" in str(excinfo))
 
 
 def test_invalid_mesh_specifier():
     ''' Check that we raise an error if "mesh_arg" is mis-spelt '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = RESTRICT_MDATA.replace("mesh_arg=GH_COARSE",
                                   "mesh_ar=GH_COARSE", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "restrict_kernel_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
-    print str(excinfo)
+    print(str(excinfo))
     assert ("mesh_ar=gh_coarse is not a valid mesh identifier" in
             str(excinfo))
 
@@ -107,7 +107,7 @@ def test_invalid_mesh_specifier():
 def test_all_args_same_mesh_error():
     ''' Check that we reject a kernel if all arguments are specified
     as being on the same mesh (coarse or fine) '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Both on fine mesh
     code = RESTRICT_MDATA.replace("GH_COARSE", "GH_FINE", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -153,7 +153,7 @@ def test_all_fields_have_mesh():
 def test_args_same_space_error():
     ''' Check that we reject a kernel if arguments on different meshes
     are specified as being on the same function space '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = RESTRICT_MDATA.replace("ANY_SPACE_2", "ANY_SPACE_1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "restrict_kernel_type"
@@ -168,7 +168,7 @@ def test_args_same_space_error():
 def test_only_field_args():
     ''' Check that we reject an inter-grid kernel if it has any arguments
     that are not fields '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Add a scalar argument to the kernel
     code = RESTRICT_MDATA.replace(
         "       arg_type(GH_FIELD, GH_READ,  ANY_SPACE_2, "
@@ -177,7 +177,7 @@ def test_only_field_args():
         "mesh_arg=GH_FINE   ), &\n"
         "       arg_type(GH_REAL, GH_READ) &", 1)
     code = code.replace("(2)", "(3)", 1)
-    print code
+    print(code)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "restrict_kernel_type"
     with pytest.raises(ParseError) as excinfo:
@@ -190,7 +190,7 @@ def test_only_field_args():
 def test_field_vector():
     ''' Check that we accept an inter-grid kernel with field-vector
     arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change both of the arguments to be vectors
     code = RESTRICT_MDATA.replace("GH_FIELD,", "GH_FIELD*2,", 2)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -213,7 +213,7 @@ def test_two_grid_types(monkeypatch):
     # Change VALID_MESH_TYPES so that it contains three values
     monkeypatch.setattr(dynamo0p3, "VALID_MESH_TYPES",
                         value=["gh_coarse", "gh_fine", "gh_medium"])
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(RESTRICT_MDATA, ignore_comments=False)
     name = "restrict_kernel_type"
     with pytest.raises(ParseError) as err:
@@ -309,7 +309,7 @@ def test_field_restrict(tmpdir, f90, f90flags):
     for distmem in [False, True]:
         psy = PSyFactory(API, distributed_memory=distmem).create(invoke_info)
         output = str(psy.gen)
-        print output
+        print(output)
 
         if utils.TEST_COMPILE:
             assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
@@ -325,8 +325,8 @@ def test_field_restrict(tmpdir, f90, f90flags):
         defs2 = (
             "      INTEGER nlayers\n"
             "      TYPE(field_proxy_type) field1_proxy, field2_proxy\n"
-            "      INTEGER, pointer :: map_any_space_2_field2(:,:) => null(), "
-            "map_any_space_1_field1(:,:) => null()\n"
+            "      INTEGER, pointer :: map_any_space_1_field1(:,:) => null(), "
+            "map_any_space_2_field2(:,:) => null()\n"
             "      INTEGER ncell_field2, ncpc_field2_field1\n"
             "      INTEGER, pointer :: cell_map_field1(:,:) => null()\n"
             "      TYPE(mesh_map_type), pointer :: mmap_field2_field1 => "
@@ -358,9 +358,9 @@ def test_field_restrict(tmpdir, f90, f90flags):
             "      !\n"
             "      ! Look-up dofmaps for each function space\n"
             "      !\n"
-            "      map_any_space_2_field2 => field2_proxy%vspace%"
-            "get_whole_dofmap()\n"
             "      map_any_space_1_field1 => field1_proxy%vspace%"
+            "get_whole_dofmap()\n"
+            "      map_any_space_2_field2 => field2_proxy%vspace%"
             "get_whole_dofmap()\n")
         assert inits in output
 
@@ -583,7 +583,7 @@ def test_prolong_vector(tmpdir, f90, f90flags):
                            api=API)
     psy = PSyFactory(API).create(invoke_info)
     output = str(psy.gen)
-    print output
+    print(output)
 
     if utils.TEST_COMPILE:
         assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)

--- a/src/psyclone/tests/dynamo0p3_quadrature_test.py
+++ b/src/psyclone/tests/dynamo0p3_quadrature_test.py
@@ -38,7 +38,7 @@
 quadrature in the LFRic API '''
 
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from fparser import api as fpapi
@@ -61,7 +61,7 @@ def test_field_xyoz(tmpdir, f90, f90flags):
                            api=API)
     psy = PSyFactory(API).create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
 
     if utils.TEST_COMPILE:
         assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
@@ -91,9 +91,8 @@ def test_field_xyoz(tmpdir, f90, f90flags):
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
         "      TYPE(quadrature_xyoz_proxy_type) qr_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
-        "      TYPE(mesh_type), pointer :: mesh => null()\n")
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n")
     assert output_decls in generated_code
     init_output = (
         "      !\n"
@@ -114,9 +113,9 @@ def test_field_xyoz(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -203,7 +202,7 @@ def test_field_xyoz(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Deallocate basis arrays\n"
         "      !\n"
-        "      DEALLOCATE (diff_basis_w2_qr, basis_w1_qr, basis_w3_qr, "
+        "      DEALLOCATE (basis_w1_qr, basis_w3_qr, diff_basis_w2_qr, "
         "diff_basis_w3_qr)\n"
         "      !\n"
         "    END SUBROUTINE invoke_0_testkern_qr_type"
@@ -225,7 +224,7 @@ def test_field_qr_deref(tmpdir, f90, f90flags):
         if utils.TEST_COMPILE:
             assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
         gen = str(psy.gen)
-        print gen
+        print(gen)
         assert (
             "    SUBROUTINE invoke_0_testkern_qr_type(f1, f2, m1, a, m2, istp,"
             " qr_data)\n" in gen)
@@ -419,8 +418,8 @@ def test_qr_basis_stub():
         "      REAL(KIND=r_def), intent(in), dimension(np_z) :: weights_z\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print generated_code
+    print(output)
+    print(generated_code)
     assert output in generated_code
 
 
@@ -456,7 +455,7 @@ def test_stub_dbasis_wrong_shape(monkeypatch):
     from psyclone import dynamo0p3
     # Change meta-data to specify differential basis functions
     diff_basis = BASIS.replace("gh_basis", "gh_diff_basis")
-    print diff_basis
+    print(diff_basis)
     ast = fpapi.parse(diff_basis, ignore_comments=False)
     metadata = DynKernMetadata(ast)
     kernel = DynKern()

--- a/src/psyclone/tests/dynamo0p3_test.py
+++ b/src/psyclone/tests/dynamo0p3_test.py
@@ -37,9 +37,11 @@
 ''' This module tests the Dynamo 0.3 API using pytest. '''
 
 # imports
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
+import sys
+from fparser import api as fpapi
 from psyclone.parse import parse, ParseError
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.dynamo0p3 import DynKernMetadata, DynKern, \
@@ -50,7 +52,6 @@ from psyclone.dynamo0p3 import DynKernMetadata, DynKern, \
 from psyclone.transformations import LoopFuseTrans
 from psyclone.gen_kernel_stub import generate
 import fparser
-from fparser import api as fpapi
 import utils
 
 # constants
@@ -107,7 +108,7 @@ end module testkern_qr
 def test_arg_descriptor_wrong_type():
     ''' Tests that an error is raised when the argument descriptor
     metadata is not of type arg_type. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_read, w2)",
                         "arg_typ(gh_field,gh_read, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -120,7 +121,7 @@ def test_arg_descriptor_wrong_type():
 
 def test_arg_descriptor_vector_str():
     ''' Test the str method of an argument descriptor containing a vector '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Change the meta-data so that the second argument is a vector
     code = CODE.replace("gh_field,gh_write,w1", "gh_field*3,gh_write,w1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -138,7 +139,7 @@ def test_arg_descriptor_vector_str():
 def test_ad_scalar_type_too_few_args():
     ''' Tests that an error is raised when the argument descriptor
     metadata for a real or an integer scalar has fewer than 2 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     name = "testkern_qr_type"
     for argname in VALID_SCALAR_NAMES:
         code = CODE.replace("arg_type(" + argname + ", gh_read)",
@@ -153,7 +154,7 @@ def test_ad_scalar_type_too_few_args():
 def test_ad_scalar_type_too_many_args():
     ''' Tests that an error is raised when the argument descriptor
     metadata for a real or an integer scalar has more than 2 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     name = "testkern_qr_type"
     for argname in VALID_SCALAR_NAMES:
         code = CODE.replace("arg_type(" + argname + ", gh_read)",
@@ -168,7 +169,7 @@ def test_ad_scalar_type_too_many_args():
 def test_ad_scalar_type_no_write():
     ''' Tests that an error is raised when the argument descriptor
     metadata for a real or an integer scalar specifies GH_WRITE '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     name = "testkern_qr_type"
     for argname in VALID_SCALAR_NAMES:
         code = CODE.replace("arg_type(" + argname + ", gh_read)",
@@ -183,7 +184,7 @@ def test_ad_scalar_type_no_write():
 def test_ad_scalar_type_no_inc():
     ''' Tests that an error is raised when the argument descriptor
     metadata for a real or an integer scalar specifies GH_INC '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     name = "testkern_qr_type"
     for argname in VALID_SCALAR_NAMES:
         code = CODE.replace("arg_type(" + argname + ", gh_read)",
@@ -198,7 +199,7 @@ def test_ad_scalar_type_no_inc():
 def test_ad_int_scalar_type_no_sum():
     ''' Tests that an error is raised when the argument descriptor
     metadata for an integer scalar specifies GH_SUM (reduction) '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_integer, gh_read)",
                         "arg_type(gh_integer, gh_sum)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -212,7 +213,7 @@ def test_ad_int_scalar_type_no_sum():
 def test_ad_field_type_too_few_args():
     ''' Tests that an error is raised when the argument descriptor
     metadata for a field has fewer than 3 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_write,w1)",
                         "arg_type(gh_field,gh_write)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -226,7 +227,7 @@ def test_ad_field_type_too_few_args():
 def test_ad_fld_type_too_many_args():
     ''' Tests that an error is raised when the argument descriptor
     metadata has more than 4 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_write,w1)",
                         "arg_type(gh_field,gh_write,w1,w1,w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -240,7 +241,7 @@ def test_ad_fld_type_too_many_args():
 def test_ad_fld_type_1st_arg():
     ''' Tests that an error is raised when the 1st argument is
     invalid'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_write,w1)",
                         "arg_type(gh_hedge,gh_write,w1)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -254,7 +255,7 @@ def test_ad_fld_type_1st_arg():
 def test_ad_op_type_too_few_args():
     ''' Tests that an error is raised when the operator descriptor
     metadata has fewer than 4 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_read, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -267,7 +268,7 @@ def test_ad_op_type_too_few_args():
 def test_ad_op_type_too_many_args():
     ''' Tests that an error is raised when the operator descriptor
     metadata has more than 4 args. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_read, w2, w2, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -280,7 +281,7 @@ def test_ad_op_type_too_many_args():
 def test_ad_op_type_wrong_3rd_arg():
     ''' Tests that an error is raised when the 3rd entry in the operator
     descriptor metadata is invalid. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_read, woops, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -294,7 +295,7 @@ def test_ad_op_type_wrong_3rd_arg():
 def test_ad_op_type_1st_arg_not_space():
     ''' Tests that an error is raised when the operator descriptor
     metadata contains something that is not a valid space. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_read, wbroke, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -307,7 +308,7 @@ def test_ad_op_type_1st_arg_not_space():
 
 def test_ad_op_type_wrong_access():
     ''' Test that an error is raised if an operator has gh_inc access. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_inc, w2, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -321,7 +322,7 @@ def test_ad_op_type_wrong_access():
 def test_ad_invalid_type():
     ''' Tests that an error is raised when an invalid descriptor type
     name is provided as the first argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_operator", "gh_operato", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -334,7 +335,7 @@ def test_ad_invalid_type():
 def test_ad_invalid_access_type():
     ''' Tests that an error is raised when an invalid access
     name is provided as the second argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_read", "gh_ead", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -346,7 +347,7 @@ def test_ad_invalid_access_type():
 def test_arg_descriptor_invalid_fs1():
     ''' Tests that an error is raised when an invalid function space
     name is provided as the third argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_field,gh_read, w3", "gh_field,gh_read, w4", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -358,7 +359,7 @@ def test_arg_descriptor_invalid_fs1():
 def test_arg_descriptor_invalid_fs2():
     ''' Tests that an error is raised when an invalid function space
     name is provided as the third argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w2, w2", "w2, w4", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -370,7 +371,7 @@ def test_arg_descriptor_invalid_fs2():
 def test_invalid_vector_operator():
     ''' Tests that an error is raised when a vector does not use "*"
     as it's operator. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_field,gh_write,w1", "gh_field+3,gh_write,w1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -382,7 +383,7 @@ def test_invalid_vector_operator():
 def test_invalid_vector_value_type():
     ''' Tests that an error is raised when a vector value is not a valid
     integer '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_field,gh_write,w1", "gh_field*n,gh_write,w1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -394,7 +395,7 @@ def test_invalid_vector_value_type():
 def test_invalid_vector_value_range():
     ''' Tests that an error is raised when a vector value is not a valid
     value (<2) '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("gh_field,gh_write,w1", "gh_field*1,gh_write,w1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -409,7 +410,7 @@ def test_invalid_vector_value_range():
 def test_fs_descriptor_wrong_type():
     ''' Tests that an error is raised when the function space descriptor
     metadata is not of type func_type. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("func_type(w2", "funced_up_type(w2", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -422,7 +423,7 @@ def test_fs_descriptor_wrong_type():
 def test_fs_descriptor_too_few_args():
     ''' Tests that an error is raised when there are two few arguments in
     the function space descriptor metadata (must be at least 2). '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w1, gh_basis", "w1", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -434,7 +435,7 @@ def test_fs_descriptor_too_few_args():
 def test_fs_desc_invalid_fs_type():
     ''' Tests that an error is raised when an invalid function space name
     is provided as the first argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w3, gh_basis", "w4, gh_basis", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -447,7 +448,7 @@ def test_fs_desc_invalid_fs_type():
 def test_fs_desc_replicated_fs_type():
     ''' Tests that an error is raised when a function space name
     is replicated. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w3, gh_basis", "w1, gh_basis", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -460,7 +461,7 @@ def test_fs_desc_replicated_fs_type():
 def test_fs_desc_invalid_op_type():
     ''' Tests that an error is raised when an invalid function space
     operator name is provided as an argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w2, gh_diff_basis", "w2, gh_dif_basis", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -473,7 +474,7 @@ def test_fs_desc_invalid_op_type():
 def test_fs_desc_replicated_op_type():
     ''' Tests that an error is raised when a function space
     operator name is replicated as an argument. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w3, gh_basis, gh_diff_basis",
                         "w3, gh_basis, gh_basis", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -487,7 +488,7 @@ def test_fs_desc_replicated_op_type():
 def test_fsdesc_fs_not_in_argdesc():
     ''' Tests that an error is raised when a function space
     name is provided that has not been used in the arg descriptor. '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("w3, gh_basis", "w0, gh_basis", 1)
     ast = fpapi.parse(code, ignore_comments=False)
     name = "testkern_qr_type"
@@ -500,7 +501,7 @@ def test_fsdesc_fs_not_in_argdesc():
 def test_missing_shape_both():
     ''' Check that we raise the correct error if a kernel requiring
     quadrature/evaluator fails to specify the shape of the evaluator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Remove the line specifying the shape of the evaluator
     code = CODE.replace(
         "     integer, parameter :: gh_shape = gh_quadrature_XYoZ\n",
@@ -517,7 +518,7 @@ def test_missing_shape_both():
 def test_missing_shape_basis_only():
     ''' Check that we raise the correct error if a kernel specifying
     that it needs gh_basis fails to specify the shape of the evaluator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Alter meta-data so only requires gh_basis
     code1 = CODE.replace(
         "     type(func_type), dimension(3) :: meta_funcs =  &\n"
@@ -542,7 +543,7 @@ def test_missing_shape_basis_only():
 def test_missing_eval_shape_diff_basis_only():
     ''' Check that we raise the correct error if a kernel specifying
     that it needs gh_diff_basis fails to specify the shape of the evaluator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Alter meta-data so only requires gh_diff_basis
     code1 = CODE.replace(
         "     type(func_type), dimension(3) :: meta_funcs =  &\n"
@@ -567,7 +568,7 @@ def test_missing_eval_shape_diff_basis_only():
 def test_invalid_shape():
     ''' Check that we raise the correct error if a kernel requiring
     quadrature/evaluator specifies an unrecognised shape for the evaluator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Specify an invalid shape for the evaluator
     code = CODE.replace(
         "gh_shape = gh_quadrature_XYoZ",
@@ -576,7 +577,7 @@ def test_invalid_shape():
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
-    print str(excinfo)
+    print(str(excinfo))
     assert ("request a valid gh_shape (one of ['gh_quadrature_xyoz', "
             "'gh_evaluator']) but got 'quadrature_wrong' for kernel "
             "'testkern_qr_type'" in str(excinfo))
@@ -585,7 +586,7 @@ def test_invalid_shape():
 def test_unecessary_shape():
     ''' Check that we raise the correct error if a kernel meta-data specifies
     an evaluator shape but does not require quadrature or an evaluator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # Remove the need for basis or diff-basis functions
     code = CODE.replace(
         "     type(func_type), dimension(3) :: meta_funcs =  &\n"
@@ -598,7 +599,7 @@ def test_unecessary_shape():
     name = "testkern_qr_type"
     with pytest.raises(ParseError) as excinfo:
         _ = DynKernMetadata(ast, name=name)
-    print str(excinfo)
+    print(str(excinfo))
     assert ("Kernel 'testkern_qr_type' specifies a gh_shape "
             "(gh_quadrature_xyoz) but does not need an evaluator because no "
             "basis or differential basis functions are required"
@@ -634,8 +635,8 @@ def test_field(tmpdir, f90, f90flags):
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
         "      !\n"
@@ -650,9 +651,9 @@ def test_field(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -680,8 +681,8 @@ def test_field(tmpdir, f90, f90flags):
         "      !\n"
         "    END SUBROUTINE invoke_0_testkern_type\n"
         "  END MODULE single_invoke_psy")
-    print output
-    print generated_code
+    print(output)
+    print(generated_code)
     assert str(generated_code).find(output) != -1
 
 
@@ -697,7 +698,7 @@ def test_field_deref():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         output = (
             "    SUBROUTINE invoke_0_testkern_type(a, f1, est_f2, m1, "
             "est_m2)\n"
@@ -716,8 +717,8 @@ def test_field_deref():
             "      INTEGER nlayers\n"
             "      TYPE(field_proxy_type) f1_proxy, est_f2_proxy, m1_proxy, "
             "est_m2_proxy\n"
-            "      INTEGER, pointer :: map_w2(:,:) => null(), "
-            "map_w3(:,:) => null(), map_w1(:,:) => null()\n")
+            "      INTEGER, pointer :: map_w1(:,:) => null(), "
+            "map_w2(:,:) => null(), map_w3(:,:) => null()\n")
         assert output in generated_code
         if dist_mem:
             output = "      TYPE(mesh_type), pointer :: mesh => null()\n"
@@ -747,9 +748,9 @@ def test_field_deref():
             "      !\n"
             "      ! Look-up dofmaps for each function space\n"
             "      !\n"
+            "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
             "      map_w2 => est_f2_proxy%vspace%get_whole_dofmap()\n"
             "      map_w3 => est_m2_proxy%vspace%get_whole_dofmap()\n"
-            "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
             "      !\n")
         assert output in generated_code
         output = (
@@ -846,11 +847,11 @@ def test_field_fs(tmpdir, f90, f90flags):
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy, "
         "f3_proxy, f4_proxy, m3_proxy, m4_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w0(:,:) => null(), "
-        "map_w1(:,:) => null(), map_any_w2(:,:) => null(), "
-        "map_wtheta(:,:) => null(), map_w2v(:,:) => null(), "
-        "map_w2h(:,:) => null()\n"
+        "      INTEGER, pointer :: map_any_w2(:,:) => null(), "
+        "map_w0(:,:) => null(), "
+        "map_w1(:,:) => null(), map_w2(:,:) => null(), "
+        "map_w2h(:,:) => null(), map_w2v(:,:) => null(), "
+        "map_w3(:,:) => null(), map_wtheta(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -874,14 +875,14 @@ def test_field_fs(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
-        "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w0 => m1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
-        "      map_any_w2 => m4_proxy%vspace%get_whole_dofmap()\n"
+        "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
+        "      map_w0 => m1_proxy%vspace%get_whole_dofmap()\n"
+        "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
         "      map_wtheta => f3_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w2v => m3_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2h => f4_proxy%vspace%get_whole_dofmap()\n"
+        "      map_w2v => m3_proxy%vspace%get_whole_dofmap()\n"
+        "      map_any_w2 => m4_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -970,8 +971,8 @@ def test_field_fs(tmpdir, f90, f90flags):
         "      !\n"
         "    END SUBROUTINE invoke_0_testkern_fs_type\n"
         "  END MODULE single_invoke_fs_psy")
-    print str(generated_code)
-    print output
+    print(str(generated_code))
+    print(output)
     assert str(generated_code).find(output) != -1
 
 
@@ -983,7 +984,7 @@ def test_real_scalar():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2)\n"
         "      USE testkern, ONLY: testkern_code\n"
@@ -995,8 +996,8 @@ def test_real_scalar():
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -1016,9 +1017,9 @@ def test_real_scalar():
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -1066,7 +1067,7 @@ def test_int_scalar():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(f1, iflag, f2, m1, m2)\n"
         "      USE testkern_one_int_scalar, ONLY: testkern_code\n"
@@ -1078,8 +1079,8 @@ def test_int_scalar():
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -1099,9 +1100,9 @@ def test_int_scalar():
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -1150,7 +1151,7 @@ def test_two_real_scalars():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2, b)\n"
         "      USE testkern_two_real_scalars, ONLY: testkern_code\n"
@@ -1162,8 +1163,8 @@ def test_two_real_scalars():
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -1183,9 +1184,9 @@ def test_two_real_scalars():
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -1233,7 +1234,7 @@ def test_two_int_scalars():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "    SUBROUTINE invoke_0(iflag, f1, f2, m1, m2, istep)\n"
         "      USE testkern_two_int_scalars, ONLY: testkern_code\n"
@@ -1245,8 +1246,8 @@ def test_two_int_scalars():
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -1266,9 +1267,9 @@ def test_two_int_scalars():
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -1323,7 +1324,7 @@ def test_two_scalars():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2, istep)\n"
         "      USE testkern_two_scalars, ONLY: testkern_code\n"
@@ -1336,8 +1337,8 @@ def test_two_scalars():
         "      INTEGER ndf_w1, undf_w1, ndf_w2, undf_w2, ndf_w3, undf_w3\n"
         "      INTEGER nlayers\n"
         "      TYPE(field_proxy_type) f1_proxy, f2_proxy, m1_proxy, m2_proxy\n"
-        "      INTEGER, pointer :: map_w2(:,:) => null(), "
-        "map_w3(:,:) => null(), map_w1(:,:) => null()\n"
+        "      INTEGER, pointer :: map_w1(:,:) => null(), "
+        "map_w2(:,:) => null(), map_w3(:,:) => null()\n"
         "      TYPE(mesh_type), pointer :: mesh => null()\n"
         "      !\n"
         "      ! Initialise field and/or operator proxies\n"
@@ -1357,9 +1358,9 @@ def test_two_scalars():
         "      !\n"
         "      ! Look-up dofmaps for each function space\n"
         "      !\n"
+        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_w2 => f2_proxy%vspace%get_whole_dofmap()\n"
         "      map_w3 => m2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      !\n"
         "      ! Initialise number of DoFs for w1\n"
         "      !\n"
@@ -1402,7 +1403,7 @@ def test_two_scalars():
 def test_no_vector_scalar():
     ''' Tests that we raise an error when kernel meta-data erroneously
     specifies a vector real or integer scalar '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     name = "testkern_qr_type"
     for argname in VALID_SCALAR_NAMES:
         code = CODE.replace("arg_type(" + argname + ", gh_read)",
@@ -1421,7 +1422,7 @@ def test_vector_field():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = psy.gen
-    print str(generated_code)
+    print(str(generated_code))
     assert str(generated_code).find("SUBROUTINE invoke_0_testkern_chi_"
                                     "type(f1, chi, f2)") != -1
     assert str(generated_code).find("TYPE(field_type), intent(inout)"
@@ -1435,7 +1436,7 @@ def test_vector_field_2():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = psy.gen
-    print generated_code
+    print(generated_code)
     # all references to chi_proxy should be chi_proxy(1)
     assert str(generated_code).find("chi_proxy%") == -1
     assert str(generated_code).count("chi_proxy(1)%vspace") == 4
@@ -1469,7 +1470,7 @@ def test_orientation():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = psy.gen
-    print str(generated_code)
+    print(str(generated_code))
     assert str(generated_code).find("INTEGER, pointer :: orientation_w2(:)"
                                     " => null()") != -1
     assert str(generated_code).find("orientation_w2 => f2_proxy%vspace%"
@@ -1483,7 +1484,7 @@ def test_operator():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     assert generated_code.find("SUBROUTINE invoke_0_testkern_operator"
                                "_type(mm_w0, chi, a, qr)") != -1
     assert generated_code.find("TYPE(operator_type), intent(inout) ::"
@@ -1506,7 +1507,7 @@ def test_operator_different_spaces(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -1637,7 +1638,7 @@ def test_operator_different_spaces(tmpdir, f90, f90flags):
         "      !\n"
         "      ! Deallocate basis arrays\n"
         "      !\n"
-        "      DEALLOCATE (diff_basis_w2_qr, diff_basis_w0_qr, basis_w3_qr)\n"
+        "      DEALLOCATE (basis_w3_qr, diff_basis_w0_qr, diff_basis_w2_qr)\n"
         "      !\n"
         "    END SUBROUTINE invoke_0_assemble_weak_derivative_w3_w2_kernel_"
         "type")
@@ -1652,7 +1653,7 @@ def test_operator_nofield(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen_code_str = str(psy.gen)
-    print gen_code_str
+    print(gen_code_str)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -1684,7 +1685,7 @@ def test_operator_nofield_different_space(
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -1708,7 +1709,7 @@ def test_operator_nofield_scalar():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert "mesh => my_mapping%get_mesh()" in gen
     assert "nlayers = my_mapping_proxy%fs_from%get_nlayers()" in gen
     assert "ndf_w2 = my_mapping_proxy%fs_from%get_ndf()" in gen
@@ -1731,7 +1732,7 @@ def test_operator_nofield_scalar_deref(
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         gen = str(psy.gen)
-        print gen
+        print(gen)
 
         if utils.TEST_COMPILE:
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
@@ -1764,7 +1765,7 @@ def test_operator_orientation(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen_str = str(psy.gen)
-    print gen_str
+    print(gen_str)
 
     if utils.TEST_COMPILE:
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
@@ -1797,7 +1798,7 @@ def test_op_orient_different_space(
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen_str = str(psy.gen)
-    print gen_str
+    print(gen_str)
 
     if utils.TEST_COMPILE:
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
@@ -1834,7 +1835,7 @@ def test_operator_deref(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if utils.TEST_COMPILE:
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
@@ -1864,7 +1865,7 @@ def test_operator_no_dofmap_lookup():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen_code = str(psy.gen)
-    print gen_code
+    print(gen_code)
     # Check that we use the field and not the operator to look-up the dofmap
     assert "theta_proxy%vspace%get_whole_dofmap()" in gen_code
     assert gen_code.count("get_whole_dofmap") == 1
@@ -1898,14 +1899,16 @@ def test_any_space_1(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-    assert ("INTEGER, pointer :: map_w0(:,:) => null(), "
+    assert ("INTEGER, pointer :: "
+            "map_any_space_1_a(:,:) => null(), "
             "map_any_space_2_b(:,:) => null(), "
-            "map_any_space_1_a(:,:) => null()\n" in generated_code)
+            "map_w0(:,:) => null()\n"
+            in generated_code)
     assert generated_code.find(
         "REAL(KIND=r_def), allocatable :: basis_any_space_1_a_qr(:,:,:,:), "
         "basis_any_space_2_b_qr(:,:,:,:)") != -1
@@ -1926,8 +1929,8 @@ def test_any_space_1(tmpdir, f90, f90flags):
             "map_any_space_2_b(:,cell), basis_any_space_2_b_qr, ndf_w0, "
             "undf_w0, map_w0(:,cell), diff_basis_w0_qr, np_xy_qr, np_z_qr, "
             "weights_xy_qr, weights_z_qr)" in generated_code)
-    assert ("DEALLOCATE (basis_any_space_2_b_qr, diff_basis_w0_qr, "
-            "basis_any_space_1_a_qr)" in generated_code)
+    assert ("DEALLOCATE (basis_any_space_1_a_qr, basis_any_space_2_b_qr, "
+            "diff_basis_w0_qr)" in generated_code)
 
 
 def test_any_space_2():
@@ -1939,7 +1942,7 @@ def test_any_space_2():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     assert "INTEGER, intent(in) :: istp" in generated_code
     assert generated_code.find(
         "INTEGER, pointer :: map_any_space_1_a(:,:) => null()") != -1
@@ -1965,7 +1968,7 @@ def test_op_any_space_different_space_1():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     assert generated_code.find(
         "ndf_any_space_2_a = a_proxy%fs_from%get_ndf()") != -1
     assert generated_code.find(
@@ -1980,7 +1983,7 @@ def test_op_any_space_different_space_2(
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
 
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
@@ -2162,7 +2165,7 @@ def test_kernel_specific(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     output0 = "USE enforce_bc_kernel_mod, ONLY: enforce_bc_code"
     assert output0 not in generated_code
     output1 = "USE function_space_mod, ONLY: w1, w2, w2h, w2v\n"
@@ -2203,7 +2206,7 @@ def test_multi_kernel_specific(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
 
     # Output must not contain any bc-related code
     output0 = "USE enforce_bc_kernel_mod, ONLY: enforce_bc_code"
@@ -2331,7 +2334,7 @@ def test_operator_bc_kernel(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     output1 = "INTEGER, pointer :: boundary_dofs(:,:) => null()"
     assert output1 in generated_code
     output2 = "boundary_dofs => op_a_proxy%fs_to%get_boundary_dofs()"
@@ -2431,7 +2434,7 @@ def test_multikernel_invoke_1():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     # check that argument names are not replicated
     output1 = "SUBROUTINE invoke_0(a, f1, f2, m1, m2)"
     assert generated_code.find(output1) != -1
@@ -2513,7 +2516,7 @@ def test_2kern_invoke_any_space():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert ("INTEGER, pointer :: map_any_space_1_f1(:,:) => null(), "
             "map_any_space_1_f2(:,:) => null()\n"
             in gen)
@@ -2542,14 +2545,14 @@ def test_multikern_invoke_any_space(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
     assert ("INTEGER, pointer :: map_any_space_1_f1(:,:) => null(), "
+            "map_any_space_1_f2(:,:) => null(), "
             "map_any_space_2_f1(:,:) => null(), "
-            "map_any_space_2_f2(:,:) => null(), "
-            "map_any_space_1_f2(:,:) => null(), map_w0(:,:) => null()" in gen)
+            "map_any_space_2_f2(:,:) => null(), map_w0(:,:) => null()" in gen)
     assert (
         "REAL(KIND=r_def), allocatable :: basis_any_space_1_f1_qr(:,:,:,:), "
         "basis_any_space_2_f2_qr(:,:,:,:), basis_any_space_1_f2_qr(:,:,:,:), "
@@ -2563,10 +2566,11 @@ def test_multikern_invoke_any_space(tmpdir, f90, f90flags):
             "basis_any_space_1_f2_qr)" in gen)
     assert (
         "      map_any_space_1_f1 => f1_proxy%vspace%get_whole_dofmap()\n"
-        "      map_any_space_2_f1 => f1_proxy%vspace%get_whole_dofmap()\n"
         "      map_any_space_2_f2 => f2_proxy%vspace%get_whole_dofmap()\n"
+        "      map_w0 => f3_proxy(1)%vspace%get_whole_dofmap()\n"
         "      map_any_space_1_f2 => f2_proxy%vspace%get_whole_dofmap()\n"
-        "      map_w0 => f3_proxy(1)%vspace%get_whole_dofmap()" in gen)
+        "      map_any_space_2_f1 => f1_proxy%vspace%get_whole_dofmap()\n"
+            in gen)
     assert ("CALL testkern_any_space_1_code(nlayers, f1_proxy%data, rdt, "
             "f2_proxy%data, f3_proxy(1)%data, f3_proxy(2)%data, "
             "f3_proxy(3)%data, ndf_any_space_1_f1, undf_any_space_1_f1, "
@@ -2587,7 +2591,7 @@ def test_mkern_invoke_multiple_any_spaces(
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
@@ -2772,8 +2776,8 @@ def test_stub_generate_working():
     ''' check that the stub generate produces the expected output '''
     result = generate(os.path.join(BASE_PATH, "simple.f90"),
                       api="dynamo0.3")
-    print SIMPLE
-    print result
+    print(SIMPLE)
+    print(result)
     assert str(result).find(SIMPLE) != -1
 
 
@@ -2781,7 +2785,7 @@ def test_stub_generate_working_noapi():
     ''' check that the stub generate produces the expected output when
     we use the default api (which should be dynamo0.3)'''
     result = generate(os.path.join(BASE_PATH, "simple.f90"))
-    print result
+    print(result)
     assert str(result).find(SIMPLE) != -1
 
 
@@ -2810,7 +2814,7 @@ def test_stub_generate_with_scalars():
     the kernel has scalar arguments '''
     result = generate(os.path.join(BASE_PATH, "simple_with_scalars.f90"),
                       api="dynamo0.3")
-    print result
+    print(result)
     assert str(result).find(SIMPLE_WITH_SCALARS) != -1
 
 
@@ -2871,7 +2875,7 @@ end module dummy_mod
 def test_load_meta_wrong_type():
     ''' Test that the load_meta function raises an appropriate error
     if the meta-data contains an un-recognised type '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(INTENT, ignore_comments=False)
     metadata = DynKernMetadata(ast)
     kernel = DynKern()
@@ -2909,8 +2913,8 @@ def test_intent():
         "      INTEGER, intent(in), dimension(ndf_w1) :: map_w1\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
@@ -2995,8 +2999,8 @@ def test_spaces():
         "      INTEGER, intent(in), dimension(ndf_w2v) :: map_w2v\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
@@ -3045,15 +3049,15 @@ def test_vectors():
         "      INTEGER, intent(in), dimension(ndf_w0) :: map_w0\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
 def test_arg_descriptor_vec_str():
     ''' Tests that the string method for DynArgDescriptor03 works as
     expected when we have a vector quantity '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(VECTORS, ignore_comments=False)
     metadata = DynKernMetadata(ast)
     field_descriptor = metadata.arg_descriptors[0]
@@ -3063,7 +3067,7 @@ def test_arg_descriptor_vec_str():
         "  argument_type[0]='gh_field'*3\n"
         "  access_descriptor[1]='gh_write'\n"
         "  function_space[2]='w0'")
-    print result
+    print(result)
     assert expected_output in result
 
 
@@ -3130,15 +3134,15 @@ def test_operators():
         "ndf_any_space_1_op_5,op_5_ncell_3d) :: op_5\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
 def test_arg_descriptor_op_str():
     ''' Tests that the string method for DynArgDescriptor03 works as
     expected when we have an operator '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(OPERATORS, ignore_comments=False)
     metadata = DynKernMetadata(ast)
     field_descriptor = metadata.arg_descriptors[0]
@@ -3149,7 +3153,7 @@ def test_arg_descriptor_op_str():
         "  access_descriptor[1]='gh_write'\n"
         "  function_space_to[2]='w0'\n"
         "  function_space_from[3]='w0'\n")
-    print result
+    print(result)
     assert expected_output in result
 
 
@@ -3234,7 +3238,7 @@ def test_orientation_stubs():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = kernel.gen_stub
-    print str(generated_code)
+    print(str(generated_code))
     assert str(generated_code).find(ORIENTATION_OUTPUT) != -1
 
 
@@ -3268,7 +3272,7 @@ def test_enforce_bc_kernel_stub_gen():
         "boundary_dofs\n"
         "    END SUBROUTINE enforce_bc_code\n"
         "  END MODULE enforce_bc_mod")
-    print str(generated_code)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
@@ -3301,7 +3305,7 @@ def test_enforce_op_bc_kernel_stub_gen():
         "boundary_dofs\n"
         "    END SUBROUTINE enforce_operator_bc_code\n"
         "  END MODULE enforce_operator_bc_mod")
-    print generated_code
+    print(generated_code)
     assert output in generated_code
 
 
@@ -3353,8 +3357,8 @@ def test_sub_name():
         "      INTEGER, intent(in), dimension(ndf_w1) :: map_w1\n"
         "    END SUBROUTINE dummy_code\n"
         "  END MODULE dummy_mod")
-    print output
-    print str(generated_code)
+    print(output)
+    print(str(generated_code))
     assert str(generated_code).find(output) != -1
 
 
@@ -3365,14 +3369,14 @@ def test_kernel_stub_usage():
 
     usage_msg = (
         "usage: genkernelstub [-h] [-o OUTFILE] [-api API] [-l] filename\n"
-        "genkernelstub: error: too few arguments")
+        )
 
     # We use the Popen constructor here rather than check_output because
     # the latter is only available in Python 2.7 onwards.
     out = Popen(['genkernelstub'],
                 stdout=PIPE,
                 stderr=STDOUT).communicate()[0]
-    assert usage_msg in out
+    assert usage_msg in out.decode('utf-8')
 
 
 def test_kernel_stub_gen_cmd_line():
@@ -3385,8 +3389,8 @@ def test_kernel_stub_gen_cmd_line():
                  os.path.join(BASE_PATH, "dummy_orientation_mod.f90")],
                 stdout=PIPE).communicate()[0]
 
-    print "Output was: ", out
-    assert ORIENTATION_OUTPUT in out
+    print("Output was: ", out)
+    assert ORIENTATION_OUTPUT in out.decode('utf-8')
 
 
 def test_stub_stencil_extent():
@@ -3398,7 +3402,7 @@ def test_stub_stencil_extent():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     result1 = (
         "    SUBROUTINE testkern_stencil_code(nlayers, field_1_w1, "
         "field_2_w2, field_2_stencil_size, field_2_stencil_map, field_3_w2, "
@@ -3422,7 +3426,7 @@ def test_stub_stencil_direction():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     result1 = (
         "    SUBROUTINE testkern_stencil_xory1d_code(nlayers, field_1_w1, "
         "field_2_w2, field_2_stencil_size, field_2_direction, "
@@ -3447,7 +3451,7 @@ def test_stub_stencil_vector():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     result1 = (
         "    SUBROUTINE testkern_stencil_vector_code(nlayers, field_1_w0_v1, "
         "field_1_w0_v2, field_1_w0_v3, field_2_w3_v1, field_2_w3_v2, "
@@ -3472,7 +3476,7 @@ def test_stub_stencil_multi():
     kernel = DynKern()
     kernel.load_meta(metadata)
     generated_code = str(kernel.gen_stub)
-    print generated_code
+    print(generated_code)
     result1 = (
         "    SUBROUTINE testkern_stencil_multi_code(nlayers, field_1_w1, "
         "field_2_w2, field_2_stencil_size, field_2_stencil_map, field_3_w2, "
@@ -3701,7 +3705,7 @@ def test_arg_descriptor_funcs_method_error():
     when function_spaces is called and the internal type is an
     unexpected value. It should not be possible to get to here so we
     need to mess about with internal values to trip this.'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
@@ -3788,6 +3792,9 @@ def test_arg_intent_error():
             "'gh_not_an_intent'" in str(excinfo))
 
 
+@pytest.mark.skipif(
+        sys.version_info>(3,),
+        reason="Deepcopy of function_space not working in Python 3")
 def test_no_arg_on_space(monkeypatch):
     ''' Tests that DynKernelArguments.get_arg_on_space[,_name] raise
     the appropriate error when there is no kernel argument on the
@@ -3826,7 +3833,7 @@ def test_arg_descriptor_func_method_error():
     when function_space is called and the internal type is an
     unexpected value. It should not be possible to get to here so we
     need to mess about with internal values to trip this.'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
@@ -3840,12 +3847,12 @@ def test_arg_descriptor_func_method_error():
 def test_arg_descriptor_fld_str():
     ''' Tests that the string method for DynArgDescriptor03 works as
     expected for a field argument'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[1]
     result = str(field_descriptor)
-    print result
+    print(result)
     expected_output = (
         "DynArgDescriptor03 object\n"
         "  argument_type[0]='gh_field'\n"
@@ -3857,12 +3864,12 @@ def test_arg_descriptor_fld_str():
 def test_arg_descriptor_real_scalar_str():
     ''' Tests that the string method for DynArgDescriptor03 works as
     expected for a real scalar argument'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
     result = str(field_descriptor)
-    print result
+    print(result)
     expected_output = (
         "DynArgDescriptor03 object\n"
         "  argument_type[0]='gh_real'\n"
@@ -3873,12 +3880,12 @@ def test_arg_descriptor_real_scalar_str():
 def test_arg_descriptor_int_scalar_str():
     ''' Tests that the string method for DynArgDescriptor03 works as
     expected for an integer scalar argument'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[5]
     result = str(field_descriptor)
-    print result
+    print(result)
     expected_output = (
         "DynArgDescriptor03 object\n"
         "  argument_type[0]='gh_integer'\n"
@@ -3891,7 +3898,7 @@ def test_arg_descriptor_str_error():
     when __str__ is called and the internal type is an
     unexpected value. It should not be possible to get to here so we
     need to mess about with internal values to trip this.'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
@@ -3905,12 +3912,12 @@ def test_arg_descriptor_str_error():
 def test_arg_descriptor_repr():
     ''' Tests that the repr method for DynArgDescriptor03 works as
     expected '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
     result = repr(field_descriptor)
-    print result
+    print(result)
     assert 'DynArgDescriptor03(arg_type(gh_real, gh_read))' \
         in result
 
@@ -3919,7 +3926,7 @@ def test_arg_desc_func_space_tofrom_err():
     ''' Tests that an internal error is raised in DynArgDescriptor03
     when function_space_to or function_space_from is called and the
     internal type is not gh_operator.'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
@@ -3999,7 +4006,7 @@ def test_arg_descriptor_init_error():
     when an invalid type is provided. However this error never gets
     tripped due to an earlier test so we need to force the error by
     changing the internal state.'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     field_descriptor = metadata.arg_descriptors[0]
@@ -4024,7 +4031,7 @@ def test_arg_descriptor_init_error():
 
 def test_func_descriptor_repr():
     ''' Tests the __repr__ output of a func_descriptor '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     func_descriptor = metadata.func_descriptors[0]
@@ -4034,7 +4041,7 @@ def test_func_descriptor_repr():
 
 def test_func_descriptor_str():
     ''' Tests the __str__ output of a func_descriptor '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     ast = fpapi.parse(CODE, ignore_comments=False)
     metadata = DynKernMetadata(ast, name="testkern_qr_type")
     func_descriptor = metadata.func_descriptors[0]
@@ -4072,7 +4079,7 @@ def test_halo_dirty_1():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "     END DO \n"
         "      !\n"
@@ -4088,7 +4095,7 @@ def test_halo_dirty_2():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "      END DO \n"
         "      !\n"
@@ -4111,7 +4118,7 @@ def test_halo_dirty_3():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = psy.gen
-    print generated_code
+    print(generated_code)
     assert str(generated_code).count("CALL f1_proxy%set_dirty()") == 2
 
 
@@ -4121,7 +4128,7 @@ def test_halo_dirty_4():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     expected = (
         "      END DO \n"
         "      !\n"
@@ -4141,7 +4148,7 @@ def test_halo_dirty_5():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     assert "set_dirty()" not in generated_code
     assert "! Set halos dirty/clean" not in generated_code
 
@@ -4153,7 +4160,7 @@ def test_no_halo_dirty():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     assert "set_dirty()" not in generated_code
     assert "! Set halos dirty/clean" not in generated_code
 
@@ -4165,16 +4172,16 @@ def test_halo_exchange():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     output1 = (
         "     IF (f2_proxy%is_dirty(depth=f2_extent+1)) THEN\n"
         "        CALL f2_proxy%halo_exchange(depth=f2_extent+1)\n"
         "      END IF \n"
         "      !\n")
-    print output1
+    print(output1)
     assert output1 in generated_code
     output2 = ("      DO cell=1,mesh%get_last_halo_cell(1)\n")
-    print output2
+    print(output2)
     assert output2 in generated_code
 
 
@@ -4187,7 +4194,7 @@ def test_halo_exchange_inc():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     output1 = (
         "      IF (a_proxy%is_dirty(depth=1)) THEN\n"
         "        CALL a_proxy%halo_exchange(depth=1)\n"
@@ -4233,7 +4240,7 @@ def test_no_halo_exchange_for_operator():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     # This kernel reads from an operator and a scalar and these
     # do not require halos to be updated.
     assert "halo_exchange" not in result
@@ -4247,7 +4254,7 @@ def test_no_set_dirty_for_operator():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     # This kernel only writes to an operator and since operators are
     # cell-local this does not require us to call the is_dirty() method.
     assert "is_dirty" not in result
@@ -4261,7 +4268,7 @@ def test_halo_exchange_different_spaces():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert result.count("halo_exchange") == 9
 
 
@@ -4273,7 +4280,7 @@ def test_halo_exchange_vectors_1():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert result.count("halo_exchange(") == 3
     for idx in range(1, 4):
         assert "f1_proxy("+str(idx)+")%halo_exchange(depth=1)" in result
@@ -4293,7 +4300,7 @@ def test_halo_exchange_vectors():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert result.count("halo_exchange(") == 7
     for idx in range(1, 4):
         assert "f1_proxy("+str(idx)+")%halo_exchange(depth=1)" in result
@@ -4315,7 +4322,7 @@ def test_halo_exchange_depths():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     expected = ("      IF (f2_proxy%is_dirty(depth=extent)) THEN\n"
                 "        CALL f2_proxy%halo_exchange(depth=extent)\n"
                 "      END IF \n"
@@ -4341,7 +4348,7 @@ def test_halo_exchange_depths_gh_inc():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     expected = ("      IF (f1_proxy%is_dirty(depth=1)) THEN\n"
                 "        CALL f1_proxy%halo_exchange(depth=1)\n"
                 "      END IF \n"
@@ -4365,7 +4372,7 @@ def test_halo_exchange_depths_gh_inc():
 def test_stencil_read_only():
     '''test that an error is raised if a field with a stencil is not
     accessed as gh_read'''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = STENCIL_CODE.replace("gh_read, w2, stencil(cross)",
                                 "gh_write, w2, stencil(cross)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -4377,7 +4384,7 @@ def test_stencil_read_only():
 def test_fs_discontinuous_and_inc_error():
     ''' Test that an error is raised if a discontinuous function space
     and gh_inc are provided for the same field in the metadata '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     for fspace in DISCONTINUOUS_FUNCTION_SPACES:
         code = CODE.replace("arg_type(gh_field,gh_read, w3)",
                             "arg_type(gh_field,gh_inc, "
@@ -4393,7 +4400,7 @@ def test_fs_discontinuous_and_inc_error():
 def test_fs_continuous_and_readwrite_error():
     ''' Test that an error is raised if a continuous function space and
     gh_readwrite are provided for the same field in the metadata '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     for fspace in CONTINUOUS_FUNCTION_SPACES:
         code = CODE.replace("arg_type(gh_field,gh_read, w2)",
                             "arg_type(gh_field,gh_readwrite, "
@@ -4409,7 +4416,7 @@ def test_fs_continuous_and_readwrite_error():
 def test_fs_anyspace_and_readwrite_error():
     ''' Test that an error is raised if any_space and
     gh_readwrite are provided for the same field in the metadata '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     for fspace in VALID_ANY_SPACE_NAMES:
         code = CODE.replace("arg_type(gh_field,gh_read, w2)",
                             "arg_type(gh_field,gh_readwrite, "
@@ -4449,8 +4456,8 @@ def test_halo_exchange_view(capsys):
         "upper_bound='cell_halo(1)']\n"
         "        " + call + " testkern_stencil_code(f1,f2,f3,f4) "
         "[module_inline=False]")
-    print expected
-    print result
+    print(expected)
+    print(result)
     assert expected in result
 
 
@@ -4462,7 +4469,7 @@ def test_no_mesh_mod():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "USE mesh_mod, ONLY: mesh_type" not in result
     assert "TYPE(mesh_type), pointer :: mesh => null()" not in result
     assert "mesh => a%get_mesh()" not in result
@@ -4477,7 +4484,7 @@ def test_mesh_mod():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "USE mesh_mod, ONLY: mesh_type" in result
     assert "TYPE(mesh_type), pointer :: mesh => null()" in result
     output = ("      !\n"
@@ -4590,7 +4597,7 @@ def test_intent_multi_kern():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         output = str(psy.gen)
-        print output
+        print(output)
         assert "TYPE(field_type), intent(inout) :: g, f\n" in output
         assert "TYPE(field_type), intent(inout) :: b, h\n" in output
         assert "TYPE(field_type), intent(in) :: c, d, a, e(3)\n" in output
@@ -4600,7 +4607,7 @@ def test_intent_multi_kern():
 def test_field_gh_sum_invalid():
     ''' Tests that an error is raised when a field is specified with
     access type gh_sum '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_read, w2)",
                         "arg_type(gh_field, gh_sum, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -4615,7 +4622,7 @@ def test_field_gh_sum_invalid():
 def test_operator_gh_sum_invalid():
     ''' Tests that an error is raised when an operator is specified with
     access type gh_sum '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator, gh_sum, w2, w2)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -4640,7 +4647,7 @@ def test_derived_type_arg():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         gen = str(psy.gen)
-        print gen
+        print(gen)
         # Check the four integer variables are named and declared correctly
         expected = (
             "    SUBROUTINE invoke_0(f1, my_obj_iflag, f2, m1, m2, "
@@ -4686,7 +4693,7 @@ def test_multiple_derived_type_args():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         gen = str(psy.gen)
-        print gen
+        print(gen)
         # Check the four integer variables are named and declared correctly
         expected = (
             "    SUBROUTINE invoke_0(f1, obj_a_iflag, f2, m1, m2, "
@@ -4731,7 +4738,7 @@ def test_single_stencil_extent():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "SUBROUTINE invoke_0_testkern_stencil_type(f1, f2, f3, f4, "
             "f2_extent)")
@@ -4778,7 +4785,7 @@ def test_single_stencil_xory1d():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0_testkern_stencil_xory1d_type(f1, f2, f3, "
             "f4, f2_extent, f2_direction)")
@@ -4833,7 +4840,7 @@ def test_single_stencil_literal():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = ("    SUBROUTINE invoke_0_testkern_stencil_type(f1, f2, "
                    "f3, f4)")
         assert output1 in result
@@ -4899,7 +4906,7 @@ def test_single_stencil_xory1d_literal():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = ("    SUBROUTINE invoke_0_testkern_stencil_xory1d_type("
                    "f1, f2, f3, f4)")
         assert output1 in result
@@ -4956,7 +4963,7 @@ def test_single_stencil_xory1d_literal_mixed():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = ("    SUBROUTINE invoke_0_testkern_stencil_xory1d_type("
                    "f1, f2, f3, f4)")
         assert output1 in result
@@ -5011,7 +5018,7 @@ def test_multiple_stencils():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0_testkern_stencil_multi_type(f1, f2, f3, "
             "f4, f2_extent, f3_extent, f3_direction)")
@@ -5094,7 +5101,7 @@ def test_multiple_stencil_same_name():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0_testkern_stencil_multi_type(f1, f2, f3, "
             "f4, extent, f3_direction)")
@@ -5161,7 +5168,7 @@ def test_multi_stencil_same_name_direction():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "SUBROUTINE invoke_0_testkern_stencil_multi_2_type(f1, f2, f3, "
             "f4, extent, direction)")
@@ -5243,7 +5250,7 @@ def test_multi_kerns_stencils_diff_fields():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0(f1, f2a, f3, f4, f2b, f2c, f2a_extent, "
             "extent)")
@@ -5313,7 +5320,7 @@ def test_extent_name_clash():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0(f2_stencil_map, f2, f2_stencil_dofmap, "
             "stencil_cross_1, f3_stencil_map, f3, f3_stencil_dofmap, "
@@ -5392,7 +5399,7 @@ def test_two_stencils_same_field():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0(f1_w1, f2_w2, f3_w2, f4_w3, f1_w3, "
             "f2_extent, extent)")
@@ -5458,7 +5465,7 @@ def test_stencils_same_field_literal_extent():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "      INTEGER f2_stencil_size_1\n"
             "      INTEGER, pointer :: f2_stencil_dofmap_1(:,:,:) => null()\n"
@@ -5519,7 +5526,7 @@ def test_stencils_same_field_literal_direct():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "      INTEGER f2_stencil_size_1\n"
             "      INTEGER, pointer :: f2_stencil_dofmap_1(:,:,:) => null()\n"
@@ -5645,7 +5652,7 @@ def test_one_kern_multi_field_same_stencil():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "    SUBROUTINE invoke_0_testkern_multi_field_same_stencil_type("
             "f0, f1, f2, f3, f4, extent, direction)")
@@ -5711,7 +5718,7 @@ def test_single_kernel_any_space_stencil():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "      f1_stencil_map => f1_proxy%vspace%get_stencil_dofmap("
             "STENCIL_CROSS,extent)\n"
@@ -5766,7 +5773,7 @@ def test_multi_kernel_any_space_stencil_1():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = (
             "      f1_stencil_map => f1_proxy%vspace%get_stencil_dofmap("
             "STENCIL_CROSS,extent)\n"
@@ -5803,7 +5810,7 @@ def test_stencil_args_unique_1():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         # we use f2_stencil_size for extent and nlayers for direction
         # as arguments
         output1 = ("    SUBROUTINE invoke_0_testkern_stencil_xory1d_type(f1, "
@@ -5853,7 +5860,7 @@ def test_stencil_args_unique_2():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         output1 = ("    SUBROUTINE invoke_0(f1, f2, f3, f4, f2_info, "
                    "f2_info_2, f2_info_1, f2_info_3)")
         assert output1 in result
@@ -5920,7 +5927,7 @@ def test_stencil_args_unique_3():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         result = str(psy.gen)
-        print result
+        print(result)
         assert (
             "      INTEGER, intent(in) :: my_info_f2_info, my_info_f2_info_2\n"
             "      INTEGER, intent(in) :: my_info_f2_info_1, "
@@ -5988,7 +5995,7 @@ def test_dynkernargs_unexpect_stencil_extent():
         os.path.join(BASE_PATH, "19.1_single_stencil.f90"),
         api="dynamo0.3")
     # find the parsed code's call class
-    call = invoke_info.calls.values()[0].kcalls[0]
+    call = list(invoke_info.calls.values())[0].kcalls[0]
     # add an extent to the stencil metadata
     kernel_metadata = call.ktype
     kernel_metadata._arg_descriptors[1].stencil['extent'] = 2
@@ -6041,7 +6048,7 @@ def test_dynglobalsum_unsupported_scalar():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     schedule = psy.invokes.invoke_list[0].schedule
     loop = schedule.children[3]
     kernel = loop.children[0]
@@ -6061,7 +6068,7 @@ def test_dynglobalsum_nodm_error():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3", distributed_memory=False).create(invoke_info)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     schedule = psy.invokes.invoke_list[0].schedule
     loop = schedule.children[0]
     kernel = loop.children[0]
@@ -6075,7 +6082,7 @@ def test_dynglobalsum_nodm_error():
 def test_no_updated_args():
     ''' Check that we raise the expected exception when we encounter a
     kernel that does not write to any of its arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_write,w1)",
                         "arg_type(gh_field,gh_read,w1)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -6090,7 +6097,7 @@ def test_no_updated_args():
 def test_scalars_only_invalid():
     ''' Check that we raise the expected exception if we encounter a
     kernel that only has (read-only) scalar arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = '''
 module testkern
   type, extends(kernel_type) :: testkern_type
@@ -6119,7 +6126,7 @@ end module testkern
 def test_multiple_updated_field_args():
     ''' Check that we successfully parse a kernel that writes to more
     than one of its field arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_field,gh_read, w2)",
                         "arg_type(gh_field,gh_write, w1)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -6135,7 +6142,7 @@ def test_multiple_updated_field_args():
 def test_multiple_updated_op_args():
     ''' Check that we successfully parse the metadata for a kernel that
     writes to more than one of its field and operator arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_operator,gh_read, w2, w2)",
                         "arg_type(gh_operator,gh_write, w1, w1)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -6153,7 +6160,7 @@ def test_multiple_updated_op_args():
 def test_multiple_updated_scalar_args():
     ''' Check that we raise the expected exception when we encounter a
     kernel that writes to more than one of its field and scalar arguments '''
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     code = CODE.replace("arg_type(gh_real, gh_read)",
                         "arg_type(gh_real, gh_sum)", 1)
     ast = fpapi.parse(code, ignore_comments=False)
@@ -6178,7 +6185,7 @@ def test_itn_space_write_w2v_w1(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if dist_mem:
             output = (
                 "      !\n"
@@ -6210,7 +6217,7 @@ def test_itn_space_fld_and_op_writers(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if dist_mem:
             output = (
                 "      !\n"
@@ -6239,7 +6246,7 @@ def test_itn_space_any_w3(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if dist_mem:
             output = (
                 "      !\n"
@@ -6268,7 +6275,7 @@ def test_itn_space_any_w1():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if dist_mem:
             output = (
                 "      !\n"
@@ -6369,7 +6376,7 @@ def test_kernel_args_has_op():
         os.path.join(BASE_PATH, "19.1_single_stencil.f90"),
         api="dynamo0.3")
     # find the parsed code's call class
-    call = invoke_info.calls.values()[0].kcalls[0]
+    call = list(invoke_info.calls.values())[0].kcalls[0]
     from psyclone.dynamo0p3 import DynKernelArguments
     dka = DynKernelArguments(call, None)
     with pytest.raises(GenerationError) as excinfo:
@@ -6489,7 +6496,7 @@ def test_multi_anyw2():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         if dist_mem:
             output = (
                 "      ! Look-up dofmaps for each function space\n"
@@ -6557,7 +6564,7 @@ def test_anyw2_vectors():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         assert "f3_proxy(1) = f3(1)%get_proxy()" in generated_code
         assert "f3_proxy(2) = f3(2)%get_proxy()" in generated_code
         assert "f3_proxy(1)%data, f3_proxy(2)%data" in generated_code
@@ -6573,7 +6580,7 @@ def test_anyw2_operators():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         output = (
             "      ! Initialise number of DoFs for any_w2\n"
             "      !\n"
@@ -6602,7 +6609,7 @@ def test_anyw2_stencils():
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
-        print generated_code
+        print(generated_code)
         output = (
             "      ! Initialise stencil dofmaps\n"
             "      !\n"
@@ -6622,7 +6629,7 @@ def test_stub_generate_with_anyw2():
     result = generate(os.path.join(BASE_PATH,
                                    "testkern_multi_anyw2_basis_mod.f90"),
                       api="dynamo0.3")
-    print result
+    print(result)
     expected_output = (
         "      REAL(KIND=r_def), intent(in), dimension(3,ndf_any_w2,"
         "np_xy,np_z) :: basis_any_w2\n"
@@ -6641,7 +6648,7 @@ def test_no_halo_for_discontinous(tmpdir, f90, f90flags):
                     api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "halo_exchange" not in result
 
     if utils.TEST_COMPILE:
@@ -6662,7 +6669,7 @@ def test_halo_for_discontinuous(tmpdir, f90, f90flags):
                     api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "IF (f1_proxy%is_dirty(depth=1)) THEN" in result
     assert "CALL f1_proxy%halo_exchange(depth=1)" in result
     assert "IF (f2_proxy%is_dirty(depth=1)) THEN" in result
@@ -6687,7 +6694,7 @@ def test_halo_for_discontinuous_2(tmpdir, f90, f90flags):
                     api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "IF (f1_proxy%is_dirty(depth=1)) THEN" not in result
     assert "CALL f1_proxy%halo_exchange(depth=1)" in result
     assert "IF (f2_proxy%is_dirty(depth=1)) THEN" not in result
@@ -6860,7 +6867,7 @@ def test_halo_ex_back_dep_no_call(monkeypatch):
     # not matter in practice as we are just trying to get PSyclone to
     # raise the appropriate exception.
     assert ("Generation Error: In HaloInfo class, field 'f2' should be from a "
-            "call but found <type 'function'>") in str(excinfo.value)
+            "call but found %s"%type(lambda: halo_exchange)) in str(excinfo.value)
 
 
 def test_HaloReadAccess_input_field():
@@ -6872,7 +6879,7 @@ def test_HaloReadAccess_input_field():
     assert (
         "Generation Error: HaloInfo class expects an argument of type "
         "DynArgument, or equivalent, on initialisation, but found, "
-        "'<type 'NoneType'>'" in str(excinfo.value))
+        "'%s'"%type(None) in str(excinfo.value))
 
 
 def test_HaloReadAccess_field_in_call():
@@ -7109,7 +7116,7 @@ def test_no_halo_exchange_annex_dofs(tmpdir, f90, f90flags):
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     result = str(psy.gen)
-    print result
+    print(result)
     if utils.TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
         assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)

--- a/src/psyclone/tests/dynamo0p3_transformations_test.py
+++ b/src/psyclone/tests/dynamo0p3_transformations_test.py
@@ -36,7 +36,7 @@
 
 ''' Tests of transformations with the Dynamo 0.3 API '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.parse import parse
@@ -91,7 +91,7 @@ def test_colour_trans_declarations(tmpdir, f90, f90flags):
         gen = str(psy.gen)
         # Fortran is not case sensitive
         gen = gen.lower()
-        print gen
+        print(gen)
 
         # Check that we've declared the loop-related variables
         # and colour-map pointers
@@ -137,7 +137,7 @@ def test_colour_trans(tmpdir, f90, f90flags):
         gen = str(psy.gen)
         # Fortran is not case sensitive
         gen = gen.lower()
-        print gen
+        print(gen)
         # Check that we're calling the API to get the no. of colours
         # and the generated loop bounds are correct
         if dist_mem:
@@ -209,7 +209,7 @@ def test_colour_trans_operator(tmpdir, f90, f90flags):
         # Store the results of applying this code transformation as a
         # string
         gen = str(psy.gen)
-        print gen
+        print(gen)
 
         # check the first argument is a colourmap lookup
         assert "CALL testkern_operator_code(cmap(colour, cell), nlayers" in gen
@@ -247,7 +247,7 @@ def test_colour_trans_cma_operator(tmpdir, f90, f90flags):
         # Store the results of applying this code transformation as a
         # string
         gen = str(psy.gen)
-        print gen
+        print(gen)
 
         if dist_mem:
             assert (
@@ -312,7 +312,7 @@ def test_colour_trans_stencil():
         # Store the results of applying this code transformation as
         # a string
         gen = str(psy.gen)
-        print gen
+        print(gen)
 
         # Check that we index the stencil dofmap appropriately
         assert (
@@ -467,7 +467,7 @@ def test_omp_colour_trans(tmpdir, f90, f90flags):
 
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
 
         if dist_mem:
             output = (
@@ -723,7 +723,7 @@ def test_colouring_multi_kernel():
         schedule, _ = otrans.apply(schedule.children[index+1].children[0])
 
         gen = str(psy.gen)
-        print gen
+        print(gen)
 
         # Check that we're calling the API to get the no. of colours
         if dist_mem:
@@ -770,7 +770,7 @@ def test_omp_region_omp_do():
         # a string
         code = str(psy.gen)
 
-        print code
+        print(code)
 
         omp_do_idx = -1
         omp_para_idx = -1
@@ -832,7 +832,7 @@ def test_omp_region_omp_do_rwdisc():
         # a string
         code = str(psy.gen)
 
-        print code
+        print(code)
 
         omp_do_idx = -1
         omp_para_idx = -1
@@ -888,7 +888,7 @@ def test_multi_kernel_single_omp_region():
         schedule, _ = rtrans.apply(schedule.children[index:index+2])
 
         code = str(psy.gen)
-        print code
+        print(code)
 
         omp_do_idx = -1
         omp_end_do_idx = -1
@@ -954,7 +954,7 @@ def test_multi_different_kernel_omp():
         schedule, _ = otrans.apply(schedule.children[index2].children[0])
 
         code = str(psy.gen)
-        print code
+        print(code)
 
         assert "private(cell)" in code
 
@@ -1096,7 +1096,7 @@ def test_loop_fuse_set_dirty():
                                schedule.children[4])
     schedule.view()
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert gen.count("set_dirty()") == 1
 
 
@@ -1127,7 +1127,7 @@ def test_loop_fuse_omp():
         schedule, _ = otrans.apply(schedule.children[index])
 
         code = str(psy.gen)
-        print code
+        print(code)
 
         # Check generated code
         omp_para_idx = -1
@@ -1191,7 +1191,7 @@ def test_loop_fuse_omp_rwdisc(tmpdir, f90, f90flags):
         schedule, _ = otrans.apply(schedule.children[index])
 
         code = str(psy.gen)
-        print code
+        print(code)
 
         # Check generated code
         omp_para_idx = -1
@@ -1275,7 +1275,7 @@ def test_fuse_colour_loops(tmpdir, f90, f90flags):
             schedule, _ = otrans.apply(loop)
 
         code = str(psy.gen)
-        print code
+        print(code)
 
         if dist_mem:
             output = (
@@ -1393,7 +1393,7 @@ def test_loop_fuse_cma():
                                    schedule.children[index+1],
                                    same_space=True)
         code = str(psy.gen)
-        print code
+        print(code)
         assert (
             "      ! Look-up required column-banded dofmaps\n"
             "      !\n"
@@ -1498,7 +1498,7 @@ def test_builtin_single_OpenMP_pdo():
         schedule, _ = otrans.apply(schedule.children[0])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel do default(shared), private(df), "
@@ -1539,7 +1539,7 @@ def test_builtin_multiple_OpenMP_pdo():
             schedule, _ = otrans.apply(child)
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel do default(shared), private(df), "
@@ -1620,7 +1620,7 @@ def test_builtin_loop_fuse_pdo():
         schedule, _ = otrans.apply(schedule.children[0])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel do default(shared), private(df), "
@@ -1670,7 +1670,7 @@ def test_builtin_single_OpenMP_do():
         # Put an OMP DO around this loop
         schedule, _ = olooptrans.apply(schedule.children[0].children[0])
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel default(shared), private(df)\n"
@@ -1720,7 +1720,7 @@ def test_builtin_multiple_OpenMP_do():
         for child in schedule.children[0].children:
             schedule, _ = olooptrans.apply(child)
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel default(shared), private(df)\n"
@@ -1811,7 +1811,7 @@ def test_builtin_loop_fuse_do():
         # Put an OMP DO around the loop
         schedule, _ = olooptrans.apply(schedule.children[0].children[0])
         result = str(psy.gen)
-        print result
+        print(result)
         if dist_mem:
             assert (
                 "      !$omp parallel default(shared), private(df)\n"
@@ -1864,7 +1864,7 @@ def test_reduction_real_pdo():
         schedule, _ = otrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      !$omp parallel do default(shared), private(df), "
@@ -1907,7 +1907,7 @@ def test_reduction_real_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      !$omp parallel default(shared), private(df)\n"
@@ -1951,7 +1951,7 @@ def test_multi_reduction_real_pdo():
                 schedule, _ = otrans.apply(child)
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2028,7 +2028,7 @@ def test_reduction_after_normal_real_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if distmem:
             expected_output = (
                 "      ! Zero summation variables\n"
@@ -2104,7 +2104,7 @@ def test_reprod_red_after_normal_real_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if distmem:
             expected_output = (
                 "      ! Zero summation variables\n"
@@ -2209,7 +2209,7 @@ def test_two_reductions_real_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if distmem:
             expected_output = (
                 "      ! Zero summation variables\n"
@@ -2288,7 +2288,7 @@ def test_two_reprod_reductions_real_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         result = str(psy.gen)
-        print result
+        print(result)
         if distmem:
             expected_output = (
                 "      ! Zero summation variables\n"
@@ -2462,7 +2462,7 @@ def test_multi_different_reduction_real_pdo():
                 schedule, _ = otrans.apply(child)
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2536,7 +2536,7 @@ def test_multi_builtins_red_then_pdo():
                 schedule, _ = otrans.apply(child)
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2610,7 +2610,7 @@ def test_multi_builtins_red_then_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2686,7 +2686,7 @@ def test_multi_builtins_red_then_fuse_pdo():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2752,7 +2752,7 @@ def test_multi_builtins_red_then_fuse_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      asum = 0.0_r_def\n"
@@ -2810,7 +2810,7 @@ def test_multi_builtins_usual_then_red_pdo():
                 schedule, _ = otrans.apply(child)
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      !$omp parallel do default(shared), private(df), "
@@ -2881,7 +2881,7 @@ def test_builtins_usual_then_red_fuse_pdo():
         schedule, _ = otrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      ! Zero summation variables\n"
@@ -2942,7 +2942,7 @@ def test_builtins_usual_then_red_fuse_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         if distmem:
             assert (
                 "      asum = 0.0_r_def\n"
@@ -3075,7 +3075,7 @@ def test_reprod_reduction_real_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         assert (
             "      USE omp_lib, ONLY: omp_get_thread_num\n"
             "      USE omp_lib, ONLY: omp_get_max_threads\n") in code
@@ -3198,7 +3198,7 @@ def test_reprod_builtins_red_then_usual_do():
         schedule, _ = rtrans.apply(schedule.children[0:2])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         assert (
             "      USE omp_lib, ONLY: omp_get_thread_num\n"
             "      USE omp_lib, ONLY: omp_get_max_threads\n") in code
@@ -3308,7 +3308,7 @@ def test_repr_bltins_red_then_usual_fuse_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         assert (
             "      USE omp_lib, ONLY: omp_get_thread_num\n"
             "      USE omp_lib, ONLY: omp_get_max_threads\n") in code
@@ -3405,7 +3405,7 @@ def test_repr_bltins_usual_then_red_fuse_do():
         schedule, _ = rtrans.apply(schedule.children[0])
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         assert "      INTEGER th_idx\n" in code
         if distmem:
             assert (
@@ -3491,7 +3491,7 @@ def test_repr_3_builtins_2_reductions_do():
                 schedule, _ = rtrans.apply(child)
         invoke.schedule = schedule
         code = str(psy.gen)
-        print code
+        print(code)
         assert "INTEGER th_idx\n" in code
         if distmem:
             for names in [
@@ -3639,10 +3639,10 @@ def test_reprod_view(capsys):
                 "upper_bound='ndofs']\n"
                 "                " + call + " sum_x(bsum,f2)\n")
         if expected not in result:
-            print "Expected ..."
-            print expected
-            print "Found ..."
-            print result
+            print("Expected ...")
+            print(expected)
+            print("Found ...")
+            print(result)
             assert 0
 
 
@@ -3976,7 +3976,7 @@ def test_rc_continuous_depth():
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f2", "m1", "m2"]:
         assert ("IF ({0}_proxy%is_dirty(depth=3)) THEN".
                 format(field_name)) in result
@@ -4004,7 +4004,7 @@ def test_rc_continuous_no_depth():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f2", "m1", "m2"]:
         assert ("      IF ({0}_proxy%is_dirty(depth=mesh%get_halo_"
                 "depth())) THEN\n"
@@ -4033,7 +4033,7 @@ def test_rc_discontinuous_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f1", "f2", "m1"]:
         assert ("      IF ({0}_proxy%is_dirty(depth=3)) THEN\n"
                 "        CALL {0}_proxy%halo_exchange(depth=3)".
@@ -4065,7 +4065,7 @@ def test_rc_discontinuous_no_depth():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f1", "f2", "m1"]:
         assert ("IF ({0}_proxy%is_dirty(depth=mesh%get_halo_depth())) "
                 "THEN".format(field_name)) in result
@@ -4093,7 +4093,7 @@ def test_rc_all_discontinuous_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert "IF (f2_proxy%is_dirty(depth=3)) THEN" in result
     assert "CALL f2_proxy%halo_exchange(depth=3)" in result
     assert "DO cell=1,mesh%get_last_halo_cell(3)" in result
@@ -4123,7 +4123,7 @@ def test_rc_all_discontinuous_no_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert ("IF (f2_proxy%is_dirty(depth=mesh%get_halo_depth())) "
             "THEN") in result
     assert ("CALL f2_proxy%halo_exchange(depth=mesh%get_halo_dep"
@@ -4154,7 +4154,7 @@ def test_rc_all_discontinuous_vector_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for idx in range(1, 4):
         assert ("IF (f2_proxy({0})%is_dirty(depth=3)) THEN".
                 format(idx)) in result
@@ -4188,7 +4188,7 @@ def test_rc_all_discontinuous_vector_no_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for idx in range(1, 4):
         assert ("IF (f2_proxy({0})%is_dirty(depth=mesh%get_halo_depth"
                 "())) THEN".format(idx)) in result
@@ -4225,7 +4225,7 @@ def test_rc_all_disc_prev_depend_depth(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert "IF (f1_proxy%is_dirty(depth=3)) THEN" not in result
     assert "CALL f1_proxy%halo_exchange(depth=3)" in result
     assert "DO cell=1,mesh%get_last_halo_cell(3)" in result
@@ -4257,7 +4257,7 @@ def test_rc_all_disc_prev_depend_no_depth():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert "CALL f1_proxy%set_dirty()" in result
     assert ("IF (f1_proxy%is_dirty(depth=mesh%get_halo_depth())) "
             "THEN") not in result
@@ -4286,7 +4286,7 @@ def test_rc_all_disc_prev_dep_depth_vector(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for idx in range(1, 4):
         assert ("IF (f1_proxy({0})%is_dirty(depth="
                 "3)) THEN".format(idx)) not in result
@@ -4323,7 +4323,7 @@ def test_rc_all_disc_prev_dep_no_depth_vect(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert "is_dirty" not in result
     for idx in range(1, 4):
         assert ("CALL f1_proxy({0})%halo_exchange(depth=mesh%get_halo_"
@@ -4359,7 +4359,7 @@ def test_rc_all_disc_prev_dep_no_depth_vect_readwrite(tmpdir, f90, f90flags):
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     # f3 has readwrite access so need to check the halos
     for idx in range(1, 4):
         assert ("IF (f3_proxy({0})%is_dirty(depth=mesh%get_halo_"
@@ -4399,7 +4399,7 @@ def test_rc_dofs_depth():
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f1", "f2"]:
         assert ("IF ({0}_proxy%is_dirty(depth=3)) "
                 "THEN".format(field_name)) in result
@@ -4427,7 +4427,7 @@ def test_rc_dofs_no_depth():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     for field_name in ["f1", "f2"]:
         assert ("IF ({0}_proxy%is_dirty(depth=mesh%get_halo_depth())) "
                 "THEN".format(field_name)) in result
@@ -4455,7 +4455,7 @@ def test_rc_dofs_depth_prev_dep():
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     # check the f1 halo exchange is added and the f2 halo exchange is
     # modified
     for field_name in ["f1", "f2"]:
@@ -4503,7 +4503,7 @@ def test_rc_dofs_no_depth_prev_dep():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     # check the f1 halo exchange is added and the f2 halo exchange is
     # modified
     for field_name in ["f1", "f2"]:
@@ -4533,7 +4533,7 @@ def test_continuous_no_set_clean():
                     api=TEST_API)
     psy = PSyFactory(TEST_API).create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "DO cell=1,mesh%get_last_halo_cell(1)" in result
     assert "CALL f1_proxy%set_dirty()" in result
     assert "CALL f1_proxy%set_clean(" not in result
@@ -4548,7 +4548,7 @@ def test_discontinuous_no_set_clean():
                     api=TEST_API)
     psy = PSyFactory(TEST_API).create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "DO cell=1,mesh%get_last_edge_cell()" in result
     assert "CALL m2_proxy%set_dirty()" in result
     assert "CALL m2_proxy%set_clean(" not in result
@@ -4563,7 +4563,7 @@ def test_dofs_no_set_clean():
                     api=TEST_API)
     psy = PSyFactory(TEST_API).create(info)
     result = str(psy.gen)
-    print result
+    print(result)
     assert "halo_exchange" not in result
     assert "DO df=1,f1_proxy%vspace%get_last_dof_owned()" in result
     assert "CALL f1_proxy%set_dirty()" in result
@@ -4586,7 +4586,7 @@ def test_rc_vector_depth():
     schedule, _ = rc_trans.apply(loop, depth=3)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert "IF (f2_proxy%is_dirty(depth=3)) THEN" in result
     assert "CALL f2_proxy%halo_exchange(depth=3)" in result
     assert "DO cell=1,mesh%get_last_halo_cell(3)" in result
@@ -4612,7 +4612,7 @@ def test_rc_vector_no_depth():
     schedule, _ = rc_trans.apply(loop)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert ("IF (f2_proxy%is_dirty(depth=mesh%get_halo_depth())) "
             "THEN") in result
     assert ("CALL f2_proxy%halo_exchange(depth=mesh%"
@@ -4670,7 +4670,7 @@ def test_rc_no_halo_decrease():
     schedule, _ = rc_trans.apply(loop, depth=4)
     invoke.schedule = schedule
     result = str(psy.gen)
-    print result
+    print(result)
     assert ("IF (f2_proxy%is_dirty(depth=mesh%get_halo_depth())) "
             "THEN") in result
     assert "IF (m1_proxy%is_dirty(depth=4)) THEN" in result
@@ -4813,7 +4813,7 @@ def test_rc_max_remove_halo_exchange(tmpdir, f90, f90flags):
     loop = schedule.children[3]
     rc_trans.apply(loop)
     result = str(psy.gen)
-    print result
+    print(result)
     # f3 halo exchange is not removed even though we redundantly
     # compute f3 as the redundant computation is on a continuous field
     # and therefore the outermost halo stays dirty. We can not be
@@ -5083,7 +5083,7 @@ def test_rc_invalid_depth_type():
     with pytest.raises(TransformationError) as excinfo:
         rc_trans.apply(loop, depth="2")
     assert ("the supplied depth should be an integer but found "
-            "type '<type 'str'>'" in str(excinfo.value))
+            "type '%s'"%(type("2")) in str(excinfo.value))
 
 
 def test_loop_fusion_different_loop_depth():
@@ -5823,7 +5823,7 @@ def test_haloex_colouring(tmpdir, f90, f90flags):
             # to py.test)
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-        print "OK for iteration ", idx
+        print("OK for iteration ", idx)
 
 
 def test_haloex_rc1_colouring(tmpdir, f90, f90flags):
@@ -5905,7 +5905,7 @@ def test_haloex_rc1_colouring(tmpdir, f90, f90flags):
             # to py.test)
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-        print "OK for iteration ", idx
+        print("OK for iteration ", idx)
 
 
 def test_haloex_rc2_colouring(tmpdir, f90, f90flags):
@@ -5990,7 +5990,7 @@ def test_haloex_rc2_colouring(tmpdir, f90, f90flags):
             # to py.test)
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-        print "OK for iteration ", idx
+        print("OK for iteration ", idx)
 
 
 def test_haloex_rc3_colouring(tmpdir, f90, f90flags):
@@ -6074,7 +6074,7 @@ def test_haloex_rc3_colouring(tmpdir, f90, f90flags):
             # to py.test)
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-        print "OK for iteration ", idx
+        print("OK for iteration ", idx)
 
 
 def test_haloex_rc4_colouring(tmpdir, f90, f90flags):
@@ -6146,7 +6146,7 @@ def test_haloex_rc4_colouring(tmpdir, f90, f90flags):
             # to py.test)
             assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
-        print "OK for iteration ", idx
+        print("OK for iteration ", idx)
 
 
 def test_intergrid_rejected():

--- a/src/psyclone/tests/expression_test.py
+++ b/src/psyclone/tests/expression_test.py
@@ -3,6 +3,7 @@
 
 from __future__ import absolute_import
 from psyclone.expression import VAR_OR_FUNCTION, FORT_EXPRESSION, SLICING
+import six
 
 
 def my_test(name, parser, test_string, names=None):
@@ -12,17 +13,27 @@ def my_test(name, parser, test_string, names=None):
     the whitespace conventions of the unparser for the test to succeed.'''
     # These imports are required in order for the exec in the code below
     # to work. Pylint complains about those as unused variables
-    # pylint: disable=unused-variable
-    from psyclone.expression import BinaryOperator, FunctionVar, Grouping, \
-        LiteralArray, NamedArg, Slicing
-    # pylint: enable=unused-variable
     pstr = parser.parseString(test_string)
     assert (str(pstr[0]) == test_string), "Failed to parse " + name + "."
     # ast.literal_eval can't be used here as the generated expression
     # calls constructors of user-defined objects
+
+    # Create and execute in a context with PSyclone's expressions available
+    # Unlike Python2 Python3's exec requries an explicit context
+    import psyclone.expression
+    context = {
+            'BinaryOperator': psyclone.expression.BinaryOperator,
+            'FunctionVar': psyclone.expression.FunctionVar,
+            'Grouping': psyclone.expression.Grouping,
+            'LiteralArray': psyclone.expression.LiteralArray,
+            'NamedArg': psyclone.expression.NamedArg,
+            'Slicing': psyclone.expression.Slicing,
+            }
     # pylint: disable=exec-used
-    exec("pstr="+repr(pstr[0]))
+    six.exec_("pstr="+repr(pstr[0]), context)
     # pylint: enable=exec-used
+    pstr = context['pstr']
+
     assert (str(pstr) == test_string), "Error in repr for " + name + "."
     if names:
         assert pstr.names == set(names), "Names do not match for " + name + "."

--- a/src/psyclone/tests/f2pygen_test.py
+++ b/src/psyclone/tests/f2pygen_test.py
@@ -8,7 +8,7 @@
 
 ''' Tests for the f2pygen module of PSyclone '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 from psyclone.f2pygen import ModuleGen, CommentGen, SubroutineGen, DoGen, \
     CallGen, AllocateGen, DeallocateGen, IfThenGen, DeclGen, TypeDeclGen,\
     ImplicitNoneGen, UseGen, DirectiveGen, AssignGen
@@ -67,7 +67,7 @@ def test_subroutine_var_with_implicit_none():
                            entity_decls=["var1"]))
     idx_var = line_number(subroutine.root, "INTEGER var1")
     idx_imp_none = line_number(subroutine.root, "IMPLICIT NONE")
-    print str(module.root)
+    print(str(module.root))
     assert idx_var - idx_imp_none == 1, \
         "variable declation must be after implicit none"
 
@@ -86,7 +86,7 @@ def test_subroutine_var_intent_in_with_directive():
     idx_par = line_number(subroutine.root, "!$omp parallel")
     idx_var = line_number(subroutine.root,
                           "INTEGER, intent(in) :: var1")
-    print str(module.root)
+    print(str(module.root))
     assert idx_par - idx_var == 1, \
         "variable declaration must be before directive"
 
@@ -144,7 +144,7 @@ def test_if_with_position_append():
     if_statement.add(CommentGen(if_statement, "GOODBYE"),
                      position=["append"])
     module.add(if_statement)
-    print str(module.root)
+    print(str(module.root))
     lines = str(module.root).splitlines()
     assert "IF (" + clause + ") THEN" in lines[3]
     assert "!HELLO" in lines[4]
@@ -161,7 +161,7 @@ def test_if_add_use():
     if_statement.add(CommentGen(if_statement, "GOODBYE"))
     if_statement.add(UseGen(if_statement, name="dibna"))
     module.add(if_statement)
-    print str(module.root)
+    print(str(module.root))
     use_line = line_number(module.root, "USE dibna")
     if_line = line_number(module.root, "IF (" + clause + ") THEN")
     # The use statement must come before the if..then block
@@ -189,7 +189,7 @@ def test_add_before():
     subroutine.add(call, position=["before", loop.root])
     lines = str(module.root).splitlines()
     # the call should be inserted before the loop
-    print lines
+    print(lines)
     assert "SUBROUTINE testsubroutine" in lines[3]
     assert "CALL testcall" in lines[4]
     assert "DO it=1,10" in lines[5]
@@ -373,7 +373,7 @@ def test_imp_none_in_module_already_exists():
     module = ModuleGen(name="testmodule", implicitnone=True)
     module.add(ImplicitNoneGen(module))
     count = count_lines(module.root, "IMPLICIT NONE")
-    print str(module.root)
+    print(str(module.root))
     assert count == 1, \
         "There should only be one instance of IMPLICIT NONE"
 
@@ -674,7 +674,7 @@ def test_basegen_start_parent_loop_dbg(capsys):
     loop.add(call)
     call.start_parent_loop(debug=True)
     out, _ = capsys.readouterr()
-    print out
+    print(out)
     expected = ("Parent is a do loop so moving to the parent\n"
                 "The type of the current node is now <class "
                 "'fparser.one.block_statements.Do'>\n"
@@ -699,7 +699,7 @@ def test_basegen_start_parent_loop_not_first_child_dbg(capsys):
     loop.add(call)
     call.start_parent_loop(debug=True)
     out, _ = capsys.readouterr()
-    print out
+    print(out)
     expected = ("Parent is a do loop so moving to the parent\n"
                 "The type of the current node is now <class "
                 "'fparser.one.block_statements.Do'>\n"
@@ -724,7 +724,7 @@ def test_basegen_start_parent_loop_omp_begin_dbg(capsys):
     loop.add(call)
     call.start_parent_loop(debug=True)
     out, _ = capsys.readouterr()
-    print out
+    print(out)
     expected = ("Parent is a do loop so moving to the parent\n"
                 "The type of the current node is now <class "
                 "'fparser.one.block_statements.Do'>\n"
@@ -753,7 +753,7 @@ def test_basegen_start_parent_loop_omp_end_dbg(capsys):
     loop.add(call)
     call.start_parent_loop(debug=True)
     out, _ = capsys.readouterr()
-    print out
+    print(out)
     expected = ("Parent is a do loop so moving to the parent\n"
                 "The type of the current node is now <class "
                 "'fparser.one.block_statements.Do'>\n"
@@ -955,7 +955,7 @@ def test_typedeclgen_multiple_use():
     sub.add(TypeDeclGen(sub, datatype="my_type",
                         entity_decls=datanames))
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = (
         "      TYPE(my_type) type2\n"
         "      TYPE(my_type) type1")
@@ -981,7 +981,7 @@ def test_typedeclgen_multiple_use2():
     sub.add(TypeDeclGen(sub, datatype="my_type2",
                         entity_decls=datanames))
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = (
         "      TYPE(my_type2) type1, type2\n"
         "      TYPE(my_type) type1")
@@ -1007,7 +1007,7 @@ def test_declgen_multiple_use():
     sub.add(DeclGen(sub, datatype="integer",
                     entity_decls=datanames))
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = (
         "      INTEGER i2\n"
         "      INTEGER i1")
@@ -1033,7 +1033,7 @@ def test_declgen_multiple_use2():
     sub.add(DeclGen(sub, datatype="integer",
                     entity_decls=datanames))
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = (
         "      INTEGER data1, data2\n"
         "      REAL data1")
@@ -1056,7 +1056,7 @@ def test_selectiongen():
     # TODO how do we specify what happens in the default case?
     sgen.adddefault()
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = ("SELECT CASE ( my_var )\n"
                 "CASE ( 1 )\n"
                 "        happy = .TRUE.\n"
@@ -1077,7 +1077,7 @@ def test_selectiongen_addcase():
     sub.add(sgen)
     sgen.addcase("1")
     gen = str(sub.root)
-    print gen
+    print(gen)
     expected = ("      SELECT CASE ( my_var )\n"
                 "        CASE ( 1 )\n"
                 "      END SELECT")
@@ -1097,7 +1097,7 @@ def test_typeselectiongen():
     sgen.addcase("fspace", [agen])
     sgen.adddefault()
     gen = str(sub.root)
-    print gen
+    print(gen)
     assert "SELECT TYPE ( my_var=>another_var )" in gen
     assert "TYPE IS ( fspace )" in gen
 
@@ -1110,7 +1110,7 @@ def test_modulegen_add_wrong_parent():
     sub = SubroutineGen(module_wrong, name="testsubroutine")
     with pytest.raises(RuntimeError) as err:
         module.add(sub)
-    print str(err)
+    print(str(err))
     assert "because it is not a descendant of it or of any of" in str(err)
 
 

--- a/src/psyclone/tests/generator_test.py
+++ b/src/psyclone/tests/generator_test.py
@@ -438,8 +438,8 @@ def test_main_unexpected_fatal_error(capsys, monkeypatch):
         "Description ...\n"
         "argument of type 'int' is not iterable\n"
         "Type ...\n"
-        "<type 'exceptions.TypeError'>\n"
-        "Stacktrace ...\n")
+        "%s\n"
+        "Stacktrace ...\n"%type(TypeError()))
     assert expected_output in output
 
 

--- a/src/psyclone/tests/gocean0p1_test.py
+++ b/src/psyclone/tests/gocean0p1_test.py
@@ -5,7 +5,7 @@
 
 ''' This module tests the GOcean 0.1 API using pytest. '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory
@@ -23,7 +23,7 @@ def test_loop_bounds_gen_multiple_loops():
                     api=API)
     psy = PSyFactory(API).create(info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
 
     expected = (
         "      DO j=1,SIZE(uold, 2)\n"

--- a/src/psyclone/tests/gocean1p0_test.py
+++ b/src/psyclone/tests/gocean1p0_test.py
@@ -37,7 +37,7 @@
 '''Tests for PSy-layer code generation that are specific to the
 GOcean 1.0 API.'''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.parse import parse
@@ -763,7 +763,7 @@ def test_offset_any_all_cu_points():
         "      END DO \n"
         "    END SUBROUTINE invoke_0_compute_u\n"
         "  END MODULE psy_single_invoke_test")
-    print generated_code
+    print(generated_code)
     assert generated_code.find(expected_output) != -1
 
 
@@ -805,7 +805,7 @@ def test_offset_any_all_points():
         "      END DO \n"
         "    END SUBROUTINE invoke_0_copy\n"
         "  END MODULE psy_single_invoke_test")
-    print generated_code
+    print(generated_code)
     assert generated_code.find(expected_output) != -1
 
 

--- a/src/psyclone/tests/gocean1p0_transformations_test.py
+++ b/src/psyclone/tests/gocean1p0_transformations_test.py
@@ -41,7 +41,7 @@ def get_invoke(algfile, idx):
     # invokes does not have a method by which to request the i'th
     # in the list so we do this rather clumsy lookup of the name
     # of the invoke that we want
-    invoke = invokes.get(invokes.names[idx])
+    invoke = invokes.get(list(invokes.names)[idx])
     return psy, invoke
 
 
@@ -1309,7 +1309,7 @@ def test_go_loop_swap_errors():
                     api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(info)
     invokes = psy.invokes
-    invoke = invokes.get(invokes.names[0])
+    invoke = invokes.get(list(invokes.names)[0])
     with pytest.raises(TransformationError) as error:
         swap.apply(invoke.schedule.children[3])
 

--- a/src/psyclone/tests/line_length_test.py
+++ b/src/psyclone/tests/line_length_test.py
@@ -9,7 +9,7 @@
 ''' This module tests the line_limit module using pytest. '''
 
 # imports
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.line_length import FortLineLength
@@ -63,8 +63,8 @@ def test_unchanged():
         "    stuff\n")
     fll = FortLineLength(line_length=25)
     output_file = fll.process(input_file)
-    print "("+input_file+")"
-    print "("+output_file+")"
+    print("("+input_file+")")
+    print("("+output_file+")")
     assert input_file == output_file, "input should remain unchanged"
 
 
@@ -107,8 +107,8 @@ def test_wrapped():
     line length is wrapped appropriately by the FortLineLength class '''
     fll = FortLineLength(line_length=30)
     output_file = fll.process(INPUT_FILE)
-    print "("+EXPECTED_OUTPUT+")"
-    print "("+output_file+")"
+    print("("+EXPECTED_OUTPUT+")")
+    print("("+output_file+")")
     assert output_file == EXPECTED_OUTPUT, "output and expected output differ "
 
 
@@ -118,8 +118,8 @@ def test_wrapped_lower():
     FortLineLength class'''
     fll = FortLineLength(line_length=30)
     output_file = fll.process(INPUT_FILE.lower())
-    print "("+EXPECTED_OUTPUT.lower()+")"
-    print "("+output_file+")"
+    print("("+EXPECTED_OUTPUT.lower()+")")
+    print("("+output_file+")")
     assert output_file == EXPECTED_OUTPUT.lower(), \
         "output and expected output differ "
 
@@ -216,8 +216,8 @@ def test_break_types_multi_line():
 
     fll = FortLineLength(line_length=24)
     output_file = fll.process(input_file)
-    print "("+output_file+")"
-    print expected_output
+    print("("+output_file+")")
+    print(expected_output)
     assert output_file == expected_output
 
 
@@ -237,8 +237,8 @@ def test_edge_conditions_statements():
         "INTEGER &\n&INTEGER\n")
     fll = FortLineLength(line_length=len("INTEGER INTEGE"))
     output_string = fll.process(input_string)
-    print output_string
-    print expected_output
+    print(output_string)
+    print(expected_output)
     assert output_string == expected_output
 
     input_string = (
@@ -251,8 +251,8 @@ def test_edge_conditions_statements():
         "INTEGER &\n&INTEGER &\n&INTEGER\n")
     fll = FortLineLength(line_length=len("INTEGER INTEGER"))
     output_string = fll.process(input_string)
-    print output_string
-    print expected_output
+    print(output_string)
+    print(expected_output)
     assert output_string == expected_output
 
 

--- a/src/psyclone/tests/parse_test.py
+++ b/src/psyclone/tests/parse_test.py
@@ -38,7 +38,7 @@
 function. '''
 
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 from psyclone.parse import parse, ParseError
@@ -182,7 +182,7 @@ def test_wrong_named_invoke():
                          "test_files", "dynamo0p3",
                          "1.0.3_wrong_named_arg_invoke.f90"),
             api="dynamo0.3")
-    print str(err)
+    print(str(err))
     assert (
         "The arguments to an invoke() must be either kernel calls or an "
         "(optional) name=" in str(err))
@@ -226,7 +226,7 @@ def test_duplicate_named_invoke():
                          "test_files", "dynamo0p3",
                          "3.3_multi_functions_multi_invokes_name_clash.f90"),
             api="dynamo0.3")
-    print str(err)
+    print(str(err))
     assert ("Found multiple named invoke()'s with the same name ('jack') "
             "when parsing " in str(err))
     assert "3.3_multi_functions_multi_invokes_name_clash.f90" in str(err)
@@ -242,7 +242,7 @@ def test_duplicate_named_invoke_case():
                          "test_files", "dynamo0p3",
                          "3.4_multi_invoke_name_clash_case_insensitive.f90"),
             api="dynamo0.3")
-    print str(err)
+    print(str(err))
     assert ("Found multiple named invoke()'s with the same name ('jack') "
             "when parsing " in str(err))
     assert "3.4_multi_invoke_name_clash_case_insensitive.f90" in str(err)

--- a/src/psyclone/tests/psyGen_test.py
+++ b/src/psyclone/tests/psyGen_test.py
@@ -45,7 +45,7 @@
 
 # user classes requiring tests
 # PSyFactory, TransInfo, Transformation
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import re
 import pytest
@@ -465,7 +465,7 @@ def test_invokes_can_always_be_printed():
         os.path.join(BASE_PATH, "1.12_single_invoke_deref_name_clash.f90"),
         api="dynamo0.3")
 
-    alg_invocation = invoke.calls.values()[0]
+    alg_invocation = list(invoke.calls.values())[0]
     inv = Invoke(alg_invocation, 0, DynSchedule)
     assert inv.__str__() == \
         "invoke_0_testkern_type(a, f1_my_field, f1%my_field, m1, m2)"
@@ -505,7 +505,7 @@ def test_derived_type_deref_naming():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke)
     generated_code = str(psy.gen)
-    print generated_code
+    print(generated_code)
     output = (
         "    SUBROUTINE invoke_0_testkern_type"
         "(a, f1_my_field, f1_my_field_1, m1, m2)\n"
@@ -615,7 +615,7 @@ def test_incremented_arg():
     # Change the kernel metadata so that the the incremented kernel
     # argument has read access
     import fparser
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # If we change the meta-data then we trip the check in the parser.
     # Therefore, we change the object produced by parsing the meta-data
     # instead
@@ -640,7 +640,7 @@ def test_written_arg():
     # Change the kernel metadata so that the only kernel argument has
     # read access
     import fparser
-    fparser.logging.disable('CRITICAL')
+    fparser.logging.disable(fparser.logging.CRITICAL)
     # If we change the meta-data then we trip the check in the parser.
     # Therefore, we change the object produced by parsing the meta-data
     # instead
@@ -704,8 +704,8 @@ def test_ompdo_directive_class_view(capsys):
                                    SCHEDULE_COLOUR_MAP["KernCall"]) +
                 " testkern_code(a,f1,f2,m1,m2) "
                 "[module_inline=False]")
-            print out
-            print expected_output
+            print(out)
+            print(expected_output)
             assert expected_output in out
 
 
@@ -752,7 +752,7 @@ def test_globalsum_view(capsys):
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     psy.invokes.invoke_list[0].schedule.view()
     output, _ = capsys.readouterr()
-    print output
+    print(output)
     expected_output = (colored("GlobalSum",
                                SCHEDULE_COLOUR_MAP["GlobalSum"]) +
                        "[scalar='asum']")
@@ -890,7 +890,7 @@ def test_invoke_name():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert "SUBROUTINE invoke_important_invoke" in gen
 
 
@@ -902,7 +902,7 @@ def test_multi_kern_named_invoke():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert "SUBROUTINE invoke_some_name" in gen
 
 
@@ -915,7 +915,7 @@ def test_named_multi_invokes():
         api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert "SUBROUTINE invoke_my_first(" in gen
     assert "SUBROUTINE invoke_my_second(" in gen
 
@@ -929,7 +929,7 @@ def test_named_invoke_name_clash():
                            api="dynamo0.3")
     psy = PSyFactory("dynamo0.3").create(invoke_info)
     gen = str(psy.gen)
-    print gen
+    print(gen)
     assert "SUBROUTINE invoke_a(invoke_a_1, b, c, istp, rdt," in gen
     assert "TYPE(field_type), intent(inout) :: invoke_a_1" in gen
 
@@ -1779,7 +1779,7 @@ def test_omp_dag_names():
     assert omp_par_node.children[0].dag_name == "OMP_do_2"
     omp_directive = super(OMPParallelDirective, omp_par_node)
     assert omp_directive.dag_name == "OMP_directive_1"
-    print type(omp_directive)
+    print(type(omp_directive))
     directive = super(OMPDirective, omp_par_node)
     assert directive.dag_name == "directive_1"
 
@@ -1859,7 +1859,7 @@ def test_node_dag(tmpdir, have_graphviz):
     my_file = tmpdir.join('test')
     schedule.dag(file_name=my_file.strpath)
     result = my_file.read()
-    print result
+    print(result)
     assert EXPECTED2.match(result)
     my_file = tmpdir.join('test.svg')
     result = my_file.read()

--- a/src/psyclone/tests/utils.py
+++ b/src/psyclone/tests/utils.py
@@ -87,7 +87,7 @@ def count_lines(root, string_name):
 
 def print_diffs(expected, actual):
     '''
-    Pretty-print(the diff between the two, possibly multi-line, strings)
+    Pretty-print the diff between the two, possibly multi-line, strings
 
     :param str expected: Multi-line string
     :param str actual: Multi-line string

--- a/src/psyclone/tests/utils.py
+++ b/src/psyclone/tests/utils.py
@@ -35,7 +35,7 @@
 
 ''' test utilities '''
 
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 import os
 import pytest
 
@@ -87,7 +87,7 @@ def count_lines(root, string_name):
 
 def print_diffs(expected, actual):
     '''
-    Pretty-print the diff between the two, possibly multi-line, strings
+    Pretty-print(the diff between the two, possibly multi-line, strings)
 
     :param str expected: Multi-line string
     :param str actual: Multi-line string
@@ -148,17 +148,17 @@ def compile_file(filename, f90, f90flags):
                                  stderr=subprocess.STDOUT)
         (output, error) = build.communicate()
     except OSError as err:
-        print "Failed to run: {0}: ".format(" ".join(arg_list))
-        print "Error was: ", str(err)
+        print("Failed to run: {0}: ".format(" ".join(arg_list)))
+        print("Error was: ", str(err))
         raise CompileError(str(err))
 
     # Check the return code
     stat = build.returncode
     if stat != 0:
-        print output
+        print(output)
         if error:
-            print "========="
-            print error
+            print("=========")
+            print(error)
         raise CompileError(output)
     else:
         return True


### PR DESCRIPTION
General changes:
 - Ensure absolute imports and print functions are used everywhere
 - Use the 'six' library to handle changes to metaclasses and exec
 - Disable the 'fparser' cache, so that modifications to the parse tree
   do not affect future parse results

API-specific changes:
 - The dynamo0p3 API output has been changed so that the output is
   consistent between different Python versions. Where unordered
   collections (sets and dicts) were used to generate output these have
   now been changed to ordered collections (sorted lists and ordered
   dicts)
   This affects ordering in variable declaration, initialisation and
   DEALLOCATE calls

Fixes #135