### PR TITLE
Reduce maximum line length for pylint to be 79, same as pep8.

### DIFF
--- a/src/psyclone/.pylintrc
+++ b/src/psyclone/.pylintrc
@@ -1,0 +1,5 @@
+[FORMAT]
+
+# Maximum number of characters on a single line.
+max-line-length=79
+


### PR DESCRIPTION
As discussed in #93 - here a simple .pylintrc file that changes the maximum line length of pylint to be 79, same as pep8.