### PR TITLE
Added --version (-v) flag, and added PSyclone version to help message.

### DIFF
--- a/src/psyclone/generator.py
+++ b/src/psyclone/generator.py
@@ -7,6 +7,8 @@
 # whose members are identified at https://puma.nerc.ac.uk/trac/GungHo/wiki
 # -----------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
+# Modified work Copyright (c) 2018 by J. Henrichs, Bureau of Meteorology
+
 
 '''
     This module provides the PSyclone 'main' routine which is intended
@@ -36,6 +38,12 @@ def handle_script(script_name, psy):
     :type script_name: string
     :param psy: The psy layer to which the script is applied.
     :type psy: :py:class:`psyclone.psyGen.PSy`
+    :raises IOError: If the file is not found.
+    :raises GenerationError: if the file does not have .py extension
+        or can not be imported.
+    :raises GenerationError: if trans() can not be called.
+    :raises GenerationError: if any exception is raised when trans()
+        was called.
     '''
     sys_path_appended = False
     try:

--- a/src/psyclone/generator.py
+++ b/src/psyclone/generator.py
@@ -21,11 +21,12 @@ import argparse
 import sys
 import os
 import traceback
-from parse import parse, ParseError
-from psyGen import PSyFactory, GenerationError
-from algGen import NoInvokesError
-from config import SUPPORTEDAPIS, DEFAULTAPI, DISTRIBUTED_MEMORY
-from line_length import FortLineLength
+from psyclone.parse import parse, ParseError
+from psyclone.psyGen import PSyFactory, GenerationError
+from psyclone.algGen import NoInvokesError
+from psyclone.config import SUPPORTEDAPIS, DEFAULTAPI, DISTRIBUTED_MEMORY
+from psyclone.line_length import FortLineLength
+from psyclone.version import __VERSION__
 
 
 def generate(filename, api="", kernel_path="", script_name=None,
@@ -84,7 +85,7 @@ def generate(filename, api="", kernel_path="", script_name=None,
     if (len(kernel_path) > 0) and (not os.access(kernel_path, os.R_OK)):
         raise IOError("kernel search path '{0}' not found".format(kernel_path))
     try:
-        from algGen import Alg
+        from psyclone.algGen import Alg
         ast, invoke_info = parse(filename, api=api, invoke_name="invoke",
                                  kernel_path=kernel_path,
                                  line_length=line_length)
@@ -159,7 +160,7 @@ def main(args):
     function if all is well, catches any errors and outputs the
     results
     '''
-
+    # pylint: disable=too-many-statements
     parser = argparse.ArgumentParser(
         description='Run the PSyclone code generator on a particular file')
     parser.add_argument('-oalg', help='filename of transformed algorithm code')
@@ -185,12 +186,21 @@ def main(args):
         help='do not generate distributed memory code')
     parser.set_defaults(dist_mem=DISTRIBUTED_MEMORY)
 
+    parser.add_argument(
+        '-v', '--version', dest='version', action="store_true",
+        help='Display version information ({0})'.format(__VERSION__))
+
     args = parser.parse_args(args)
 
     if args.api not in SUPPORTEDAPIS:
         print "Unsupported API '{0}' specified. Supported API's are "\
             "{1}.".format(args.api, SUPPORTEDAPIS)
         exit(1)
+
+    if args.version:
+        print "PSyclone version: {0}".format(__VERSION__)
+
+    # pylint: disable=broad-except
     try:
         alg, psy = generate(args.filename, api=args.api,
                             kernel_path=args.directory,

--- a/src/psyclone/tests/generator_test.py
+++ b/src/psyclone/tests/generator_test.py
@@ -102,6 +102,7 @@ def test_similar_kernel_name():
 
 
 def test_recurse_correct_kernel_path():
+    # pylint: disable=invalid-name
     '''checks that the generator succeeds when the location of the kernel
        source code is *not* the same as that of the algorithm code and
        recursion through subdirectories is required'''
@@ -123,6 +124,7 @@ def test_script_file_not_found():
 
 
 def test_script_file_not_found_relative():
+    # pylint: disable=invalid-name
     ''' checks that generator.py raises an appropriate error when a script
         file is supplied that can't be found in the Python path. In
         this case the script path is not supplied so must be found via the
@@ -156,6 +158,7 @@ def test_script_file_no_extension():
 
 
 def test_script_file_wrong_extension():
+    # pylint: disable=invalid-name
     ''' checks that generator.py raises an appropriate error when a
         script file does not have the '.py' extension'''
     with pytest.raises(GenerationError):
@@ -178,6 +181,7 @@ def test_script_invalid_content():
 
 
 def test_script_invalid_content_runtime():
+    # pylint: disable=invalid-name
     ''' checks that generator.py raises an appropriate error when a
         script file contains valid python syntactically but produces a
         runtime exception. '''
@@ -315,6 +319,7 @@ def test_alg_lines_too_long_tested():
 
 
 def test_alg_lines_too_long_not_tested():
+    # pylint: disable=invalid-name
     ''' Test that the generate function returns successfully if the
     line_length argument is not set (as it should default to False)
     when the algorithm file has lines longer than 132 characters. We
@@ -336,6 +341,7 @@ def test_kern_lines_too_long_tested():
 
 
 def test_kern_lines_too_long_not_tested():
+    # pylint: disable=invalid-name
     ''' Test that the generate function returns successfully if the
     line_length argument is not set (as it should default to False)
     when a kernel file has lines longer than 132 characters. We
@@ -352,6 +358,24 @@ def test_continuators():
                                  "test_files", "dynamo0p3",
                                  "1.1.0_single_invoke_xyoz_qr.f90"),
                     api="dynamo0.3", line_length=True)
+
+
+def test_main_version(capsys):
+    '''Tests that the version info is printed correctly.'''
+    # First test if -h includes the right version info:
+    with pytest.raises(SystemExit):
+        main(["-h"])
+    output, _ = capsys.readouterr()
+    from psyclone.version import __VERSION__
+    assert "Display version information ({0})".format(__VERSION__) in output
+
+    # Now test -v, but it needs a filename for argparse to work. Just use
+    # some invalid parameters - "-v" prints its output before that.
+    with pytest.raises(SystemExit) as _:
+        main(["-v", "does-not-exist"])
+    output, _ = capsys.readouterr()
+
+    assert "PSyclone version: {0}".format(__VERSION__) in output
 
 
 def test_main_invalid_api(capsys):
@@ -391,6 +415,7 @@ def test_main_expected_fatal_error(capsys):
 
 
 def test_main_unexpected_fatal_error(capsys, monkeypatch):
+    # pylint: disable=invalid-name
     '''Tests that we get the expected output and the code exits with an
     error when an unexpected fatal error is returned from the generate
     function.'''

--- a/src/psyclone/tests/generator_test.py
+++ b/src/psyclone/tests/generator_test.py
@@ -5,6 +5,8 @@
 # whose members are identified at https://puma.nerc.ac.uk/trac/GungHo/wiki
 # -----------------------------------------------------------------------------
 # Author R. Ford STFC Daresbury Lab
+# Modified work Copyright (c) 2018 by J. Henrichs, Bureau of Meteorology
+
 
 '''
 A module to perform pytest unit and functional tests on the code in


### PR DESCRIPTION
I recently had the problem with Justin that we couldn't easily identify which psyclone version was installed - we had to look at the installation directory to see this (afaik ... unless I missed something).

So this pull requests add a -v option (which admittedly is limited useful, since ```psyclone -v``` ALONE does not work, the argument parsing requires a filename to be specified, so you need to do ```psyclone -v somefile```). But the version number is now also listed in the -h output.

I also fixed some pylint messages.