### PR TITLE
Make gocean loop specification more flexible

### DIFF
--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -1,3 +1,4 @@
+# pylint: disable=too-many-lines
 # -----------------------------------------------------------------------------
 # BSD 3-Clause License
 #
@@ -297,9 +298,9 @@ class GOSchedule(Schedule):
 
     def view(self, indent=0):
         ''' Print a representation of this GOSchedule '''
-        print(self.indent(indent) + self.coloured_text + "[invoke='" + \
-            self.invoke.name + "',Constant loop bounds=" + \
-            str(self._const_loop_bounds) + "]")
+        print(self.indent(indent) + self.coloured_text + "[invoke='" +
+              self.invoke.name + "',Constant loop bounds=" +
+              str(self._const_loop_bounds) + "]")
         for entity in self._children:
             entity.view(indent=indent + 1)
 
@@ -360,6 +361,7 @@ class GOSchedule(Schedule):
         self._const_loop_bounds = obj
 
 
+# pylint: disable=too-many-instance-attributes
 class GOLoop(Loop):
     ''' The GOcean specific Loop class. This passes the GOcean specific
         single loop information to the base class so it creates the one we
@@ -457,6 +459,7 @@ class GOLoop(Loop):
                     {'inner': {'start': "1", 'stop': "{stop}+1"},
                      'outer': {'start': "1", 'stop': "{stop}+1"}}
 
+    # pylint: disable=too-many-branches
     def _upper_bound(self):
         ''' Returns the upper bound of this loop as a string '''
         schedule = self.ancestor(GOSchedule)
@@ -476,9 +479,12 @@ class GOLoop(Loop):
                 stop = schedule.jloop_stop
 
             if index_offset:
-                d_bounds = self._bounds_lookup[index_offset][self.field_space] \
-                    [self._iteration_space][self._loop_type]
-                stop = d_bounds["stop"].format(start='', stop=stop)
+                # This strange line splitting was the only way I could find
+                # to avoid pep8 warnings: using [..._space]\ keeps on
+                # complaining about a white space
+                bounds = self._bounds_lookup[index_offset][self.field_space][
+                    self._iteration_space][self._loop_type]
+                stop = bounds["stop"].format(start='', stop=stop)
             else:
                 stop = "not yet set"
         else:
@@ -512,6 +518,7 @@ class GOLoop(Loop):
                     stop += "%ystop"
         return stop
 
+    # pylint: disable=too-many-branches
     def _lower_bound(self):
         ''' Returns a string containing the expression for the lower
         bound of the loop '''
@@ -531,9 +538,12 @@ class GOLoop(Loop):
             else:
                 stop = schedule.jloop_stop
             if index_offset:
-                d_bounds = self._bounds_lookup[index_offset][self.field_space] \
-                         [self._iteration_space][self._loop_type]
-                start = d_bounds["start"].format(start='', stop=stop)
+                # This strange line splitting was the only way I could find
+                # to avoid pep8 warnings: using [..._space]\ keeps on
+                # complaining about a white space
+                bounds = self._bounds_lookup[index_offset][self.field_space][
+                    self._iteration_space][self._loop_type]
+                start = bounds["start"].format(start='', stop=stop)
             else:
                 start = "not yet set"
         else:
@@ -612,6 +622,7 @@ class GOLoop(Loop):
         Loop.gen_code(self, parent)
 
 
+# pylint: disable=too-few-public-methods
 class GOBuiltInCallFactory(object):
     ''' A GOcean-specific built-in call factory. No built-ins
         are supported in GOcean at the moment. '''
@@ -625,6 +636,7 @@ class GOBuiltInCallFactory(object):
             "Built-ins are not supported for the GOcean 1.0 API")
 
 
+# pylint: disable=too-few-public-methods
 class GOKernCallFactory(object):
     ''' A GOcean-specific kernel-call factory. A standard kernel call in
     GOcean consists of a doubly-nested loop (over i and j) and a call to
@@ -902,6 +914,7 @@ class GOStencil(object):
         self._name = None
         self._initialised = False
 
+    # pylint: disable=too-many-branches
     def load(self, stencil_info, kernel_name):
         '''Take parsed stencil metadata information, check it is valid and
         store it in a convenient form. The kernel_name argument is
@@ -1163,7 +1176,6 @@ class GO1p0Descriptor(Descriptor):
             access = kernel_arg.args[0].name
             grid_var = kernel_arg.args[1].name
             funcspace = ""
-            stencil = ""
 
             self._grid_prop = grid_var
             self._type = "grid_property"

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -396,66 +396,66 @@ class GOLoop(Loop):
 
         # Loop bounds for a mesh with NE offset
         self._bounds_lookup['offset_ne']['ct']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_ne']['ct']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': ""},
-             'outer': {'start': "2", 'stop': ""}}
+            {'inner': {'start': "2", 'stop': "{stop}"},
+             'outer': {'start': "2", 'stop': "{stop}"}}
         self._bounds_lookup['offset_ne']['cu']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': ""},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_ne']['cu']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': "-1"},
-             'outer': {'start': "2", 'stop': ""}}
+            {'inner': {'start': "2", 'stop': "{stop}-1"},
+             'outer': {'start': "2", 'stop': "{stop}"}}
         self._bounds_lookup['offset_ne']['cv']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': ""}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}"}}
         self._bounds_lookup['offset_ne']['cv']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': ""},
-             'outer': {'start': "2", 'stop': "-1"}}
+            {'inner': {'start': "2", 'stop': "{stop}"},
+             'outer': {'start': "2", 'stop': "{stop}-1"}}
         self._bounds_lookup['offset_ne']['cf']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': ""},
-             'outer': {'start': "1", 'stop': ""}}
+            {'inner': {'start': "1", 'stop': "{stop}"},
+             'outer': {'start': "1", 'stop': "{stop}"}}
         self._bounds_lookup['offset_ne']['cf']['internal_pts'] = \
-            {'inner': {'start': "1", 'stop': "-1"},
-             'outer': {'start': "1", 'stop': "-1"}}
+            {'inner': {'start': "1", 'stop': "{stop}-1"},
+             'outer': {'start': "1", 'stop': "{stop}-1"}}
         # Loop bounds for a mesh with SE offset
         self._bounds_lookup['offset_sw']['ct']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_sw']['ct']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': ""},
-             'outer': {'start': "2", 'stop': ""}}
+            {'inner': {'start': "2", 'stop': "{stop}"},
+             'outer': {'start': "2", 'stop': "{stop}"}}
         self._bounds_lookup['offset_sw']['cu']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_sw']['cu']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': "+1"},
-             'outer': {'start': "2", 'stop': ""}}
+            {'inner': {'start': "2", 'stop': "{stop}+1"},
+             'outer': {'start': "2", 'stop': "{stop}"}}
         self._bounds_lookup['offset_sw']['cv']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_sw']['cv']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': ""},
-             'outer': {'start': "2", 'stop': "+1"}}
+            {'inner': {'start': "2", 'stop': "{stop}"},
+             'outer': {'start': "2", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_sw']['cf']['all_pts'] = \
-            {'inner': {'start': "1", 'stop': "+1"},
-             'outer': {'start': "1", 'stop': "+1"}}
+            {'inner': {'start': "1", 'stop': "{stop}+1"},
+             'outer': {'start': "1", 'stop': "{stop}+1"}}
         self._bounds_lookup['offset_sw']['cf']['internal_pts'] = \
-            {'inner': {'start': "2", 'stop': "+1"},
-             'outer': {'start': "2", 'stop': "+1"}}
+            {'inner': {'start': "2", 'stop': "{stop}+1"},
+             'outer': {'start': "2", 'stop': "{stop}+1"}}
         # For offset 'any'
         for gridpt_type in VALID_FIELD_GRID_TYPES:
             for itspace in VALID_ITERATES_OVER:
                 self._bounds_lookup['offset_any'][gridpt_type][itspace] = \
-                    {'inner': {'start': "1", 'stop': ""},
-                     'outer': {'start': "1", 'stop': ""}}
+                    {'inner': {'start': "1", 'stop': "{stop}"},
+                     'outer': {'start': "1", 'stop': "{stop}"}}
         # For 'every' grid-point type
         for offset in SUPPORTED_OFFSETS:
             for itspace in VALID_ITERATES_OVER:
                 self._bounds_lookup[offset]['every'][itspace] = \
-                    {'inner': {'start': "1", 'stop': "+1"},
-                     'outer': {'start': "1", 'stop': "+1"}}
+                    {'inner': {'start': "1", 'stop': "{stop}+1"},
+                     'outer': {'start': "1", 'stop': "{stop}+1"}}
 
     def _upper_bound(self):
         ''' Returns the upper bound of this loop as a string '''
@@ -476,8 +476,9 @@ class GOLoop(Loop):
                 stop = schedule.jloop_stop
 
             if index_offset:
-                stop += (self._bounds_lookup[index_offset][self.field_space]
-                         [self._iteration_space][self._loop_type]["stop"])
+                d_bounds = self._bounds_lookup[index_offset][self.field_space] \
+                    [self._iteration_space][self._loop_type]
+                stop = d_bounds["stop"].format(start='', stop=stop)
             else:
                 stop = "not yet set"
         else:
@@ -525,9 +526,14 @@ class GOLoop(Loop):
             if go_kernels:
                 index_offset = go_kernels[0].index_offset
 
+            if self._loop_type == "inner":
+                stop = schedule.iloop_stop
+            else:
+                stop = schedule.jloop_stop
             if index_offset:
-                start = (self._bounds_lookup[index_offset][self.field_space]
-                         [self._iteration_space][self._loop_type]["start"])
+                d_bounds = self._bounds_lookup[index_offset][self.field_space] \
+                         [self._iteration_space][self._loop_type]
+                start = d_bounds["start"].format(start='', stop=stop)
             else:
                 start = "not yet set"
         else:

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -297,7 +297,9 @@ class GOSchedule(Schedule):
         self._const_loop_bounds = True
 
     def view(self, indent=0):
-        ''' Print a representation of this GOSchedule '''
+        '''Print a representation of this GOSchedule.
+        :param int indent: optional argument indicating the level of
+        indentation to add before outputting the class information.'''
         print(self.indent(indent) + self.coloured_text + "[invoke='" +
               self.invoke.name + "',Constant loop bounds=" +
               str(self._const_loop_bounds) + "]")
@@ -370,6 +372,12 @@ class GOLoop(Loop):
         in the Dynamo api. '''
     def __init__(self, parent=None,
                  topology_name="", loop_type=""):
+        '''Constructs a GOLoop instance.
+        :param parent: Optional parent node (default None).
+        :type parent: :py:class:`psyclone.psyGen.node`
+        :param str topology_name: Optional opology of the loop (unused atm).
+        :param str loop_type: Loop type - must be 'inner' or 'outer'.'''
+
         Loop.__init__(self, parent=parent,
                       valid_loop_types=VALID_LOOP_TYPES)
         self.loop_type = loop_type
@@ -461,7 +469,14 @@ class GOLoop(Loop):
 
     # pylint: disable=too-many-branches
     def _upper_bound(self):
-        ''' Returns the upper bound of this loop as a string '''
+        ''' Returns the upper bound of this loop as a string.
+        This takes the field type and usage of const_loop_bounds
+        into account. In case of const_loop_bounds it will be
+        using the data in self._bounds_lookup to find the appropriate
+        indices depending on offset, field type, and iteration space.
+        All occurences of {start} and {stop} in _bounds_loopup will
+        be replaced with the constant loop boundary variable, e.g.
+        "{stop}+1" will become "istop+1".'''
         schedule = self.ancestor(GOSchedule)
         if schedule.const_loop_bounds:
             index_offset = ""
@@ -520,8 +535,15 @@ class GOLoop(Loop):
 
     # pylint: disable=too-many-branches
     def _lower_bound(self):
-        ''' Returns a string containing the expression for the lower
-        bound of the loop '''
+        ''' Returns the lower bound of this loop as a string.
+        This takes the field type and usage of const_loop_bounds
+        into account. In case of const_loop_bounds it will be
+        using the data in self._bounds_lookup to find the appropriate
+        indices depending on offset, field type, and iteration space.
+        All occurences of {start} and {stop} in _bounds_loopup will
+        be replaced with the constant loop boundary variable, e.g.
+        "{stop}+1" will become "istop+1".'''
+
         schedule = self.ancestor(GOSchedule)
         if schedule.const_loop_bounds:
             index_offset = ""

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -476,7 +476,8 @@ class GOLoop(Loop):
         indices depending on offset, field type, and iteration space.
         All occurences of {start} and {stop} in _bounds_loopup will
         be replaced with the constant loop boundary variable, e.g.
-        "{stop}+1" will become "istop+1".'''
+        "{stop}+1" will become "istop+1" (or "jstop+1 depending on
+        loop type).'''
         schedule = self.ancestor(GOSchedule)
         if schedule.const_loop_bounds:
             index_offset = ""
@@ -542,7 +543,8 @@ class GOLoop(Loop):
         indices depending on offset, field type, and iteration space.
         All occurences of {start} and {stop} in _bounds_loopup will
         be replaced with the constant loop boundary variable, e.g.
-        "{stop}+1" will become "istop+1".'''
+        "{stop}+1" will become "istop+1" (or "jstop+1" depending on
+        loop type).'''
 
         schedule = self.ancestor(GOSchedule)
         if schedule.const_loop_bounds:


### PR DESCRIPTION
Atm it is not possible to specify a single-iteration loop (e.g. only a single halo row or columns), e.g. 
```
do i=1, 1
```
or
```
do j=x_max, x_max
``` 
This pull request makes the loop boundary specification more flexible to allow to specify a loop 'nest' that only covers one (or two, ...) rows/columns:
```
        self._bounds_lookup['offset_ne']['ct']['s_halo'] = \
            {'inner': {'start': "1", 'stop': "{stop}+1"},
             'outer': {'start': '{stop}+1', 'stop':"{stop}+1"}}
```
This will specify an outer loop on a single halo row only.

No new iteration space is actually added in this pull request, though a few pep8/pylint issues were fixed. I'll actually add support for 1-d iteration space in a separate pull request (which then will also add tests).
