### PR TITLE
Use gen_invoke from utils.py everywhere

### DIFF
--- a/src/psyclone/tests/__init__.py
+++ b/src/psyclone/tests/__init__.py
@@ -1,0 +1,33 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2017, Science and Technology Facilities Council
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------

--- a/src/psyclone/tests/dynamo0p3_basis_test.py
+++ b/src/psyclone/tests/dynamo0p3_basis_test.py
@@ -45,7 +45,7 @@ from fparser import api as fpapi
 from psyclone.parse import parse, ParseError
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.dynamo0p3 import DynKernMetadata, DynKern
-import utils
+from  psyclone.tests.utils import code_compiles, print_diffs, TEST_COMPILE
 
 # constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -110,9 +110,9 @@ def test_single_kern_eval(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     # First, check the declarations
     expected_decl = (
@@ -224,9 +224,9 @@ def test_single_kern_eval_op(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     # Kernel writes to an operator, the 'to' space of which is W0. Kernel
     # requires basis on W2 ('from'-space of operator) and diff-basis on
@@ -301,9 +301,9 @@ def test_two_qr(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     expected_declns = (
         "    SUBROUTINE invoke_0(f1, f2, m1, a, m2, istp, g1, g2, n1, b, "
@@ -398,7 +398,7 @@ def test_two_qr(tmpdir, f90, f90flags):
         "n2_proxy%vspace, diff_dim_w3, ndf_w3, diff_basis_w3_qr2)\n"
         "      !\n")
     if expected_code not in gen_code:
-        utils.print_diffs(expected_code, gen_code)
+        print_diffs(expected_code, gen_code)
         assert 0
     expected_kern_call = (
         "      ! Call our kernels\n"
@@ -429,7 +429,7 @@ def test_two_qr(tmpdir, f90, f90flags):
         "diff_basis_w3_qr2)\n"
     )
     if expected_kern_call not in gen_code:
-        utils.print_diffs(expected_kern_call, gen_code)
+        print_diffs(expected_kern_call, gen_code)
         assert 0
 
 
@@ -443,9 +443,9 @@ def test_two_identical_qr(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     expected_init = (
         "      ! Look-up quadrature variables\n"
@@ -526,9 +526,9 @@ def test_anyw2(tmpdir, f90, f90flags):
         generated_code = str(psy.gen)
         print(generated_code)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # Test that generated code compiles
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         output = (
             "      ! Initialise number of DoFs for any_w2\n"
@@ -578,9 +578,9 @@ def test_qr_plus_eval(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # Test that generated code compiles
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     output_decls = (
         "    SUBROUTINE invoke_0(f0, f1, f2, m1, a, m2, istp, qr)\n"
@@ -713,9 +713,9 @@ def test_two_eval_same_space(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # Test that generated code compiles
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     output_init = (
         "      !\n"
@@ -784,9 +784,9 @@ def test_two_eval_diff_space(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     # The first kernel in the invoke (testkern_eval_type) requires basis and
     # diff basis functions for the spaces of the first and second field
@@ -881,9 +881,9 @@ def test_two_eval_same_var_same_space(
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # Test that generated code compiles
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     # We should only get one set of basis and diff-basis functions in the
     # generated code
@@ -923,9 +923,9 @@ def test_two_eval_op_to_space(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # Test that generated code compiles
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     # testkern_eval writes to W0. testkern_eval_op_to writes to W3.
     # testkern_eval requires basis fns on W0 and eval_op_to requires basis
@@ -1040,9 +1040,9 @@ def test_eval_diff_nodal_space(tmpdir, f90, f90flags):
     gen_code = str(psy.gen)
     print(gen_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # Test that generated code compiles
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     expected_alloc = (
         "      ndf_nodal_w3 = f1_proxy%vspace%get_ndf()\n"

--- a/src/psyclone/tests/dynamo0p3_builtins_test.py
+++ b/src/psyclone/tests/dynamo0p3_builtins_test.py
@@ -47,7 +47,7 @@ from psyclone.parse import parse, ParseError
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.configuration import ConfigFactory
 from psyclone import dynamo0p3_builtins
-import utils
+from psyclone.tests.utils import TEST_COMPILE, code_compiles
 
 # constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -426,11 +426,10 @@ def test_X_plus_Y(tmpdir, f90, f90flags, monkeypatch):
                     output_dm_2 = output_dm_2.replace("annexed", "owned")
                 assert output_dm_2 in code
 
-            if utils.TEST_COMPILE:
+            if TEST_COMPILE:
                 # If compilation testing has been enabled (--compile
                 # flag to py.test)
-                assert utils.code_compiles(API, psy, tmpdir,
-                                           f90, f90flags)
+                assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
 
 def test_inc_X_plus_Y(monkeypatch, annexed):
@@ -1802,10 +1801,10 @@ def test_inc_X_powint_n(tmpdir, f90, f90flags, monkeypatch, annexed):
         code = str(psy.gen)
         print(code)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
         if not distmem:
             output = (
@@ -2273,10 +2272,10 @@ def test_builtin_set(tmpdir, f90, f90flags, monkeypatch, annexed):
         code = str(psy.gen)
         print(code)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
         if not distmem:
             output_seq = (

--- a/src/psyclone/tests/dynamo0p3_cma_test.py
+++ b/src/psyclone/tests/dynamo0p3_cma_test.py
@@ -46,7 +46,7 @@ from psyclone.parse import ParseError, parse
 from psyclone.dynamo0p3 import DynKernMetadata
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.gen_kernel_stub import generate
-import utils
+from psyclone.tests.utils import code_compiles, TEST_COMPILE
 
 # Constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -662,10 +662,10 @@ def test_cma_asm(tmpdir, f90, f90flags):
                 "cbanded_map_any_space_1_lma_op1, ndf_any_space_2_lma_op1, "
                 "cbanded_map_any_space_2_lma_op1)") in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_cma_asm_field():
@@ -871,10 +871,10 @@ def test_cma_apply(tmpdir, f90, f90flags):
         # We do not perform halo swaps for operators
         assert "cma_op1_proxy%is_dirty(" not in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_cma_apply_discontinuous_spaces(tmpdir, f90, f90flags):
@@ -955,10 +955,10 @@ def test_cma_apply_discontinuous_spaces(tmpdir, f90, f90flags):
             assert "CALL field_c_proxy%set_dirty()" in code
             assert "cma_op2_proxy%is_dirty(" not in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_cma_apply_same_space():
@@ -1036,10 +1036,10 @@ def test_cma_matrix_matrix(tmpdir, f90, f90flags):
         if distmem:
             assert "_dirty(" not in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_cma_matrix_matrix_2scalars(tmpdir, f90, f90flags):
@@ -1082,10 +1082,10 @@ def test_cma_matrix_matrix_2scalars(tmpdir, f90, f90flags):
         if distmem:
             assert "_dirty(" not in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_cma_multi_kernel(tmpdir, f90, f90flags):
@@ -1165,10 +1165,10 @@ def test_cma_multi_kernel(tmpdir, f90, f90flags):
                 "cma_opc_bandwidth, cma_opc_alpha, cma_opc_beta, "
                 "cma_opc_gamma_m, cma_opc_gamma_p)") in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 # Tests for the kernel-stub generator

--- a/src/psyclone/tests/dynamo0p3_multigrid_test.py
+++ b/src/psyclone/tests/dynamo0p3_multigrid_test.py
@@ -46,10 +46,10 @@ import os
 import pytest
 import fparser
 from fparser import api as fpapi
-import utils
 from psyclone.dynamo0p3 import DynKernMetadata
 from psyclone.parse import ParseError, parse
 from psyclone.psyGen import PSyFactory
+from psyclone.tests.utils import code_compiles, TEST_COMPILE
 
 # constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -231,8 +231,8 @@ def test_field_prolong(tmpdir, f90, f90flags):
         psy = PSyFactory(API, distributed_memory=distmem).create(invoke_info)
         gen_code = str(psy.gen)
 
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
         expected = (
             "      USE prolong_kernel_mod, ONLY: prolong_kernel_code\n"
@@ -311,8 +311,8 @@ def test_field_restrict(tmpdir, f90, f90flags):
         output = str(psy.gen)
         print(output)
 
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
         defs = (
             "      USE restrict_kernel_mod, ONLY: restrict_kernel_code\n"
@@ -412,8 +412,8 @@ def test_restrict_prolong_chain(tmpdir, f90, f90flags):
         psy = PSyFactory(API, distributed_memory=distmem).create(invoke_info)
         output = str(psy.gen)
 
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
         expected = (
             "      ! Look-up mesh objects and loop limits for inter-grid "
@@ -585,8 +585,8 @@ def test_prolong_vector(tmpdir, f90, f90flags):
     output = str(psy.gen)
     print(output)
 
-    if utils.TEST_COMPILE:
-        assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+    if TEST_COMPILE:
+        assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
     assert "TYPE(field_type), intent(inout) :: field1(3)" in output
     assert "TYPE(field_proxy_type) field1_proxy(3)" in output

--- a/src/psyclone/tests/dynamo0p3_quadrature_test.py
+++ b/src/psyclone/tests/dynamo0p3_quadrature_test.py
@@ -45,7 +45,7 @@ from fparser import api as fpapi
 from psyclone.parse import parse
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.dynamo0p3 import DynKernMetadata, DynKern
-import utils
+from psyclone.tests.utils import code_compiles, TEST_COMPILE
 
 # constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -63,8 +63,8 @@ def test_field_xyoz(tmpdir, f90, f90flags):
     generated_code = str(psy.gen)
     print(generated_code)
 
-    if utils.TEST_COMPILE:
-        assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+    if TEST_COMPILE:
+        assert code_compiles(API, psy, tmpdir, f90, f90flags)
 
     output_decls = (
         "    SUBROUTINE invoke_0_testkern_qr_type(f1, f2, m1, a, m2, istp,"
@@ -221,8 +221,8 @@ def test_field_qr_deref(tmpdir, f90, f90flags):
         psy = PSyFactory("dynamo0.3",
                          distributed_memory=dist_mem).create(invoke_info)
 
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(API, psy, tmpdir, f90, f90flags)
         gen = str(psy.gen)
         print(gen)
         assert (

--- a/src/psyclone/tests/dynamo0p3_test.py
+++ b/src/psyclone/tests/dynamo0p3_test.py
@@ -53,7 +53,7 @@ from psyclone.dynamo0p3 import DynKernMetadata, DynKern, \
 from psyclone.transformations import LoopFuseTrans
 from psyclone.gen_kernel_stub import generate
 from psyclone.configuration import ConfigFactory
-import utils
+from psyclone.tests.utils import code_compiles, TEST_COMPILE
 
 # constants
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -626,9 +626,9 @@ def test_field(tmpdir, f90, f90flags):
                            api=TEST_API)
     psy = PSyFactory(TEST_API, distributed_memory=False).create(invoke_info)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     generated_code = psy.gen
     output = (
@@ -833,10 +833,10 @@ def test_field_fs(tmpdir, f90, f90flags):
                            api=TEST_API)
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     generated_code = psy.gen
     output = (
@@ -1522,9 +1522,9 @@ def test_operator_different_spaces(tmpdir, f90, f90flags):
     generated_code = str(psy.gen)
     print(generated_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     decl_output = (
         "    SUBROUTINE invoke_0_assemble_weak_derivative_w3_w2_kernel_type"
@@ -1668,9 +1668,9 @@ def test_operator_nofield(tmpdir, f90, f90flags):
     gen_code_str = str(psy.gen)
     print(gen_code_str)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     assert gen_code_str.find("SUBROUTINE invoke_0_testkern_operator_"
                              "nofield_type(mm_w2, chi, qr)") != -1
@@ -1700,9 +1700,9 @@ def test_operator_nofield_different_space(
     gen = str(psy.gen)
     print(gen)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     assert "mesh => my_mapping%get_mesh()" in gen
     assert "nlayers = my_mapping_proxy%fs_from%get_nlayers()" in gen
@@ -1747,8 +1747,8 @@ def test_operator_nofield_scalar_deref(
         gen = str(psy.gen)
         print(gen)
 
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
         if dist_mem:
             assert "mesh => opbox_my_mapping%get_mesh()" in gen
@@ -1780,8 +1780,8 @@ def test_operator_orientation(tmpdir, f90, f90flags):
     gen_str = str(psy.gen)
     print(gen_str)
 
-    if utils.TEST_COMPILE:
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+    if TEST_COMPILE:
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     assert gen_str.find("SUBROUTINE invoke_0_testkern_operator"
                         "_orient_type(mm_w1, chi, qr)") != -1
@@ -1813,8 +1813,8 @@ def test_op_orient_different_space(
     gen_str = str(psy.gen)
     print(gen_str)
 
-    if utils.TEST_COMPILE:
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+    if TEST_COMPILE:
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     assert (
         "INTEGER, pointer :: orientation_w1(:) => null(), orientation_w2(:)"
@@ -1849,8 +1849,8 @@ def test_operator_deref(tmpdir, f90, f90flags):
                          distributed_memory=dist_mem).create(invoke_info)
         generated_code = str(psy.gen)
         print(generated_code)
-        if utils.TEST_COMPILE:
-            assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        if TEST_COMPILE:
+            assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
         assert generated_code.find("SUBROUTINE invoke_0_testkern_operator"
                                    "_type(mm_w0_op, chi, a, qr)") != -1
@@ -1913,9 +1913,9 @@ def test_any_space_1(tmpdir, f90, f90flags):
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
     print(generated_code)
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
     assert ("INTEGER, pointer :: "
             "map_any_space_1_a(:,:) => null(), "
@@ -1998,9 +1998,9 @@ def test_op_any_space_different_space_2(
     generated_code = str(psy.gen)
     print(generated_code)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
     assert "ndf_any_space_1_b = b_proxy%fs_to%get_ndf()" in generated_code
     assert "dim_any_space_1_b = b_proxy%fs_to%get_dim_space()" in \
         generated_code
@@ -2204,10 +2204,10 @@ def test_kernel_specific(tmpdir, f90, f90flags):
         "boundary_dofs)")
     assert output6 not in generated_code
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_multi_kernel_specific(tmpdir, f90, f90flags):
@@ -2271,10 +2271,10 @@ def test_multi_kernel_specific(tmpdir, f90, f90flags):
         "boundary_dofs_1)")
     assert output10 not in generated_code
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_field_bc_kernel(tmpdir, f90, f90flags):
@@ -2299,10 +2299,10 @@ def test_field_bc_kernel(tmpdir, f90, f90flags):
         "undf_any_space_1_a, map_any_space_1_a(:,cell), boundary_dofs)")
     assert str(generated_code).find(output3) != -1
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_bc_kernel_field_only(monkeypatch):
@@ -2358,10 +2358,10 @@ def test_operator_bc_kernel(tmpdir, f90, f90flags):
         "ndf_any_space_2_op_a, boundary_dofs)")
     assert output3 in generated_code
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_operator_bc_kernel_fld_err(monkeypatch):
@@ -2559,9 +2559,9 @@ def test_multikern_invoke_any_space(tmpdir, f90, f90flags):
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     gen = str(psy.gen)
     print(gen)
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
     assert ("INTEGER, pointer :: map_any_space_1_f1(:,:) => null(), "
             "map_any_space_1_f2(:,:) => null(), "
             "map_any_space_2_f1(:,:) => null(), "
@@ -2605,9 +2605,9 @@ def test_mkern_invoke_multiple_any_spaces(
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     gen = str(psy.gen)
     print(gen)
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
     assert "ndf_any_space_1_f1 = f1_proxy%vspace%get_ndf()" in gen
     assert ("CALL qr%compute_function(BASIS, f1_proxy%vspace, "
             "dim_any_space_1_f1, ndf_any_space_1_f1, "
@@ -6212,10 +6212,10 @@ def test_itn_space_write_w2v_w1(tmpdir, f90, f90flags):
                 "      DO cell=1,m2_proxy%vspace%get_ncell()\n")
             assert output in generated_code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+            assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_itn_space_fld_and_op_writers(tmpdir, f90, f90flags):
@@ -6244,10 +6244,10 @@ def test_itn_space_fld_and_op_writers(tmpdir, f90, f90flags):
                 "      DO cell=1,op1_proxy%fs_from%get_ncell()\n")
             assert output in generated_code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+            assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_itn_space_any_w3(tmpdir, f90, f90flags):
@@ -6273,10 +6273,10 @@ def test_itn_space_any_w3(tmpdir, f90, f90flags):
                 "      DO cell=1,f1_proxy%vspace%get_ncell()\n")
             assert output in generated_code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled
             # (--compile --f90="<compiler_name>" flags to py.test)
-            assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+            assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_itn_space_any_w1():
@@ -6665,10 +6665,10 @@ def test_no_halo_for_discontinous(tmpdir, f90, f90flags):
     print(result)
     assert "halo_exchange" not in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_halo_for_discontinuous(tmpdir, f90, f90flags, monkeypatch, annexed):
@@ -6705,10 +6705,10 @@ def test_halo_for_discontinuous(tmpdir, f90, f90flags, monkeypatch, annexed):
         assert "IF (m1_proxy%is_dirty(depth=1)) THEN" in result
         assert "CALL m1_proxy%halo_exchange(depth=1)" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_halo_for_discontinuous_2(tmpdir, f90, f90flags, monkeypatch, annexed):
@@ -6742,10 +6742,10 @@ def test_halo_for_discontinuous_2(tmpdir, f90, f90flags, monkeypatch, annexed):
         assert "IF (m1_proxy%is_dirty(depth=1)) THEN" in result
         assert "CALL m1_proxy%halo_exchange(depth=1)" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_arg_discontinuous(monkeypatch, annexed):
@@ -7013,10 +7013,10 @@ def test_HaloReadAccess_discontinuous_field(tmpdir, f90, f90flags):
     assert halo_access.literal_depth == 0
     assert halo_access.stencil_type is None
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
+        assert code_compiles(TEST_API, psy, tmpdir, f90, f90flags)
 
 
 def test_loop_cont_read_inv_bound(monkeypatch, annexed):
@@ -7186,10 +7186,10 @@ def test_no_halo_exchange_annex_dofs(tmpdir, f90, f90flags, monkeypatch,
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     result = str(psy.gen)
     print(result)
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles(TEST_API, psy, tmpdir,
+        assert code_compiles(TEST_API, psy, tmpdir,
                                    f90, f90flags)
     if annexed:
         assert "CALL f1_proxy%halo_exchange" not in result

--- a/src/psyclone/tests/dynamo0p3_transformations_test.py
+++ b/src/psyclone/tests/dynamo0p3_transformations_test.py
@@ -51,7 +51,7 @@ from psyclone.transformations import TransformationError, \
     MoveTrans, \
     Dynamo0p3RedundantComputationTrans
 from psyclone.configuration import ConfigFactory
-import utils
+from psyclone.tests.utils import TEST_COMPILE, code_compiles
 
 
 # The version of the API that the tests in this file
@@ -107,10 +107,10 @@ def test_colour_trans_declarations(tmpdir, f90, f90flags):
             assert "integer, pointer :: cmap(:,:), ncp_colour(:)" in gen
         assert "integer colour" in gen
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colour_trans(tmpdir, f90, f90flags):
@@ -182,10 +182,10 @@ def test_colour_trans(tmpdir, f90, f90flags):
             assert dirty_str in gen
             assert gen.count("set_dirty()") == 1
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colour_trans_operator(tmpdir, f90, f90flags):
@@ -219,10 +219,10 @@ def test_colour_trans_operator(tmpdir, f90, f90flags):
         # check the first argument is a colourmap lookup
         assert "CALL testkern_operator_code(cmap(colour, cell), nlayers" in gen
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colour_trans_cma_operator(tmpdir, f90, f90flags):
@@ -283,10 +283,10 @@ def test_colour_trans_cma_operator(tmpdir, f90, f90flags):
             "        END DO \n"
             "      END DO \n") in gen
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colour_trans_stencil():
@@ -495,10 +495,10 @@ def test_omp_colour_trans(tmpdir, f90, f90flags):
 
         assert output in code
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_omp_colour_orient_trans():
@@ -656,11 +656,11 @@ def test_check_seq_colours_omp_do(tmpdir, f90, f90flags):
         assert "target loop is over colours" in str(excinfo.value)
         assert "must be computed serially" in str(excinfo.value)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test) This test checks the code without OpenMP as
             # this transformation fails
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colouring_after_openmp():
@@ -1241,10 +1241,10 @@ def test_loop_fuse_omp_rwdisc(tmpdir, f90, f90flags, monkeypatch, annexed):
         assert cell_enddo_idx > call2_idx
         assert omp_endpara_idx - cell_enddo_idx == 1
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_fuse_colour_loops(tmpdir, f90, f90flags):
@@ -1372,10 +1372,10 @@ def test_fuse_colour_loops(tmpdir, f90, f90flags):
             assert set_dirty_str in code
             assert code.count("set_dirty()") == 2
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_loop_fuse_cma():
@@ -4259,10 +4259,10 @@ def test_rc_discontinuous_depth(tmpdir, f90, f90flags, monkeypatch, annexed):
     assert ("      CALL m2_proxy%set_dirty()\n"
             "      CALL m2_proxy%set_clean(3)") in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_discontinuous_no_depth(monkeypatch, annexed):
@@ -4327,10 +4327,10 @@ def test_rc_all_discontinuous_depth(tmpdir, f90, f90flags):
     assert "CALL f1_proxy%set_dirty()" in result
     assert "CALL f1_proxy%set_clean(3)" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_discontinuous_no_depth(tmpdir, f90, f90flags):
@@ -4358,10 +4358,10 @@ def test_rc_all_discontinuous_no_depth(tmpdir, f90, f90flags):
     assert "DO cell=1,mesh%get_last_halo_cell()" in result
     assert "CALL f1_proxy%set_clean(mesh%get_halo_depth())" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_discontinuous_vector_depth(tmpdir, f90, f90flags):
@@ -4392,10 +4392,10 @@ def test_rc_all_discontinuous_vector_depth(tmpdir, f90, f90flags):
         assert "CALL f1_proxy({0})%set_dirty()".format(idx) in result
         assert "CALL f1_proxy({0})%set_clean(3)".format(idx) in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_discontinuous_vector_no_depth(tmpdir, f90, f90flags):
@@ -4426,10 +4426,10 @@ def test_rc_all_discontinuous_vector_no_depth(tmpdir, f90, f90flags):
         assert ("CALL f1_proxy({0})%set_clean(mesh%get_halo_"
                 "depth())".format(idx)) in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_disc_prev_depend_depth(tmpdir, f90, f90flags):
@@ -4460,10 +4460,10 @@ def test_rc_all_disc_prev_depend_depth(tmpdir, f90, f90flags):
     assert "CALL f3_proxy%set_dirty()" in result
     assert "CALL f3_proxy%set_clean(3)" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_disc_prev_depend_no_depth():
@@ -4525,10 +4525,10 @@ def test_rc_all_disc_prev_dep_depth_vector(tmpdir, f90, f90flags):
         assert "CALL f3_proxy({0})%set_dirty()".format(idx) in result
         assert "CALL f3_proxy({0})%set_clean(3)".format(idx) in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_disc_prev_dep_no_depth_vect(tmpdir, f90, f90flags):
@@ -4561,10 +4561,10 @@ def test_rc_all_disc_prev_dep_no_depth_vect(tmpdir, f90, f90flags):
         assert ("CALL f3_proxy({0})%set_clean(mesh%get_halo_depth())".
                 format(idx)) in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_all_disc_prev_dep_no_depth_vect_readwrite(tmpdir, f90, f90flags):
@@ -4603,10 +4603,10 @@ def test_rc_all_disc_prev_dep_no_depth_vect_readwrite(tmpdir, f90, f90flags):
         assert ("CALL f3_proxy({0})%set_clean(mesh%get_halo_depth())".
                 format(idx)) in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_dofs_depth():
@@ -5004,10 +5004,10 @@ def test_rc_remove_halo_exchange(tmpdir, f90, f90flags, monkeypatch):
     assert "IF (m1_proxy%is_dirty(depth=1)) THEN" in result
     assert "CALL m1_proxy%halo_exchange(depth=1)" in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
     #
     invoke = psy.invokes.invoke_list[0]
@@ -5077,10 +5077,10 @@ def test_rc_max_remove_halo_exchange(tmpdir, f90, f90flags):
     # bother as that is not relevant to this test.
     assert "CALL f4_proxy%halo_exchange(depth=1)" not in result
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled
         # (--compile --f90="<compiler_name>" flags to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_continuous_halo_remove():
@@ -5737,10 +5737,10 @@ def test_rc_colour(tmpdir, f90, f90flags):
         "      CALL f1_proxy%set_dirty()\n"
         "      CALL f1_proxy%set_clean(1)" in result)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_max_colour(tmpdir, f90, f90flags):
@@ -5788,10 +5788,10 @@ def test_rc_max_colour(tmpdir, f90, f90flags):
         "      CALL f1_proxy%set_dirty()\n"
         "      CALL f1_proxy%set_clean(mesh%get_halo_depth()-1)" in result)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_colour_discontinuous():
@@ -5874,10 +5874,10 @@ def test_rc_then_colour(tmpdir, f90, f90flags):
         "      CALL f1_proxy%set_dirty()\n"
         "      CALL f1_proxy%set_clean(2)" in result)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_rc_then_colour2(tmpdir, f90, f90flags):
@@ -5931,10 +5931,10 @@ def test_rc_then_colour2(tmpdir, f90, f90flags):
         "      CALL f1_proxy%set_dirty()\n"
         "      CALL f1_proxy%set_clean(mesh%get_halo_depth()-1)" in result)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_loop_fuse_then_rc(tmpdir, f90, f90flags):
@@ -5993,10 +5993,10 @@ def test_loop_fuse_then_rc(tmpdir, f90, f90flags):
         "      CALL f1_proxy%set_dirty()\n"
         "      CALL f1_proxy%set_clean(mesh%get_halo_depth()-1)" in result)
 
-    if utils.TEST_COMPILE:
+    if TEST_COMPILE:
         # If compilation testing has been enabled (--compile flag
         # to py.test)
-        assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+        assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
 
 def test_haloex_colouring(tmpdir, f90, f90flags):
@@ -6061,10 +6061,10 @@ def test_haloex_colouring(tmpdir, f90, f90flags):
         halo_exchange = schedule.children[4]
         check_halo_exchange(halo_exchange)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         print("OK for iteration ", idx)
 
@@ -6143,10 +6143,10 @@ def test_haloex_rc1_colouring(tmpdir, f90, f90flags):
         halo_exchange = schedule.children[4]
         check_halo_exchange(halo_exchange)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         print("OK for iteration ", idx)
 
@@ -6228,10 +6228,10 @@ def test_haloex_rc2_colouring(tmpdir, f90, f90flags):
         halo_exchange = schedule.children[4]
         check_halo_exchange(halo_exchange)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         print("OK for iteration ", idx)
 
@@ -6312,10 +6312,10 @@ def test_haloex_rc3_colouring(tmpdir, f90, f90flags):
         halo_exchange = schedule.children[4]
         check_halo_exchange(halo_exchange)
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         print("OK for iteration ", idx)
 
@@ -6384,10 +6384,10 @@ def test_haloex_rc4_colouring(tmpdir, f90, f90flags):
         assert isinstance(schedule.children[0], DynHaloExchange)
         assert schedule.children[0].field.name == "f1"
 
-        if utils.TEST_COMPILE:
+        if TEST_COMPILE:
             # If compilation testing has been enabled (--compile flag
             # to py.test)
-            assert utils.code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
+            assert code_compiles("dynamo0.3", psy, tmpdir, f90, f90flags)
 
         print("OK for iteration ", idx)
 

--- a/src/psyclone/tests/f2pygen_test.py
+++ b/src/psyclone/tests/f2pygen_test.py
@@ -41,7 +41,7 @@ from psyclone.f2pygen import ModuleGen, CommentGen, SubroutineGen, DoGen, \
     CallGen, AllocateGen, DeallocateGen, IfThenGen, DeclGen, TypeDeclGen,\
     CharDeclGen, ImplicitNoneGen, UseGen, DirectiveGen, AssignGen
 from psyclone.psyGen import InternalError
-import utils
+from psyclone.tests.utils import count_lines, line_number, string_compiles
 
 # Fortran we have to add to some of the generated code in order to
 # perform compilation checks.
@@ -122,8 +122,8 @@ def test_subroutine_var_with_implicit_none():
     module.add(subroutine)
     subroutine.add(DeclGen(subroutine, datatype="integer",
                            entity_decls=["var1"]))
-    idx_var = utils.line_number(subroutine.root, "INTEGER var1")
-    idx_imp_none = utils.line_number(subroutine.root, "IMPLICIT NONE")
+    idx_var = line_number(subroutine.root, "INTEGER var1")
+    idx_imp_none = line_number(subroutine.root, "IMPLICIT NONE")
     print(str(module.root))
     assert idx_var - idx_imp_none == 1, \
         "variable declation must be after implicit none"
@@ -140,8 +140,8 @@ def test_subroutine_var_intent_in_with_directive():
                                 "parallel", ""))
     subroutine.add(DeclGen(subroutine, datatype="integer",
                            intent="in", entity_decls=["var1"]))
-    idx_par = utils.line_number(subroutine.root, "!$omp parallel")
-    idx_var = utils.line_number(subroutine.root,
+    idx_par = line_number(subroutine.root, "!$omp parallel")
+    idx_var = line_number(subroutine.root,
                                 "INTEGER, intent(in) :: var1")
     assert idx_par - idx_var == 1, \
         "variable declaration must be before directive"
@@ -218,8 +218,8 @@ def test_if_add_use():
     if_statement.add(UseGen(if_statement, name="dibna"))
     module.add(if_statement)
     print(str(module.root))
-    use_line = utils.line_number(module.root, "USE dibna")
-    if_line = utils.line_number(module.root, "IF (" + clause + ") THEN")
+    use_line = line_number(module.root, "USE dibna")
+    if_line = line_number(module.root, "IF (" + clause + ") THEN")
     # The use statement must come before the if..then block
     assert use_line < if_line
 
@@ -368,8 +368,8 @@ def test_imp_none_in_module():
     correct location'''
     module = ModuleGen(name="testmodule", implicitnone=False)
     module.add(ImplicitNoneGen(module))
-    in_idx = utils.line_number(module.root, "IMPLICIT NONE")
-    cont_idx = utils.line_number(module.root, "CONTAINS")
+    in_idx = line_number(module.root, "IMPLICIT NONE")
+    cont_idx = line_number(module.root, "CONTAINS")
     assert in_idx > -1, "IMPLICIT NONE not found"
     assert cont_idx > -1, "CONTAINS not found"
     assert cont_idx - in_idx == 1, "CONTAINS is not on the line after" +\
@@ -386,7 +386,7 @@ def test_imp_none_in_module_with_decs():
     module.add(TypeDeclGen(module, datatype="my_type",
                            entity_decls=["type1"]))
     module.add(ImplicitNoneGen(module))
-    in_idx = utils.line_number(module.root, "IMPLICIT NONE")
+    in_idx = line_number(module.root, "IMPLICIT NONE")
     assert in_idx == 1
 
 
@@ -401,7 +401,7 @@ def test_imp_none_in_module_with_use_and_decs():
                            entity_decls=["type1"]))
     module.add(UseGen(module, "fred"))
     module.add(ImplicitNoneGen(module))
-    in_idx = utils.line_number(module.root, "IMPLICIT NONE")
+    in_idx = line_number(module.root, "IMPLICIT NONE")
     assert in_idx == 2
 
 
@@ -419,7 +419,7 @@ def test_imp_none_in_module_with_use_and_decs_and_comments():
         module.add(CommentGen(module, " hello "+str(idx)),
                    position=["before_index", 2*idx])
     module.add(ImplicitNoneGen(module))
-    in_idx = utils.line_number(module.root, "IMPLICIT NONE")
+    in_idx = line_number(module.root, "IMPLICIT NONE")
     assert in_idx == 3
 
 
@@ -428,7 +428,7 @@ def test_imp_none_in_module_already_exists():
     already exists'''
     module = ModuleGen(name="testmodule", implicitnone=True)
     module.add(ImplicitNoneGen(module))
-    count = utils.count_lines(module.root, "IMPLICIT NONE")
+    count = count_lines(module.root, "IMPLICIT NONE")
     print(str(module.root))
     assert count == 1, \
         "There should only be one instance of IMPLICIT NONE"
@@ -455,7 +455,7 @@ def test_imp_none_in_subroutine_with_decs():
     sub.add(TypeDeclGen(sub, datatype="my_type",
                         entity_decls=["type1"]))
     sub.add(ImplicitNoneGen(module))
-    in_idx = utils.line_number(sub.root, "IMPLICIT NONE")
+    in_idx = line_number(sub.root, "IMPLICIT NONE")
     assert in_idx == 1
 
 
@@ -472,7 +472,7 @@ def test_imp_none_in_subroutine_with_use_and_decs():
                         entity_decls=["type1"]))
     sub.add(UseGen(sub, "fred"))
     sub.add(ImplicitNoneGen(sub))
-    in_idx = utils.line_number(sub.root, "IMPLICIT NONE")
+    in_idx = line_number(sub.root, "IMPLICIT NONE")
     assert in_idx == 2
 
 
@@ -492,7 +492,7 @@ def test_imp_none_in_subroutine_with_use_and_decs_and_comments():
         sub.add(CommentGen(sub, " hello "+str(idx)),
                 position=["before_index", 2*idx])
     sub.add(ImplicitNoneGen(sub))
-    in_idx = utils.line_number(sub.root, "IMPLICIT NONE")
+    in_idx = line_number(sub.root, "IMPLICIT NONE")
     assert in_idx == 3
 
 
@@ -503,7 +503,7 @@ def test_imp_none_in_subroutine_already_exists():
     sub = SubroutineGen(module, name="testsubroutine", implicitnone=True)
     module.add(sub)
     sub.add(ImplicitNoneGen(sub))
-    count = utils.count_lines(sub.root, "IMPLICIT NONE")
+    count = count_lines(sub.root, "IMPLICIT NONE")
     assert count == 1, \
         "There should only be one instance of IMPLICIT NONE"
 
@@ -526,7 +526,7 @@ def test_subgen_implicit_none_false():
     module = ModuleGen(name="testmodule")
     sub = SubroutineGen(module, name="testsubroutine", implicitnone=False)
     module.add(sub)
-    count = utils.count_lines(sub.root, "IMPLICIT NONE")
+    count = count_lines(sub.root, "IMPLICIT NONE")
     assert count == 0, "IMPLICIT NONE SHOULD NOT EXIST"
 
 
@@ -536,7 +536,7 @@ def test_subgen_implicit_none_true():
     module = ModuleGen(name="testmodule")
     sub = SubroutineGen(module, name="testsubroutine", implicitnone=True)
     module.add(sub)
-    count = utils.count_lines(sub.root, "IMPLICIT NONE")
+    count = count_lines(sub.root, "IMPLICIT NONE")
     assert count == 1, "IMPLICIT NONE SHOULD EXIST"
 
 
@@ -546,7 +546,7 @@ def test_subgen_implicit_none_default():
     module = ModuleGen(name="testmodule")
     sub = SubroutineGen(module, name="testsubroutine")
     module.add(sub)
-    count = utils.count_lines(sub.root, "IMPLICIT NONE")
+    count = count_lines(sub.root, "IMPLICIT NONE")
     assert count == 0, "IMPLICIT NONE SHOULD NOT EXIST BY DEFAULT"
 
 
@@ -640,7 +640,7 @@ def test_basegen_append():
     sub.add(DeclGen(sub, datatype="integer",
                     entity_decls=["var1"]))
     sub.add(CommentGen(sub, " hello"), position=["append"])
-    cindex = utils.line_number(sub.root, "hello")
+    cindex = line_number(sub.root, "hello")
     assert cindex == 3
 
 
@@ -654,7 +654,7 @@ def test_basegen_append_default():
     BaseGen.add(sub, DeclGen(sub, datatype="integer",
                              entity_decls=["var1"]))
     BaseGen.add(sub, CommentGen(sub, " hello"))
-    cindex = utils.line_number(sub.root, "hello")
+    cindex = line_number(sub.root, "hello")
     assert cindex == 3
 
 
@@ -666,7 +666,7 @@ def test_basegen_first():
     sub.add(DeclGen(sub, datatype="integer",
                     entity_decls=["var1"]))
     sub.add(CommentGen(sub, " hello"), position=["first"])
-    cindex = utils.line_number(sub.root, "hello")
+    cindex = line_number(sub.root, "hello")
     assert cindex == 1
 
 
@@ -680,11 +680,11 @@ def test_basegen_after_index():
     sub.add(DeclGen(sub, datatype="integer",
                     entity_decls=["var2"]))
     sub.add(CommentGen(sub, " hello"), position=["after_index", 1])
-    # The code checked by utils.line_number() *includes* the SUBROUTINE
+    # The code checked by line_number() *includes* the SUBROUTINE
     # statement (which is obviously not a child of the SubroutineGen
     # object) and therefore the index it returns is 1 greater than we
     # might expect.
-    assert utils.line_number(sub.root, "hello") == 3
+    assert line_number(sub.root, "hello") == 3
 
 
 def test_basegen_before_error():
@@ -848,7 +848,7 @@ def test_progunitgen_multiple_generic_use():
     module.add(sub)
     sub.add(UseGen(sub, name="fred"))
     sub.add(UseGen(sub, name="fred"))
-    assert utils.count_lines(sub.root, "USE fred") == 1
+    assert count_lines(sub.root, "USE fred") == 1
 
 
 def test_progunitgen_multiple_use1():
@@ -859,7 +859,7 @@ def test_progunitgen_multiple_use1():
     module.add(sub)
     sub.add(UseGen(sub, name="fred"))
     sub.add(UseGen(sub, name="fred", only=True, funcnames=["astaire"]))
-    assert utils.count_lines(sub.root, "USE fred") == 1
+    assert count_lines(sub.root, "USE fred") == 1
 
 
 def test_progunitgen_multiple_use2():
@@ -873,7 +873,7 @@ def test_progunitgen_multiple_use2():
     module.add(sub)
     sub.add(UseGen(sub, name="fred", only=True, funcnames=["astaire"]))
     sub.add(UseGen(sub, name="fred"))
-    assert utils.count_lines(sub.root, "USE fred") == 2
+    assert count_lines(sub.root, "USE fred") == 2
 
 
 def test_progunit_multiple_use3():
@@ -894,7 +894,7 @@ def test_progunit_multiple_use3():
         "      USE fred, ONLY: d\n"
         "      USE fred, ONLY: a, b, c")
     assert expected in gen
-    assert utils.count_lines(sub.root, "USE fred") == 2
+    assert count_lines(sub.root, "USE fred") == 2
     # ensure that the input list does not get modified
     assert funcnames == ["c", "d"]
 
@@ -909,8 +909,8 @@ def test_adduse_empty_only():
     from psyclone.f2pygen import adduse
     # Add a use statement with only=True but an empty list of entities
     adduse("fred", sub.root, only=True, funcnames=[])
-    assert utils.count_lines(sub.root, "USE fred") == 1
-    assert utils.count_lines(sub.root, "USE fred, only") == 0
+    assert count_lines(sub.root, "USE fred") == 1
+    assert count_lines(sub.root, "USE fred, only") == 0
 
 
 def test_adduse():
@@ -984,7 +984,7 @@ def test_decl_logical(tmpdir, f90, f90flags):
     assert "logical var2" in gen
     assert gen.count("logical first_time") == 1
     # Check that the generated code compiles (if enabled)
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
 
 
 def test_decl_char(tmpdir, f90, f90flags):
@@ -1006,7 +1006,7 @@ def test_decl_char(tmpdir, f90, f90flags):
     assert "character(len=28) :: my_string3='this is a string'" in gen
     # Check that the generated Fortran compiles (if compilation testing is
     # enabled)
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
     # Finally, check initialisation using a variable name. Since this
     # variable isn't declared, we can't include it in the compilation test.
     sub.add(CharDeclGen(sub, length="my_len",
@@ -1037,7 +1037,7 @@ def test_decl_save(tmpdir, f90, f90flags):
     # manually add a declaration for "field_type".
     parts = gen.split("implicit none")
     gen = parts[0] + "implicit none\n" + TYPEDECL + parts[1]
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
 
 
 def test_decl_target(tmpdir, f90, f90flags):
@@ -1061,7 +1061,7 @@ def test_decl_target(tmpdir, f90, f90flags):
     # must manually add a definition for the derived type.
     parts = gen.split("implicit none")
     gen = parts[0] + "implicit none\n" + TYPEDECL + parts[1]
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
 
 
 def test_decl_initial_vals(tmpdir, f90, f90flags):
@@ -1089,7 +1089,7 @@ def test_decl_initial_vals(tmpdir, f90, f90flags):
     assert "integer, save :: ivar=1" in gen
     assert "real, save :: var=1.0" in gen
     # Check that the generated code compiles (if enabled)
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
 
     # Multiple variables
     sub.add(DeclGen(sub, datatype="integer", save=True,
@@ -1106,7 +1106,7 @@ def test_decl_initial_vals(tmpdir, f90, f90flags):
     assert "integer, save :: ivar1=1, ivar2=2" in gen
     assert "real, save :: var1=1.0, var2=-1.0" in gen
     # Check that the generated code compiles (if enabled)
-    assert utils.string_compiles(gen, tmpdir, f90, f90flags)
+    assert string_compiles(gen, tmpdir, f90, f90flags)
 
 
 def test_declgen_invalid_vals():
@@ -1406,7 +1406,7 @@ def test_do_loop_with_increment():
     module.add(sub)
     dogen = DoGen(sub, "it", "1", "10", step="2")
     sub.add(dogen)
-    count = utils.count_lines(sub.root, "DO it=1,10,2")
+    count = count_lines(sub.root, "DO it=1,10,2")
     assert count == 1
 
 
@@ -1422,8 +1422,8 @@ def test_do_loop_add_after():
     dogen.add(assign1)
     assign2 = AssignGen(dogen, lhs="sad", rhs=".FALSE.")
     dogen.add(assign2, position=["before", assign1.root])
-    a1_line = utils.line_number(sub.root, "happy = ")
-    a2_line = utils.line_number(sub.root, "sad = ")
+    a1_line = line_number(sub.root, "happy = ")
+    a2_line = line_number(sub.root, "sad = ")
     assert a1_line > a2_line
 
 

--- a/src/psyclone/tests/gocean1p0_transformations_test.py
+++ b/src/psyclone/tests/gocean1p0_transformations_test.py
@@ -49,7 +49,7 @@ from psyclone.transformations import TransformationError, \
     GOceanOMPLoopTrans, KernelModuleInlineTrans, GOceanLoopFuseTrans, \
     ACCParallelTrans, ACCDataTrans, ACCLoopTrans
 from psyclone.generator import GenerationError
-from utils import count_lines, get_invoke
+from psyclone.tests.utils import count_lines, get_invoke
 
 # The version of the PSyclone API that the tests in this file
 # exercise
@@ -60,9 +60,8 @@ def test_const_loop_bounds_not_schedule():
     ''' Check that we raise an error if we attempt to apply the
     constant loop-bounds transformation to something that is
     not a Schedule '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test11_different_iterates_over_one_invoke.f90"), API, 0)
+    _, invoke = get_invoke("test11_different_iterates_over_one_invoke.f90",
+                           API, idx=0)
     schedule = invoke.schedule
     cbtrans = GOConstLoopBoundsTrans()
 
@@ -73,9 +72,8 @@ def test_const_loop_bounds_not_schedule():
 def test_const_loop_bounds_toggle():
     ''' Check that we can toggle constant loop bounds on and off and
     that the default behaviour is "on" '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test11_different_iterates_over_one_invoke.f90"), API, 0)
+    psy, invoke = get_invoke("test11_different_iterates_over_one_invoke.f90",
+                             API, idx=0);
     schedule = invoke.schedule
     cbtrans = GOConstLoopBoundsTrans()
 
@@ -118,9 +116,8 @@ def test_const_loop_bounds_invalid_offset():
     ''' Test that we raise an appropriate error if we attempt to generate
     code with constant loop bounds for a kernel that expects an
     unsupported grid-offset '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test26_const_bounds_invalid_offset.f90"), API, 0)
+    psy, invoke = get_invoke("test26_const_bounds_invalid_offset.f90",
+                             API, idx=0)
     cbtrans = GOConstLoopBoundsTrans()
     schedule = invoke.schedule
     newsched, _ = cbtrans.apply(schedule, const_bounds=True)
@@ -132,9 +129,8 @@ def test_const_loop_bounds_invalid_offset():
 def test_loop_fuse_different_iterates_over():
     ''' Test that an appropriate error is raised when we attempt to
     fuse two loops that have differing values of ITERATES_OVER '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test11_different_iterates_over_one_invoke.f90"), API, 0)
+    _, invoke = get_invoke("test11_different_iterates_over_one_invoke.f90",
+                           API, idx=0)
     schedule = invoke.schedule
     lftrans = LoopFuseTrans()
     cbtrans = GOConstLoopBoundsTrans()
@@ -155,9 +151,7 @@ def test_loop_fuse_different_iterates_over():
 
 def test_loop_fuse_unexpected_error():
     ''' Test that we catch an unexpected error when loop fusing '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test14_module_inline_same_kernel.f90"), API, 0)
+    _, invoke = get_invoke("test14_module_inline_same_kernel.f90", API, idx=0)
     schedule = invoke.schedule
 
     lftrans = GOceanLoopFuseTrans()
@@ -176,8 +170,7 @@ def test_loop_fuse_unexpected_error():
 def test_omp_parallel_loop():
     '''Test that we can generate an OMP PARALLEL DO correctly,
     independent of whether or not we are generating constant loop bounds '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     omp = GOceanOMPParallelLoopTrans()
@@ -219,8 +212,7 @@ def test_omp_region_with_wrong_arg_type():
     ''' Test that the OpenMP PARALLEL region transformation
         raises an appropriate error if passed something that is not
         a list of Nodes or a single Node. '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
 
     ompr = OMPParallelTrans()
 
@@ -231,8 +223,7 @@ def test_omp_region_with_wrong_arg_type():
 def test_omp_region_with_single_loop():
     ''' Test that we can pass the OpenMP PARALLEL region transformation
         a single node in a schedule '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -281,8 +272,7 @@ def test_omp_region_with_single_loop():
 def test_omp_region_with_slice():
     ''' Test that we can pass the OpenMP PARALLEL region transformation
     a list of nodes specified as a slice '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -312,8 +302,7 @@ def test_omp_region_with_slice():
 def test_omp_region_no_slice():
     ''' Test that we can pass the OpenMP PARALLEL region transformation
     a list of nodes specified as node.children '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     ompr = OMPParallelTrans()
 
@@ -342,8 +331,7 @@ def test_omp_region_no_slice_no_const_bounds():
     PARALLEL region transformation to a list of nodes when the Schedule
     has been transformed to use loop-bound look-ups '''
 
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     ompr = OMPParallelTrans()
     cbtrans = GOConstLoopBoundsTrans()
@@ -373,8 +361,7 @@ def test_omp_region_retains_kernel_order1():
     ''' Test that applying the OpenMP PARALLEL region transformation
     to a sub-set of nodes (last 2 of three) does not change their
     ordering '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -428,8 +415,7 @@ def test_omp_region_retains_kernel_order2():
     ''' Test that applying the OpenMP PARALLEL region transformation
     to a sub-set of nodes (first 2 of 3) does not change their
     ordering '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -463,8 +449,7 @@ def test_omp_region_retains_kernel_order3():
     ''' Test that applying the OpenMP PARALLEL region transformation
     to a sub-set of nodes (middle 1 of 3) does not change their
     ordering '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -503,8 +488,7 @@ def test_omp_region_before_loops_trans():
     ''' Test of the OpenMP PARALLEL region transformation where
     we do the region transformation before the loop
     transformations. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Put all of the loops in the schedule within a single
@@ -545,8 +529,7 @@ def test_omp_region_before_loops_trans():
 def test_omp_region_after_loops_trans():
     ''' Test of the OpenMP PARALLEL region transformation where we
     do the loop transformations before the region transformation '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Put an OpenMP do directive around each loop contained
@@ -587,8 +570,7 @@ def test_omp_region_commutes_with_loop_trans():
     ''' Test that the OpenMP PARALLEL region and (orphan) loop
     transformations commute - i.e. we get the same result
     independent of the order in which they are applied. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Put an OpenMP do directive around each loop contained
@@ -613,8 +595,7 @@ def test_omp_region_commutes_with_loop_trans():
 
     # Put all of the loops in the schedule within a single
     # OpenMP region
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompr = OMPParallelTrans()
@@ -642,8 +623,7 @@ def test_omp_region_commutes_with_loop_trans_bounds_lookup():
     transformations commute after constant bounds have been
     switched off - i.e. we get the same result
     independent of the order in which they are applied. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     # Turn-off constant loop bounds
     cbtrans = GOConstLoopBoundsTrans()
@@ -671,8 +651,7 @@ def test_omp_region_commutes_with_loop_trans_bounds_lookup():
     # ...we re-generate the original schedule here rather than
     # keeping a (deep) copy of it from earlier as that can
     # cause resource problems.
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_two_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     # Turn-off constant loop bounds
     cbtrans = GOConstLoopBoundsTrans()
@@ -704,8 +683,7 @@ def test_omp_region_nodes_not_children_of_same_parent():
     ''' Test that we raise appropriate error if user attempts
     to put a region around nodes that are not children of
     the same parent '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPParallelLoopTrans()
@@ -726,7 +704,7 @@ def test_omp_region_nodes_not_children_of_same_schedule():
     ''' Test that we raise appropriate error if user attempts
     to put a region around nodes that are not children of
     the same schedule '''
-    alg_file = os.path.join("gocean1p0", "test12_two_invokes_two_kernels.f90")
+    alg_file = "test12_two_invokes_two_kernels.f90"
     _, invoke1 = get_invoke(alg_file, API, 0)
     schedule1 = invoke1.schedule
     _, invoke2 = get_invoke(alg_file, API, 1)
@@ -745,8 +723,7 @@ def test_omp_loop_outside_region():
     ''' Test that a generation error is raised if we try and
     have an orphaned OpenMP loop that is not enclosed
     within a parallel region '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Put an OpenMP do directive around each loop contained
@@ -772,8 +749,7 @@ def test_omp_loop_applied_to_non_loop():
     ''' Test that we raise a TransformationError if we attempt
     to apply an OMP DO transformation to something that
     is not a loop '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     from psyclone.transformations import OMPLoopTrans
@@ -791,8 +767,7 @@ def test_go_omp_loop_applied_to_non_loop():
     ''' Test that we raise a TransformationError if we attempt
     to apply a GOcean OMP DO transformation to something that
     is not a loop '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans()
@@ -809,8 +784,7 @@ def test_go_omp_loop_applied_to_wrong_loop_type():
     ''' Test that we raise a TransformationError if we attempt to
     apply a GOcean OMP  DO transformation to a loop of
     the wrong type '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Manually break the loop-type of the first loop in order to
@@ -830,8 +804,7 @@ def test_go_omp_parallel_loop_applied_to_non_loop():
     ''' Test that we raise a TransformationError if we attempt to
     apply a GOcean OMP Parallel DO transformation to something that
     is not a loop '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPParallelLoopTrans()
@@ -848,8 +821,7 @@ def test_go_omp_parallel_loop_applied_to_wrong_loop_type():
     ''' Test that we raise a TransformationError if we attempt to
     apply a GOcean OMP Parallel DO transformation to a loop of
     the wrong type '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Manually break the loop-type of the first loop in order to
@@ -869,8 +841,7 @@ def test_omp_parallel_do_inside_parallel_region():
     ''' Test that a generation error is raised if we attempt
     to have an OpenMP parallel do within an OpenMP
     parallel region '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPParallelLoopTrans()
@@ -895,8 +866,7 @@ def test_omp_parallel_region_inside_parallel_do():
     ''' Test that a generation error is raised if we attempt
     to have an OpenMP parallel region within an OpenMP
     parallel do (with the latter applied first) '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPParallelLoopTrans()
@@ -914,8 +884,7 @@ def test_omp_parallel_do_around_parallel_region():
     ''' Test that a generation error is raised if we attempt
     to have an OpenMP parallel region around an OpenMP
     parallel do (with the latter applied second) '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPParallelLoopTrans()
@@ -941,8 +910,7 @@ def test_omp_parallel_do_around_parallel_region():
 def test_omp_region_with_children_of_different_types():
     ''' Test that we can generate code if we have an
     OpenMP parallel region enclosing children of different types. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans()
@@ -964,8 +932,7 @@ def test_omp_region_with_children_of_different_types():
 def test_omp_schedule_default_static():
     ''' Test that if no OMP schedule is specified then we default
     to "static" '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans()
@@ -990,8 +957,7 @@ def test_omp_schedule_default_static():
 def test_omp_do_schedule_runtime():
     ''' Test that we can specify the schedule of an OMP do as
     "runtime" '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans(omp_schedule="runtime")
@@ -1015,8 +981,7 @@ def test_omp_do_schedule_runtime():
 def test_omp_do_schedule_dynamic():
     ''' Test that we can specify the schedule of an OMP do as
     "dynamic" '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans(omp_schedule="dynamic")
@@ -1040,8 +1005,7 @@ def test_omp_do_schedule_dynamic():
 def test_omp_do_schedule_guided():
     ''' Test that we can specify the schedule of an OMP do as
     "guided" '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans(omp_schedule="guided")
@@ -1072,8 +1036,7 @@ def test_omp_schedule_guided_with_empty_chunk():
 def test_omp_schedule_guided_with_chunk():
     ''' Test that we can specify the schedule of an OMP do as
     "guided,n" where n is some chunk size'''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     ompl = GOceanOMPLoopTrans(omp_schedule="guided,10")
@@ -1110,8 +1073,7 @@ def test_omp_schedule_auto_with_chunk():
 
 def test_module_noinline_default():
     ''' Test that by default there is no module inlining '''
-    psy, _ = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, _ = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     gen = str(psy.gen)
     # check that the subroutine has not been inlined
     assert 'SUBROUTINE compute_cu_code(i, j, cu, p, u)' not in gen
@@ -1124,8 +1086,7 @@ def test_module_inline():
     ''' Test that we can succesfully inline a basic kernel subroutine
     routine into the PSy layer module by directly setting inline to
     true for the specified kernel. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0].children[0]
     kern_call.module_inline = True
@@ -1142,8 +1103,7 @@ def test_module_inline():
 def test_module_inline_with_transformation():
     ''' Test that we can succesfully inline a basic kernel subroutine
     routine into the PSy layer module using a transformation '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[1].children[0].children[0]
     inline_trans = KernelModuleInlineTrans()
@@ -1159,8 +1119,7 @@ def test_module_no_inline_with_transformation():
     ''' Test that we can switch off the inlining of a kernel routine
     into the PSy layer module using a transformation. Relies on the
     test_module_inline() test being successful to be a valid test. '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0].children[0]
     # directly switch on inlining
@@ -1186,8 +1145,7 @@ def test_module_no_inline_with_transformation():
 def test_transformation_inline_error_if_not_kernel():
     ''' Test that the inline transformation fails if the object being
     passed is not a kernel'''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0]
     inline_trans = KernelModuleInlineTrans()
@@ -1198,8 +1156,7 @@ def test_transformation_inline_error_if_not_kernel():
 def test_module_inline_with_sub_use():
     ''' Test that we can module inline a kernel subroutine which
     contains a use statement'''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_scalar_int_arg.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_scalar_int_arg.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0].children[0]
     inline_trans = KernelModuleInlineTrans()
@@ -1217,9 +1174,8 @@ def test_module_inline_same_kernel():
     '''Tests that correct results are obtained when an invoke that uses
     the same kernel subroutine more than once has that kernel
     inlined'''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test14_module_inline_same_kernel.f90"), API, 0)
+    psy, invoke = get_invoke("test14_module_inline_same_kernel.f90", API,
+                             idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0].children[0]
     inline_trans = KernelModuleInlineTrans()
@@ -1240,9 +1196,7 @@ def test_module_inline_warning_no_change():
     request is already what is happening. No warning is currently made
     as we have not added logging to the code but this test covers the
     clause '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "test14_module_inline_same_kernel.f90"), API, 0)
+    _, invoke = get_invoke("test14_module_inline_same_kernel.f90", API, idx=0)
     schedule = invoke.schedule
     kern_call = schedule.children[0].children[0].children[0]
     inline_trans = KernelModuleInlineTrans()
@@ -1254,8 +1208,7 @@ def test_loop_swap_correct():
     last invokes to make sure the inserting of the inner loop happens at
     the right place.'''
 
-    psy, _ = get_invoke(
-        os.path.join("gocean1p0", "test27_loop_swap.f90"), API, 0)
+    psy, _ = get_invoke("test27_loop_swap.f90", API, idx=0)
     invoke = psy.invokes.get("invoke_loop1")
     schedule = invoke.schedule
     schedule_str = str(schedule)
@@ -1313,8 +1266,7 @@ kern call: bc_solid_v_code'''
 def test_go_loop_swap_errors():
     ''' Test loop swapping transform with incorrect parameters. '''
 
-    psy, invoke_loop1 = get_invoke(
-        os.path.join("gocean1p0", "test27_loop_swap.f90"), API, 1)
+    psy, invoke_loop1 = get_invoke("test27_loop_swap.f90", API, idx=1)
 
     schedule = invoke_loop1.schedule
     swap = GOLoopSwapTrans()
@@ -1384,8 +1336,7 @@ def test_acc_parallel_not_a_loop():
     ''' Test that we raise an appropriate error if we attempt
     to apply the OpenACC Parallel transformation to something that
     is not a loop '''
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     acct = ACCParallelTrans()
@@ -1398,8 +1349,7 @@ def test_acc_parallel_not_a_loop():
 def test_acc_parallel_trans():
     ''' Test that we can apply an OpenACC parallel transformation
     to a loop '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     acct = ACCParallelTrans()
@@ -1437,8 +1387,7 @@ def test_acc_parallel_trans():
 def test_acc_data_not_a_schedule():
     ''' Test that we raise an appropriate error if we attempt to apply
     an OpenACC Data transformation to something that is not a Schedule '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     acct = ACCDataTrans()
@@ -1463,8 +1412,7 @@ def test_acc_data_not_a_schedule():
 def test_acc_data_copyin():
     ''' Test that we correctly generate the arguments to the copyin
     clause of an OpenACC data region '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     accpt = ACCParallelTrans()
@@ -1502,8 +1450,7 @@ def test_acc_data_copyin():
 def test_acc_data_grid_copyin():
     ''' Test that we correctly generate the arguments to the copyin
     clause of an OpenACC data region when grid properties are required '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_grid_props.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_grid_props.f90", API, idx=0)
     schedule = invoke.schedule
 
     accpt = ACCParallelTrans()
@@ -1540,9 +1487,7 @@ def test_acc_rscalar_update():
     Check that we generate code to update any real scalar kernel arguments on
     the device.
     '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_scalar_float_arg.f90"),
-        API, 0)
+    psy, invoke = get_invoke("single_invoke_scalar_float_arg.f90", API, idx=0)
     schedule = invoke.schedule
 
     accpt = ACCParallelTrans()
@@ -1575,9 +1520,7 @@ def test_acc_iscalar_update():
     Check that we generate code to update any integer scalar kernel arguments
     on the device.
     '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_scalar_int_arg.f90"),
-        API, 0)
+    psy, invoke = get_invoke("single_invoke_scalar_int_arg.f90", API, idx=0)
     schedule = invoke.schedule
 
     accpt = ACCParallelTrans()
@@ -1610,10 +1553,8 @@ def test_acc_update_two_scalars():
     Check that we generate two separate acc_update_device() calls when
     we have two scalars.
     '''
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0",
-                     "single_invoke_two_kernels_scalars.f90"),
-        API, 0)
+    psy, invoke = get_invoke("single_invoke_two_kernels_scalars.f90", API,
+                             idx=0)
     schedule = invoke.schedule
 
     accpt = ACCParallelTrans()
@@ -1649,8 +1590,7 @@ def test_acc_data_parallel_commute():
     accpt = ACCParallelTrans()
     accdt = ACCDataTrans()
 
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Put each loop within an OpenACC parallel region
@@ -1666,8 +1606,7 @@ def test_acc_data_parallel_commute():
 
     # Repeat these transformations but create the region
     # before the parallel loops
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Create a data region for the whole schedule
@@ -1690,8 +1629,7 @@ def test_accdata_duplicate():
     accdt = ACCDataTrans()
     accpt = ACCParallelTrans()
 
-    _, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    _, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     # Create a data region for the whole schedule
@@ -1713,8 +1651,7 @@ def test_accloop():
     accpara = ACCParallelTrans()
     accdata = ACCDataTrans()
 
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API, 0)
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API, idx=0)
     schedule = invoke.schedule
 
     with pytest.raises(TransformationError) as err:
@@ -1766,9 +1703,8 @@ def test_acc_collapse():
     accpara = ACCParallelTrans()
     accdata = ACCDataTrans()
 
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API,
-        name="invoke_0")
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API,
+                             name="invoke_0")
     schedule = invoke.schedule
     child = schedule.children[0]
 
@@ -1814,9 +1750,8 @@ def test_acc_indep(capsys):
     accpara = ACCParallelTrans()
     accdata = ACCDataTrans()
 
-    psy, invoke = get_invoke(
-        os.path.join("gocean1p0", "single_invoke_three_kernels.f90"), API,
-        name="invoke_0")
+    psy, invoke = get_invoke("single_invoke_three_kernels.f90", API,
+                             name="invoke_0")
     schedule = invoke.schedule
     new_sched, _ = acclpt.apply(schedule.children[0], independent=False)
     new_sched, _ = acclpt.apply(schedule.children[1], independent=True)

--- a/src/psyclone/tests/profile_test.py
+++ b/src/psyclone/tests/profile_test.py
@@ -46,36 +46,9 @@ from psyclone.gocean1p0 import GOKern, GOSchedule
 from psyclone.parse import parse
 from psyclone.profiler import Profiler, ProfileNode
 from psyclone.psyGen import Loop, NameSpace, PSyFactory
-
+from psyclone.tests.utils import get_invoke
 from psyclone.transformations import GOceanOMPLoopTrans, OMPParallelTrans, \
     ProfileRegionTrans, TransformationError
-
-
-# TODO: Once #170 is merged, use the new tests/utils.py module
-def get_invoke(api, algfile, key):
-    ''' Utility method to get the idx'th invoke from the algorithm
-    specified in file '''
-
-    if api == "gocean1.0":
-        dir_name = "gocean1p0"
-    elif api == "dynamo0.3":
-        dir_name = "dynamo0p3"
-    else:
-        assert False
-    _, info = parse(os.path.
-                    join(os.path.dirname(os.path.abspath(__file__)),
-                         "test_files", dir_name, algfile),
-                    api=api)
-    psy = PSyFactory(api).create(info)
-    invokes = psy.invokes
-    if isinstance(key, str):
-        invoke = invokes.get(key)
-    else:
-        # invokes does not have a method by which to request the i'th
-        # in the list so we do this rather clumsy lookup of the name
-        # of the invoke that we want
-        invoke = invokes.get(list(invokes.names)[key])
-    return psy, invoke
 
 
 # -----------------------------------------------------------------------------
@@ -98,8 +71,8 @@ def test_profile_basic(capsys):
     '''Check basic functionality: node names, schedule view.
     '''
     Profiler.set_options([Profiler.INVOKES])
-    _, invoke = get_invoke("gocean1.0", "test11_different_iterates_over_"
-                           "one_invoke.f90", 0)
+    _, invoke = get_invoke("test11_different_iterates_over_one_invoke.f90",
+                           "gocean1.0", idx=0)
 
     assert isinstance(invoke.schedule.children[0], ProfileNode)
 
@@ -173,8 +146,8 @@ def test_profile_invokes_gocean1p0():
     '''Check that an invoke is instrumented correctly
     '''
     Profiler.set_options([Profiler.INVOKES])
-    _, invoke = get_invoke("gocean1.0", "test11_different_iterates_over_"
-                           "one_invoke.f90", 0)
+    _, invoke = get_invoke("test11_different_iterates_over_one_invoke.f90",
+                           "gocean1.0", idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -198,8 +171,7 @@ def test_profile_invokes_gocean1p0():
     assert re.search(correct_re, code, re.I) is not None
 
     # Test that two kernels in one invoke get instrumented correctly.
-    _, invoke = get_invoke("gocean1.0", "single_invoke_"
-                           "two_kernels.f90", 0)
+    _, invoke = get_invoke("single_invoke_two_kernels.f90", "gocean1.0", 0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -231,8 +203,8 @@ def test_unique_region_names():
     names are identical.'''
 
     Profiler.set_options([Profiler.KERNELS])
-    _, invoke = get_invoke("gocean1.0",
-                           "single_invoke_two_identical_kernels.f90", 0)
+    _, invoke = get_invoke("single_invoke_two_identical_kernels.f90",
+                           "gocean1.0", 0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -284,8 +256,8 @@ def test_profile_kernels_gocean1p0():
     '''Check that all kernels are instrumented correctly
     '''
     Profiler.set_options([Profiler.KERNELS])
-    _, invoke = get_invoke("gocean1.0", "single_invoke_"
-                           "two_kernels.f90", 0)
+    _, invoke = get_invoke("single_invoke_two_kernels.f90", "gocean1.0",
+                           idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -333,7 +305,7 @@ def test_profile_invokes_dynamo0p3():
     Profiler.set_options([Profiler.INVOKES])
 
     # First test for a single invoke with a single kernel work as expected:
-    _, invoke = get_invoke("dynamo0.3", "1_single_invoke.f90", 0)
+    _, invoke = get_invoke("1_single_invoke.f90", "dynamo0.3", idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -351,7 +323,7 @@ def test_profile_invokes_dynamo0p3():
     assert re.search(correct_re, code, re.I) is not None
 
     # Next test two kernels in one invoke:
-    _, invoke = get_invoke("dynamo0.3", "1.2_multi_invoke.f90", 0)
+    _, invoke = get_invoke("1.2_multi_invoke.f90", "dynamo0.3", idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -381,7 +353,7 @@ def test_profile_kernels_dynamo0p3():
     Dynamo 0.3 invoke.
     '''
     Profiler.set_options([Profiler.KERNELS])
-    _, invoke = get_invoke("dynamo0.3", "1_single_invoke.f90", 0)
+    _, invoke = get_invoke("1_single_invoke.f90", "dynamo0.3", idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -399,7 +371,7 @@ def test_profile_kernels_dynamo0p3():
                   r"call ProfileEnd\(profile\)")
     assert re.search(correct_re, code, re.I) is not None
 
-    _, invoke = get_invoke("dynamo0.3", "1.2_multi_invoke.f90", 0)
+    _, invoke = get_invoke("1.2_multi_invoke.f90", "dynamo0.3", idx=0)
 
     # Convert the invoke to code, and remove all new lines, to make
     # regex matching easier
@@ -432,7 +404,8 @@ def test_profile_kernels_dynamo0p3():
 def test_transform(capsys):
     '''Tests normal behaviour of profile region transformation.'''
 
-    _, invoke = get_invoke("gocean1.0", "test27_loop_swap.f90", "invoke_loop1")
+    _, invoke = get_invoke("test27_loop_swap.f90", "gocean1.0",
+                           name="invoke_loop1")
     schedule = invoke.schedule
 
     prt = ProfileRegionTrans()
@@ -514,7 +487,8 @@ def test_transform_errors(capsys):
 
     # This has been imported and tested before, so we can assume
     # here that this all works as expected/
-    _, invoke = get_invoke("gocean1.0", "test27_loop_swap.f90", "invoke_loop1")
+    _, invoke = get_invoke("test27_loop_swap.f90", "gocean1.0", 
+                           name="invoke_loop1")
 
     schedule = invoke.schedule
     prt = ProfileRegionTrans()
@@ -577,7 +551,8 @@ def test_transform_errors(capsys):
 
     # Test that we don't add a profile node inside a OMP do loop (which
     # would be invalid syntax):
-    _, invoke = get_invoke("gocean1.0", "test27_loop_swap.f90", "invoke_loop1")
+    _, invoke = get_invoke("test27_loop_swap.f90", "gocean1.0",
+                           name="invoke_loop1")
     schedule = invoke.schedule
 
     prt = ProfileRegionTrans()
@@ -600,7 +575,8 @@ def test_omp_transform():
     '''Tests that the profiling transform works correctly with OMP
      parallelisation.'''
 
-    _, invoke = get_invoke("gocean1.0", "test27_loop_swap.f90", "invoke_loop1")
+    _, invoke = get_invoke("test27_loop_swap.f90", "gocean1.0",
+                           name="invoke_loop1")
     schedule = invoke.schedule
 
     prt = ProfileRegionTrans()

--- a/src/psyclone/tests/psyGen_test.py
+++ b/src/psyclone/tests/psyGen_test.py
@@ -50,7 +50,7 @@ import os
 import re
 import pytest
 from fparser import api as fpapi
-from utils import get_invoke
+from psyclone.tests.utils import get_invoke
 from psyclone.psyGen import TransInfo, Transformation, PSyFactory, NameSpace, \
     NameSpaceFactory, OMPParallelDoDirective, PSy, \
     OMPParallelDirective, OMPDoDirective, OMPDirective, Directive
@@ -142,7 +142,7 @@ def test_new_module():
     transformations.  There should be no transformations
     available as the new module uses a different
     transformation base class'''
-    from test_files import dummy_transformations
+    from psyclone.tests.test_files import dummy_transformations
     trans = TransInfo(module=dummy_transformations)
     assert trans.num_trans == 0
 
@@ -152,7 +152,8 @@ def test_new_baseclass():
     should be no transformations available as the default
     transformations module does not use the specified base
     class'''
-    from test_files.dummy_transformations import LocalTransformation
+    from psyclone.tests.test_files.dummy_transformations import \
+        LocalTransformation
     trans = TransInfo(base_class=LocalTransformation)
     assert trans.num_trans == 0
 
@@ -162,7 +163,7 @@ def test_new_module_and_baseclass():
     transformations and the baseclass. There should be one
     transformation available as the module specifies one test
     transformation using the specified base class '''
-    from test_files import dummy_transformations
+    from psyclone.tests.test_files import dummy_transformations
     trans = TransInfo(module=dummy_transformations,
                       base_class=dummy_transformations.LocalTransformation)
     assert trans.num_trans == 1
@@ -757,8 +758,7 @@ def test_acc_dir_view(capsys):
     accdt = ACCDataTrans()
     accpt = ACCParallelTrans()
 
-    _, invoke = get_invoke(os.path.join("gocean1p0", "single_invoke.f90"),
-                           "gocean1.0", idx=0)
+    _, invoke = get_invoke("single_invoke.f90", "gocean1.0", idx=0)
     colour = SCHEDULE_COLOUR_MAP["Directive"]
     schedule = invoke.schedule
     # Enter-data
@@ -1770,8 +1770,7 @@ def test_node_is_valid_location():
 def test_node_ancestor():
     ''' Test the Node.ancestor() method '''
     from psyclone.psyGen import Node, Loop
-    _, invoke = get_invoke(os.path.join("gocean1p0", "single_invoke.f90"),
-                           "gocean1.0", idx=0)
+    _, invoke = get_invoke("single_invoke.f90", "gocean1.0", idx=0)
     sched = invoke.schedule
     sched.view()
     kern = sched.children[0].children[0].children[0]
@@ -1864,8 +1863,7 @@ def test_acc_dag_names():
     from psyclone.psyGen import ACCDataDirective
     from psyclone.transformations import ACCDataTrans, ACCParallelTrans, \
         ACCLoopTrans
-    _, invoke = get_invoke(os.path.join("gocean1p0", "single_invoke.f90"),
-                           "gocean1.0", idx=0)
+    _, invoke = get_invoke("single_invoke.f90", "gocean1.0", idx=0)
     schedule = invoke.schedule
 
     acclt = ACCLoopTrans()

--- a/src/psyclone/tests/utils.py
+++ b/src/psyclone/tests/utils.py
@@ -282,9 +282,20 @@ def get_invoke(algfile, api, idx=None, name=None):
         raise RuntimeError("Either the index or the name of the "
                            "requested invoke must be specified")
 
+    if api == "gocean1.0":
+        dir_name = "gocean1p0"
+    elif api == "dynamo0.3":
+        dir_name = "dynamo0p3"
+    elif api == "gocean0.1":
+        dir_name = "gocean0p1"
+    elif api == "dyanmo0.1":
+        dir_name = "dynamo0p1"
+    else:
+        assert False
+
     _, info = parse(os.path.
                     join(os.path.dirname(os.path.abspath(__file__)),
-                         "test_files", algfile),
+                         "test_files", dir_name, algfile),
                     api=api)
     psy = PSyFactory(api).create(info)
     if name:


### PR DESCRIPTION
OK, I admit that this change got a bit out of hand :)  I started with fixing the one todo (use gen_invoke from utils in profiler_test) ... and then I ended up doing:
- Update utils.gen_invoke so that there is no need to add the api-specific directory in the caller, instead set the directory based on API (leaving out gungho, since afaik that's deprecated)
- use the new gen_invoke everywhere, and remove all the os.path.join that previously added the api-specific subdirectory name
- Then I also didn't like the 'import utils' (imho this is just asking for trouble sooner or later), so I did a proper from psyclone.tests.utils import ... (which needed a __init__ file in tests), and replaced all utils.XXX uses appropriately.