### PR TITLE
Fix handling of unicode characters in source (py36 and below).

### DIFF
--- a/src/psyclone/parse/utils.py
+++ b/src/psyclone/parse/utils.py
@@ -38,6 +38,8 @@ the parser modules.
 
 '''
 
+import io
+
 from psyclone.configuration import Config
 from psyclone.line_length import FortLineLength
 from psyclone.psyGen import InternalError
@@ -95,7 +97,7 @@ def check_line_length(filename):
     '''
     fll = FortLineLength()
     try:
-        with open(filename, "r") as myfile:
+        with io.open(filename, "r", encoding='utf8') as myfile:
             code_str = myfile.read()
     except IOError as excinfo:
         raise InternalError(


### PR DESCRIPTION
This PR fixes a bug seen with PSyclone and Python 3.6 and below relating to unicode characters in Fortran comments. The file I saw this in was in the LFRic ``algorithm/iterative_solvers/diagonal_preconditioner_mod.x90`` file. The [line in question](https://code.metoffice.gov.uk/trac/lfric/browser/LFRic/trunk/gungho/source/kernel/held_suarez_fv_kernel_mod.F90?rev=14423#L14) has a unicode dash:

```
!> non-hydrostatic models. Q.J.R. Meteorol. Soc., 135: 469–484.
```

Traceback along the lines of:

```
Full psyclone working/unit-tests/algorithm/slow_physics_alg_mod.x90
Error, unexpected exception, please report to the authors:
Description ...
'ascii' codec can't decode byte 0xe2 in position 783: ordinal not in range(128)
Type ...
<class 'UnicodeDecodeError'>
Stacktrace ...
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/generator.py", line 396, in main
    kern_naming=args.kernel_renaming)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/generator.py", line 222, in generate
    line_length=line_length)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/algorithm.py", line 102, in parse
    return my_parser.parse(alg_filename)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/algorithm.py", line 220, in parse
    invoke_call = self.create_invoke_call(statement)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/algorithm.py", line 268, in create_invoke_call
    kernel_call = self.create_kernel_call(argument)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/algorithm.py", line 305, in create_kernel_call
    kernel_name, args)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/algorithm.py", line 374, in create_coded_kernel_call
    self._kernel_path, self._line_length)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/kernel.py", line 195, in get_kernel_ast
    check_line_length(filepath)
  File "/data/users/itpe/modules/packages/production-os42-1/psyclone/master/psyclone/parse/utils.py", line 100, in check_line_length
    code_str = myfile.read()
  File "/opt/scitools/environments/production/2019_01_08/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
make[1]: *** [working/unit-tests/algorithm/slow_physics_alg_mod_psy.f90] Error 1
make: *** [generate-unit-tests] Error 2
```

This issue does not occur with python 3.7, so I assume the codecs improvement documented in the py37 [what's new](https://docs.python.org/3/whatsnew/3.7.html#what-s-new-in-python-3-7) addresses the issue.

To add a sweetener to this, I've also added coverage of the actual function failing.

I suspect we will see similar issues on fparser, but haven't yet started looking into that.