### PR TITLE
Remove duplicate operator tests in LFRic API

### DIFF
--- a/changelog
+++ b/changelog
@@ -209,6 +209,8 @@
         65) PR #400 towards #385. Adds support for Fortran Do loops in
         the PSyIR - loop bounds are now captured.
 
+	66) PR #469 for #465. Removes duplicate lma tests.
+
 release 1.7.0 20th December 2018
 
 	1) #172 and PR #173 Add support for logical declaration, the save

--- a/src/psyclone/tests/dynamo0p3_lma_test.py
+++ b/src/psyclone/tests/dynamo0p3_lma_test.py
@@ -253,13 +253,12 @@ def test_operator():
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
 
-    assert generated_code.find("SUBROUTINE invoke_0_testkern_operator"
-                               "_type(mm_w0, chi, a, qr)") != -1
-    assert generated_code.find("TYPE(operator_type), intent(inout) ::"
-                               " mm_w0") != -1
-    assert generated_code.find("TYPE(operator_proxy_type) mm_w0_"
-                               "proxy") != -1
-    assert generated_code.find("mm_w0_proxy = mm_w0%get_proxy()") != -1
+    assert (
+        "SUBROUTINE invoke_0_testkern_operator_type(mm_w0, chi, a, qr)"
+        in generated_code)
+    assert "TYPE(operator_type), intent(inout) :: mm_w0" in generated_code
+    assert "TYPE(operator_proxy_type) mm_w0_proxy" in generated_code
+    assert "mm_w0_proxy = mm_w0%get_proxy()" in generated_code
     assert ("CALL testkern_operator_code(cell, nlayers, mm_w0_proxy%ncell_3d, "
             "mm_w0_proxy%local_stencil, chi_proxy(1)%data, chi_proxy(2)%data, "
             "chi_proxy(3)%data, a, ndf_w0, undf_w0, map_w0(:,cell), "
@@ -415,14 +414,14 @@ def test_operator_nofield(tmpdir):
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
 
-    assert gen_code_str.find("SUBROUTINE invoke_0_testkern_operator_"
-                             "nofield_type(mm_w2, chi, qr)") != -1
-    assert gen_code_str.find("TYPE(operator_type), intent(inout) :: "
-                             "mm_w2") != -1
-    assert gen_code_str.find("TYPE(operator_proxy_type) mm_w2_proxy") != -1
-    assert gen_code_str.find("mm_w2_proxy = mm_w2%get_proxy()") != -1
-    assert gen_code_str.find("undf_w2") == -1
-    assert gen_code_str.find("map_w2") == -1
+    assert (
+        "SUBROUTINE invoke_0_testkern_operator_nofield_type(mm_w2, chi, qr)"
+        in gen_code_str)
+    assert "TYPE(operator_type), intent(inout) :: mm_w2" in gen_code_str
+    assert "TYPE(operator_proxy_type) mm_w2_proxy" in gen_code_str
+    assert "mm_w2_proxy = mm_w2%get_proxy()" in gen_code_str
+    assert "undf_w2" not in gen_code_str
+    assert "map_w2" not in gen_code_str
     assert ("CALL testkern_operator_nofield_code(cell, nlayers, "
             "mm_w2_proxy%ncell_3d, mm_w2_proxy%local_stencil, "
             "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, "
@@ -517,16 +516,15 @@ def test_operator_orientation(tmpdir):
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
 
-    assert gen_str.find("SUBROUTINE invoke_0_testkern_operator"
-                        "_orient_type(mm_w1, chi, qr)") != -1
-    assert gen_str.find("TYPE(operator_type), intent(inout) ::"
-                        " mm_w1") != -1
-    assert gen_str.find("TYPE(operator_proxy_type) mm_w1_"
-                        "proxy") != -1
-    assert gen_str.find("mm_w1_proxy = mm_w1%get_proxy()") != -1
-    assert gen_str.find(
+    assert (
+        "SUBROUTINE invoke_0_testkern_operator_orient_type(mm_w1, chi, qr)"
+        in gen_str)
+    assert "TYPE(operator_type), intent(inout) :: mm_w1" in gen_str
+    assert "TYPE(operator_proxy_type) mm_w1_proxy" in gen_str
+    assert "mm_w1_proxy = mm_w1%get_proxy()" in gen_str
+    assert (
         "orientation_w1 => mm_w1_proxy%fs_from%get_cell_orientation"
-        "(cell)") != -1
+        "(cell)" in gen_str)
     assert ("CALL testkern_operator_orient_code(cell, nlayers, "
             "mm_w1_proxy%ncell_3d, mm_w1_proxy%local_stencil, "
             "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, ndf_w1, "
@@ -581,21 +579,19 @@ def test_operator_deref(tmpdir, dist_mem):
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
 
-    assert generated_code.find("SUBROUTINE invoke_0_testkern_operator"
-                               "_type(mm_w0_op, chi, a, qr)") != -1
-    assert generated_code.find("TYPE(operator_type), intent(inout) ::"
-                               " mm_w0_op") != -1
-    assert generated_code.find("TYPE(operator_proxy_type) mm_w0_op_"
-                               "proxy") != -1
     assert (
-        generated_code.find("mm_w0_op_proxy = mm_w0_op%get_proxy()") != -1)
-    assert generated_code.find(
+        "SUBROUTINE invoke_0_testkern_operator_type(mm_w0_op, chi, a, qr)"
+        in generated_code)
+    assert "TYPE(operator_type), intent(inout) :: mm_w0_op" in generated_code
+    assert "TYPE(operator_proxy_type) mm_w0_op_proxy" in generated_code
+    assert "mm_w0_op_proxy = mm_w0_op%get_proxy()" in generated_code
+    assert (
         "CALL testkern_operator_code(cell, nlayers, "
         "mm_w0_op_proxy%ncell_3d, mm_w0_op_proxy%local_stencil, "
         "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, a, "
         "ndf_w0, undf_w0, map_w0(:,cell), basis_w0_qr, "
         "diff_basis_w0_qr, np_xy_qr, np_z_qr, weights_xy_qr, "
-        "weights_z_qr)") != -1
+        "weights_z_qr)" in generated_code)
 
 
 def test_operator_no_dofmap_lookup():

--- a/src/psyclone/tests/dynamo0p3_lma_test.py
+++ b/src/psyclone/tests/dynamo0p3_lma_test.py
@@ -268,8 +268,8 @@ def test_operator():
 
 
 def test_operator_different_spaces(tmpdir):
-    '''tests that an operator with different to and from spaces is
-    implemented correctly in the PSy layer'''
+    ''' Tests that an operator with different to and from spaces is
+    implemented correctly in the PSy layer '''
     _, invoke_info = parse(os.path.join(BASE_PATH,
                                         "10.3_operator_different_spaces.f90"),
                            api=TEST_API)
@@ -405,7 +405,7 @@ def test_operator_different_spaces(tmpdir):
 
 
 def test_operator_nofield(tmpdir):
-    ''' tests that an operator with no field on the same space is
+    ''' Tests that an operator with no field on the same space is
     implemented correctly in the PSy layer '''
     _, invoke_info = parse(os.path.join(BASE_PATH,
                                         "10.1_operator_nofield.f90"),
@@ -454,7 +454,7 @@ def test_operator_nofield_different_space(tmpdir):
 
 
 def test_operator_nofield_scalar(tmpdir):
-    ''' tests that an operator with no field and a
+    ''' Tests that an operator with no field and a
     scalar argument is implemented correctly in the PSy layer '''
     _, invoke_info = parse(os.path.join(BASE_PATH,
                                         "10.6_operator_no_field_scalar.f90"),
@@ -462,7 +462,7 @@ def test_operator_nofield_scalar(tmpdir):
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     gen = str(psy.gen)
 
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)    
+    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
     assert "mesh => my_mapping_proxy%fs_from%get_mesh()" in gen
     assert "nlayers = my_mapping_proxy%fs_from%get_nlayers()" in gen
     assert "ndf_w2 = my_mapping_proxy%fs_from%get_ndf()" in gen
@@ -507,7 +507,7 @@ def test_operator_nofield_scalar_deref(tmpdir, dist_mem):
 
 
 def test_operator_orientation(tmpdir):
-    ''' tests that an operator requiring orientation information is
+    ''' Tests that an operator requiring orientation information is
     implemented correctly in the PSy layer '''
     _, invoke_info = parse(os.path.join(BASE_PATH,
                                         "10.2_operator_orient.f90"),
@@ -536,8 +536,8 @@ def test_operator_orientation(tmpdir):
 
 
 def test_op_orient_different_space(tmpdir):
-    '''tests that an operator on different spaces requiring orientation
-    information is implemented correctly in the PSy layer. '''
+    ''' Tests that an operator on different spaces requiring orientation
+    information is implemented correctly in the PSy layer '''
     _, invoke_info = parse(os.path.join(BASE_PATH,
                                         "10.4_operator_orient_different_"
                                         "space.f90"),

--- a/src/psyclone/tests/dynamo0p3_test.py
+++ b/src/psyclone/tests/dynamo0p3_test.py
@@ -32,7 +32,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
-# Modified I. Kavcic Met Office, C.M. Maynard, Met Office/University of Reading.
+# Modified I. Kavcic Met Office,
+#          C. M. Maynard, Met Office/University of Reading.
 
 ''' This module tests the Dynamo 0.3 API using pytest. '''
 
@@ -551,7 +552,7 @@ def test_field_deref(tmpdir, dist_mem):
         assert output in generated_code
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-    
+
     output = (
         "      REAL(KIND=r_def), intent(in) :: a\n"
         "      TYPE(field_type), intent(inout) :: f1\n"
@@ -827,7 +828,7 @@ def test_real_scalar(tmpdir):
     generated_code = str(psy.gen)
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-    
+
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2)\n"
         "      USE testkern, ONLY: testkern_code\n"
@@ -912,9 +913,10 @@ def test_int_scalar(tmpdir):
     generated_code = str(psy.gen)
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-    
+
     expected = (
-        "    SUBROUTINE invoke_0_testkern_one_int_scalar_type(f1, iflag, f2, m1, m2)\n"
+        "    SUBROUTINE invoke_0_testkern_one_int_scalar_type"
+        "(f1, iflag, f2, m1, m2)\n"
         "      USE testkern_one_int_scalar_mod, ONLY: testkern_code\n"
         "      USE mesh_mod, ONLY: mesh_type\n"
         "      INTEGER, intent(in) :: iflag\n"
@@ -997,8 +999,8 @@ def test_two_real_scalars(tmpdir):
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
 
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)    
-    
+    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
+
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2, b)\n"
         "      USE testkern_two_real_scalars, ONLY: testkern_code\n"
@@ -1082,7 +1084,7 @@ def test_two_int_scalars(tmpdir):
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-    
+
     expected = (
         "    SUBROUTINE invoke_0(iflag, f1, f2, m1, m2, istep)\n"
         "      USE testkern_two_int_scalars, ONLY: testkern_code\n"
@@ -1172,8 +1174,8 @@ def test_two_scalars(tmpdir):
                            api=TEST_API)
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
 
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)    
-    
+    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
+
     generated_code = str(psy.gen)
     expected = (
         "    SUBROUTINE invoke_0_testkern_type(a, f1, f2, m1, m2, istep)\n"
@@ -1272,7 +1274,7 @@ def test_vector_field():
                            api=TEST_API)
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     generated_code = str(psy.gen)
-    
+
     assert ("SUBROUTINE invoke_0_testkern_chi_type(f1, chi, f2)" in
             generated_code)
     assert "TYPE(field_type), intent(inout) :: f1, chi(3)" in generated_code
@@ -1287,7 +1289,7 @@ def test_vector_field_2(tmpdir):
     generated_code = str(psy.gen)
 
     assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-    
+
     # all references to chi_proxy should be chi_proxy(1)
     assert "chi_proxy%" not in generated_code
     assert generated_code.count("chi_proxy(1)%vspace") == 5
@@ -1324,393 +1326,6 @@ def test_orientation():
     assert "INTEGER, pointer :: orientation_w2(:) => null()" in generated_code
     assert ("orientation_w2 => f2_proxy%vspace%"
             "get_cell_orientation(cell)" in generated_code)
-
-
-def test_operator():
-    ''' tests that an operator is implemented correctly in the PSy
-    layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "10_operator.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    generated_code = str(psy.gen)
-    print(generated_code)
-    assert ("SUBROUTINE invoke_0_testkern_operator"
-            "_type(mm_w0, chi, a, qr)" in generated_code)
-    assert "TYPE(operator_type), intent(inout) :: mm_w0" in generated_code
-    assert "TYPE(operator_proxy_type) mm_w0_proxy" in generated_code
-    assert "mm_w0_proxy = mm_w0%get_proxy()" in generated_code
-    assert ("CALL testkern_operator_code(cell, nlayers, mm_w0_proxy%ncell_3d, "
-            "mm_w0_proxy%local_stencil, chi_proxy(1)%data, chi_proxy(2)%data, "
-            "chi_proxy(3)%data, a, ndf_w0, undf_w0, map_w0(:,cell), "
-            "basis_w0_qr, diff_basis_w0_qr, np_xy_qr, np_z_qr, weights_xy_qr, "
-            "weights_z_qr)") in generated_code
-
-
-def test_operator_different_spaces(tmpdir):
-    '''tests that an operator with different to and from spaces is
-    implemented correctly in the PSy layer'''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.3_operator_different_spaces.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    generated_code = str(psy.gen)
-    print(generated_code)
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-    decl_output = (
-        "    SUBROUTINE invoke_0_assemble_weak_derivative_w3_w2_kernel_type"
-        "(mapping, chi, qr)\n"
-        "      USE assemble_weak_derivative_w3_w2_kernel_mod, ONLY: "
-        "assemble_weak_derivative_w3_w2_kernel_code\n"
-        "      USE quadrature_xyoz_mod, ONLY: quadrature_xyoz_type, "
-        "quadrature_xyoz_proxy_type\n"
-        "      USE function_space_mod, ONLY: BASIS, DIFF_BASIS\n"
-        "      USE mesh_mod, ONLY: mesh_type\n"
-        "      TYPE(field_type), intent(in) :: chi(3)\n"
-        "      TYPE(operator_type), intent(inout) :: mapping\n"
-        "      TYPE(quadrature_xyoz_type), intent(in) :: qr\n"
-        "      INTEGER cell\n"
-        "      REAL(KIND=r_def), allocatable :: diff_basis_w0_qr(:,:,:,:), "
-        "basis_w3_qr(:,:,:,:), diff_basis_w2_qr(:,:,:,:)\n"
-        "      INTEGER diff_dim_w0, dim_w3, diff_dim_w2\n"
-        "      REAL(KIND=r_def), pointer :: weights_xy_qr(:) => null(), "
-        "weights_z_qr(:) => null()\n"
-        "      INTEGER np_xy_qr, np_z_qr\n"
-        "      INTEGER nlayers\n"
-        "      TYPE(operator_proxy_type) mapping_proxy\n"
-        "      TYPE(field_proxy_type) chi_proxy(3)\n"
-        "      TYPE(quadrature_xyoz_proxy_type) qr_proxy\n"
-        "      INTEGER, pointer :: map_w0(:,:) => null()\n"
-        "      INTEGER ndf_w3, ndf_w2, ndf_w0, undf_w0\n"
-        "      TYPE(mesh_type), pointer :: mesh => null()\n"
-        "      INTEGER, pointer :: orientation_w2(:) => null()\n")
-    assert decl_output in generated_code
-    output = (
-        "      !\n"
-        "      ! Initialise field and/or operator proxies\n"
-        "      !\n"
-        "      mapping_proxy = mapping%get_proxy()\n"
-        "      chi_proxy(1) = chi(1)%get_proxy()\n"
-        "      chi_proxy(2) = chi(2)%get_proxy()\n"
-        "      chi_proxy(3) = chi(3)%get_proxy()\n"
-        "      !\n"
-        "      ! Initialise number of layers\n"
-        "      !\n"
-        "      nlayers = mapping_proxy%fs_from%get_nlayers()\n"
-        "      !\n"
-        "      ! Create a mesh object\n"
-        "      !\n"
-        "      mesh => mapping_proxy%fs_from%get_mesh()\n"
-        "      !\n"
-        "      ! Look-up dofmaps for each function space\n"
-        "      !\n"
-        "      map_w0 => chi_proxy(1)%vspace%get_whole_dofmap()\n"
-        "      !\n"
-        "      ! Initialise number of DoFs for w3\n"
-        "      !\n"
-        "      ndf_w3 = mapping_proxy%fs_to%get_ndf()\n"
-        "      !\n"
-        "      ! Initialise number of DoFs for w2\n"
-        "      !\n"
-        "      ndf_w2 = mapping_proxy%fs_from%get_ndf()\n"
-        "      !\n"
-        "      ! Initialise number of DoFs for w0\n"
-        "      !\n"
-        "      ndf_w0 = chi_proxy(1)%vspace%get_ndf()\n"
-        "      undf_w0 = chi_proxy(1)%vspace%get_undf()\n"
-        "      !\n"
-        "      ! Look-up quadrature variables\n"
-        "      !\n"
-        "      qr_proxy = qr%get_quadrature_proxy()\n"
-        "      np_xy_qr = qr_proxy%np_xy\n"
-        "      np_z_qr = qr_proxy%np_z\n"
-        "      weights_xy_qr => qr_proxy%weights_xy\n"
-        "      weights_z_qr => qr_proxy%weights_z\n"
-        "      !\n"
-        "      ! Allocate basis/diff-basis arrays\n"
-        "      !\n"
-        "      diff_dim_w0 = chi_proxy(1)%vspace%get_dim_space_diff()\n"
-        "      dim_w3 = mapping_proxy%fs_to%get_dim_space()\n"
-        "      diff_dim_w2 = mapping_proxy%fs_from%get_dim_space_diff()\n"
-        "      ALLOCATE (diff_basis_w0_qr(diff_dim_w0, ndf_w0, np_xy_qr, "
-        "np_z_qr))\n"
-        "      ALLOCATE (basis_w3_qr(dim_w3, ndf_w3, np_xy_qr, np_z_qr))\n"
-        "      ALLOCATE (diff_basis_w2_qr(diff_dim_w2, ndf_w2, np_xy_qr, "
-        "np_z_qr))\n"
-        "      !\n"
-        "      ! Compute basis/diff-basis arrays\n"
-        "      !\n"
-        "      CALL qr%compute_function(DIFF_BASIS, chi_proxy(1)%vspace, "
-        "diff_dim_w0, ndf_w0, diff_basis_w0_qr)\n"
-        "      CALL qr%compute_function(BASIS, mapping_proxy%fs_to, "
-        "dim_w3, ndf_w3, basis_w3_qr)\n"
-        "      CALL qr%compute_function(DIFF_BASIS, mapping_proxy%fs_from, "
-        "diff_dim_w2, ndf_w2, diff_basis_w2_qr)\n"
-        "      !\n"
-        "      ! Call kernels and communication routines\n"
-        "      !\n"
-        "      IF (chi_proxy(1)%is_dirty(depth=1)) THEN\n"
-        "        CALL chi_proxy(1)%halo_exchange(depth=1)\n"
-        "      END IF \n"
-        "      !\n"
-        "      IF (chi_proxy(2)%is_dirty(depth=1)) THEN\n"
-        "        CALL chi_proxy(2)%halo_exchange(depth=1)\n"
-        "      END IF \n"
-        "      !\n"
-        "      IF (chi_proxy(3)%is_dirty(depth=1)) THEN\n"
-        "        CALL chi_proxy(3)%halo_exchange(depth=1)\n"
-        "      END IF \n"
-        "      !\n"
-        "      DO cell=1,mesh%get_last_halo_cell(1)\n"
-        "        !\n"
-        "        orientation_w2 => mapping_proxy%fs_from%get_cell_orientation("
-        "cell)\n"
-        "        !\n"
-        "        CALL assemble_weak_derivative_w3_w2_kernel_code(cell, "
-        "nlayers, mapping_proxy%ncell_3d, mapping_proxy%local_stencil, "
-        "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, ndf_w3, "
-        "basis_w3_qr, ndf_w2, diff_basis_w2_qr, orientation_w2, "
-        "ndf_w0, undf_w0, map_w0(:,cell), diff_basis_w0_qr, "
-        "np_xy_qr, np_z_qr, weights_xy_qr, weights_z_qr)\n"
-        "      END DO \n"
-        "      !\n"
-        "      ! Deallocate basis arrays\n"
-        "      !\n"
-        "      DEALLOCATE (basis_w3_qr, diff_basis_w0_qr, diff_basis_w2_qr)\n"
-        "      !\n"
-        "    END SUBROUTINE invoke_0_assemble_weak_derivative_w3_w2_kernel_"
-        "type")
-    assert output in generated_code
-
-
-def test_operator_nofield(tmpdir):
-    ''' tests that an operator with no field on the same space is
-    implemented correctly in the PSy layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.1_operator_nofield.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen_code_str = str(psy.gen)
-    print(gen_code_str)
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-    assert ("SUBROUTINE invoke_0_testkern_operator_"
-            "nofield_type(mm_w2, chi, qr)" in gen_code_str)
-    assert "TYPE(operator_type), intent(inout) :: mm_w2" in gen_code_str
-    assert "TYPE(operator_proxy_type) mm_w2_proxy" in gen_code_str
-    assert "mm_w2_proxy = mm_w2%get_proxy()" in gen_code_str
-    assert "undf_w2" not in gen_code_str
-    assert "map_w2" not in gen_code_str
-    assert ("CALL testkern_operator_nofield_code(cell, nlayers, "
-            "mm_w2_proxy%ncell_3d, mm_w2_proxy%local_stencil, "
-            "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, "
-            "ndf_w2, basis_w2_qr, ndf_w0, undf_w0, "
-            "map_w0(:,cell), diff_basis_w0_qr, np_xy_qr, np_z_qr, "
-            "weights_xy_qr, weights_z_qr)" in gen_code_str)
-
-
-def test_operator_nofield_different_space(tmpdir):
-    ''' tests that an operator with no field on different spaces is
-    implemented correctly in the PSy layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.5_operator_no_field_different_"
-                                        "space.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen = str(psy.gen)
-    print(gen)
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-    assert "mesh => my_mapping_proxy%fs_from%get_mesh()" in gen
-    assert "nlayers = my_mapping_proxy%fs_from%get_nlayers()" in gen
-    assert "ndf_w3 = my_mapping_proxy%fs_from%get_ndf()" in gen
-    assert "ndf_w2 = my_mapping_proxy%fs_to%get_ndf()" in gen
-    # We compute operators redundantly (out to the L1 halo)
-    assert "DO cell=1,mesh%get_last_halo_cell(1)" in gen
-    assert ("(cell, nlayers, my_mapping_proxy%ncell_3d, my_mapping_proxy%"
-            "local_stencil, ndf_w2, ndf_w3)" in gen)
-
-
-def test_operator_nofield_scalar():
-    ''' tests that an operator with no field and a
-    scalar argument is implemented correctly in the PSy layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.6_operator_no_field_scalar.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen = str(psy.gen)
-    print(gen)
-    assert "mesh => my_mapping_proxy%fs_from%get_mesh()" in gen
-    assert "nlayers = my_mapping_proxy%fs_from%get_nlayers()" in gen
-    assert "ndf_w2 = my_mapping_proxy%fs_from%get_ndf()" in gen
-    assert "DO cell=1,mesh%get_last_halo_cell(1)" in gen
-    assert ("(cell, nlayers, my_mapping_proxy%ncell_3d, my_mapping_proxy%"
-            "local_stencil, b, ndf_w2, basis_w2_qr, np_xy_qr, np_z_qr, "
-            "weights_xy_qr, weights_z_qr)" in gen)
-
-
-def test_operator_nofield_scalar_deref(tmpdir):
-    ''' Tests that an operator with no field and a
-    scalar argument is implemented correctly in the PSy layer when both
-    are obtained by dereferencing derived type objects '''
-    _, invoke_info = parse(
-        os.path.join(BASE_PATH,
-                     "10.6.1_operator_no_field_scalar_deref.f90"),
-        api=TEST_API)
-    for dist_mem in [True, False]:
-        psy = PSyFactory(TEST_API,
-                         distributed_memory=dist_mem).create(invoke_info)
-        gen = str(psy.gen)
-        print(gen)
-
-        assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-        if dist_mem:
-            assert "mesh => opbox_my_mapping_proxy%fs_from%get_mesh()" in gen
-        assert "nlayers = opbox_my_mapping_proxy%fs_from%get_nlayers()" in gen
-        assert "ndf_w2 = opbox_my_mapping_proxy%fs_from%get_ndf()" in gen
-        assert ("qr_get_instance%compute_function(BASIS, "
-                "opbox_my_mapping_proxy%fs_from, "
-                "dim_w2, ndf_w2, basis_w2_qr_get_instance)" in gen)
-        if dist_mem:
-            assert "DO cell=1,mesh%get_last_halo_cell(1)" in gen
-        else:
-            assert (
-                "DO cell=1,opbox_my_mapping_proxy%fs_from%get_ncell()" in gen)
-        assert (
-            "(cell, nlayers, opbox_my_mapping_proxy%ncell_3d, "
-            "opbox_my_mapping_proxy%local_stencil, box_b, ndf_w2, "
-            "basis_w2_qr_get_instance, np_xy_qr_get_instance, "
-            "np_z_qr_get_instance, weights_xy_qr_get_instance,"
-            " weights_z_qr_get_instance)" in gen)
-
-
-def test_operator_orientation(tmpdir):
-    ''' tests that an operator requiring orientation information is
-    implemented correctly in the PSy layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.2_operator_orient.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen_str = str(psy.gen)
-    print(gen_str)
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-    assert ("SUBROUTINE invoke_0_testkern_operator_orient_type(mm_w1, chi, qr)"
-            in gen_str)
-    assert "TYPE(operator_type), intent(inout) :: mm_w1" in gen_str
-    assert "TYPE(operator_proxy_type) mm_w1_proxy" in gen_str
-    assert "mm_w1_proxy = mm_w1%get_proxy()" in gen_str
-    assert ("orientation_w1 => mm_w1_proxy%fs_from%get_cell_orientation"
-            "(cell)" in gen_str)
-    assert ("CALL testkern_operator_orient_code(cell, nlayers, "
-            "mm_w1_proxy%ncell_3d, mm_w1_proxy%local_stencil, "
-            "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, ndf_w1, "
-            "basis_w1_qr, orientation_w1, ndf_w0, undf_w0, map_w0(:,cell), "
-            "diff_basis_w0_qr, np_xy_qr, np_z_qr, weights_xy_qr, "
-            "weights_z_qr)" in gen_str)
-
-
-def test_op_orient_different_space(tmpdir):
-    '''tests that an operator on different spaces requiring orientation
-    information is implemented correctly in the PSy layer. '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.4_operator_orient_different_"
-                                        "space.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen_str = str(psy.gen)
-    print(gen_str)
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-    assert (
-        "INTEGER, pointer :: orientation_w1(:) => null(), orientation_w2(:)"
-        " => null()" in gen_str)
-    assert "ndf_w2 = my_mapping_proxy%fs_from%get_ndf()" in gen_str
-    assert "ndf_w1 = my_mapping_proxy%fs_to%get_ndf()" in gen_str
-    assert "dim_w1 = my_mapping_proxy%fs_to%get_dim_space()" in gen_str
-    assert ("CALL qr%compute_function(BASIS, my_mapping_proxy%fs_to, "
-            "dim_w1, ndf_w1, basis_w1_qr)" in gen_str)
-    assert (
-        "orientation_w2 => my_mapping_proxy%fs_from%get_cell_orientation("
-        "cell)" in gen_str)
-    assert (
-        "orientation_w1 => my_mapping_proxy%fs_to%get_cell_orientation(cell)"
-        in gen_str)
-    assert ("(cell, nlayers, my_mapping_proxy%ncell_3d, "
-            "my_mapping_proxy%local_stencil, chi_proxy(1)%data, "
-            "chi_proxy(2)%data, chi_proxy(3)%data, ndf_w1, basis_w1_qr, "
-            "orientation_w1, ndf_w2, orientation_w2, ndf_w0, undf_w0, "
-            "map_w0(:,cell), diff_basis_w0_qr, np_xy_qr, np_z_qr, "
-            "weights_xy_qr, weights_z_qr)" in gen_str)
-
-
-def test_operator_deref(tmpdir):
-    ''' Tests that we generate correct names for an operator in the PSy
-    layer when obtained by de-referencing a derived type in the Algorithm
-    layer '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "10.8_operator_deref.f90"),
-                           api=TEST_API)
-    for dist_mem in [True, False]:
-        psy = PSyFactory(TEST_API,
-                         distributed_memory=dist_mem).create(invoke_info)
-        generated_code = str(psy.gen)
-        print(generated_code)
-        assert Dynamo0p3Build(tmpdir).code_compiles(psy)
-
-        assert ("SUBROUTINE invoke_0_testkern_operator"
-                "_type(mm_w0_op, chi, a, qr)" in generated_code)
-        assert ("TYPE(operator_type), intent(inout) :: mm_w0_op" in
-                generated_code)
-        assert "TYPE(operator_proxy_type) mm_w0_op_proxy" in generated_code
-        assert "mm_w0_op_proxy = mm_w0_op%get_proxy()" in generated_code
-        assert (
-            "CALL testkern_operator_code(cell, nlayers, "
-            "mm_w0_op_proxy%ncell_3d, mm_w0_op_proxy%local_stencil, "
-            "chi_proxy(1)%data, chi_proxy(2)%data, chi_proxy(3)%data, a, "
-            "ndf_w0, undf_w0, map_w0(:,cell), basis_w0_qr, "
-            "diff_basis_w0_qr, np_xy_qr, np_z_qr, weights_xy_qr, "
-            "weights_z_qr)" in generated_code)
-
-
-def test_operator_no_dofmap_lookup():
-    ''' Check that we use a field rather than an operator to look-up
-    a dofmap, even when the operator precedes the field in the argument
-    list. '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.9_operator_first.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    gen_code = str(psy.gen)
-    print(gen_code)
-    # Check that we use the field and not the operator to look-up the dofmap
-    assert "theta_proxy%vspace%get_whole_dofmap()" in gen_code
-    assert gen_code.count("get_whole_dofmap") == 1
-
-
-def test_operator_read_level1_halo():
-    ''' Check that we raise an error if a kernel attempts to read from an
-    operator beyond the level-1 halo '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "10.7_operator_read.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-    loop = schedule.children[0]
-    # Modify the loop bound so that we attempt to read from the L2 halo
-    # (of the operator)
-    loop.set_upper_bound("cell_halo", index=2)
-    # Attempt to generate the code
-    with pytest.raises(GenerationError) as excinfo:
-        _ = psy.gen
-    assert ("Kernel 'testkern_operator_code' reads from an operator and "
-            "therefore cannot be used for cells beyond the level 1 halo. "
-            "However the containing loop goes out to level 2" in str(excinfo))
 
 
 def test_any_space_1(tmpdir):
@@ -2135,29 +1750,6 @@ def test_bc_kernel_field_only(monkeypatch, annexed, dist_mem):
     assert ("Expected a gh_field from which to look-up boundary dofs "
             "for kernel enforce_bc_code but got gh_operator"
             in str(excinfo))
-
-
-def test_operator_bc_kernel(tmpdir):
-    ''' Tests that a kernel with a particular name is recognised as a
-    kernel that applies boundary conditions to operators and that
-    appropriate code is added to support this. '''
-    _, invoke_info = parse(os.path.join(BASE_PATH,
-                                        "12.4_enforce_op_bc_kernel.f90"),
-                           api=TEST_API)
-    psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
-    generated_code = str(psy.gen)
-    print(generated_code)
-    output1 = "INTEGER, pointer :: boundary_dofs_op_a(:,:) => null()"
-    assert output1 in generated_code
-    output2 = "boundary_dofs_op_a => op_a_proxy%fs_to%get_boundary_dofs()"
-    assert output2 in generated_code
-    output3 = (
-        "CALL enforce_operator_bc_code(cell, nlayers, op_a_proxy%ncell_3d, "
-        "op_a_proxy%local_stencil, ndf_any_space_1_op_a, "
-        "ndf_any_space_2_op_a, boundary_dofs_op_a)")
-    assert output3 in generated_code
-
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
 
 
 def test_bc_kernel_anyspace1_only():
@@ -3164,7 +2756,7 @@ def test_halo_dirty_4():
         "      !\n"
         "      CALL chi_proxy(1)%set_dirty()\n"
         "      CALL chi_proxy(2)%set_dirty()\n"
-        "      CALL chi_proxy(3)%set_dirty()\n"                                 
+        "      CALL chi_proxy(3)%set_dirty()\n"
         "      CALL f1_proxy%set_dirty()\n")
     assert expected in generated_code
 
@@ -3541,7 +3133,7 @@ def test_mesh_mod(tmpdir):
                            api=TEST_API)
     psy = PSyFactory(TEST_API, distributed_memory=True).create(invoke_info)
     result = str(psy.gen)
-    assert Dynamo0p3Build(tmpdir).code_compiles(psy)    
+    assert Dynamo0p3Build(tmpdir).code_compiles(psy)
     assert "USE mesh_mod, ONLY: mesh_type" in result
     assert "TYPE(mesh_type), pointer :: mesh => null()" in result
     output = ("      !\n"


### PR DESCRIPTION
This PR is for issue  #465. 

All duplicate operator tests from `dynamo0p3_test.py` that were copied and further developed in `dynamo0p3_lma_test.py` are removed (see [comment 1 in issue 465](https://github.com/stfc/PSyclone/issues/465#issue-477951797)) for the complete list. I decided not to move the other 4 tests that are also listed there (not duplicates but still operator tests). This can be done at the reviewer's request.
I also cleaned up `pycodestyle` errors in both tests.