### PR TITLE
Exclude Return nodes from profiling regions (closes #820)

### DIFF
--- a/changelog
+++ b/changelog
@@ -40,6 +40,11 @@
 	16) #808 for #800. Adds support in the PSyIR for the case when a
 	variable used to dimension an array has deferred or unknown type.
 
+	17) #822 for #820. Excludes return statements from profile and
+	directive regions. Also reworks the relevant code to exclude nodes
+	rather than include them which makes more sense as exclusion is
+	the exception.
+
 release 1.9.0 20th May 2020
 
 	1) #602 for #597. Modify Node.ancestor() to optionally include

--- a/src/psyclone/psyir/transformations/profile_trans.py
+++ b/src/psyclone/psyir/transformations/profile_trans.py
@@ -38,7 +38,7 @@
 '''This module provides the Profile transformation.
 '''
 
-from psyclone.psyir.nodes import Node, ProfileNode
+from psyclone.psyir.nodes import Return, ProfileNode
 from psyclone.psyir.transformations.psy_data_trans import PSyDataTrans
 
 
@@ -72,7 +72,7 @@ class ProfileTrans(PSyDataTrans):
     '''
     # Unlike other transformations we can be fairly relaxed about the nodes
     # that a region can contain as we don't have to understand them.
-    valid_node_types = (Node,)
+    excluded_node_types = (Return,)
 
     def __init__(self):
         super(ProfileTrans, self).__init__(ProfileNode)

--- a/src/psyclone/psyir/transformations/psy_data_trans.py
+++ b/src/psyclone/psyir/transformations/psy_data_trans.py
@@ -38,7 +38,7 @@
 '''
 
 from psyclone.configuration import Config
-from psyclone.psyir.nodes import Node, PSyDataNode, Schedule
+from psyclone.psyir.nodes import PSyDataNode, Schedule, Return
 from psyclone.psyGen import InvokeSchedule
 from psyclone.psyir.transformations.region_trans import RegionTrans
 from psyclone.psyir.transformations.transformation_error \
@@ -80,7 +80,7 @@ class PSyDataTrans(RegionTrans):
     # Unlike other transformations we can be fairly relaxed about the nodes
     # that a region can contain as we don't have to understand them.
     # TODO: #415 Support different classes of PSyData calls.
-    valid_node_types = (Node,)
+    excluded_node_types = (Return,)
 
     def __init__(self, node_class=PSyDataNode):
         super(PSyDataTrans, self).__init__()

--- a/src/psyclone/psyir/transformations/region_trans.py
+++ b/src/psyclone/psyir/transformations/region_trans.py
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # BSD 3-Clause License
 #
-# Copyright (c) 2017-2019, Science and Technology Facilities Council.
+# Copyright (c) 2017-2020, Science and Technology Facilities Council.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -35,7 +35,8 @@
 #        J. Henrichs, Bureau of Meteorology
 # Modified I. Kavcic, Met Office
 
-'''This module contains the base class RegionTrans.
+'''This module contains the base class RegionTrans. All transformations which
+   act on a region of code (list of PSyIR nodes) sub-class this one.
 '''
 
 import abc
@@ -58,12 +59,12 @@ class RegionTrans(Transformation):
     the original AST, no node is duplicated, and that all nodes have
     the same parent. We also check that all nodes to be enclosed are
     valid for this transformation - this requires that the sub-class
-    populate the `valid_node_types` tuple.
+    populate the `excluded_node_types` tuple.
 
     '''
-    # The types of Node that we support within this region. Must be
+    # The types of Node that are excluded from within this region. Must be
     # populated by sub-class.
-    valid_node_types = ()
+    excluded_node_types = ()
 
     def get_node_list(self, nodes):
         '''This is a helper function for region based transformations.
@@ -169,10 +170,11 @@ class RegionTrans(Transformation):
                 flat_list = [item for item in child.walk(object, Kern)
                              if not isinstance(item, Schedule)]
                 for item in flat_list:
-                    if not isinstance(item, self.valid_node_types):
+                    if isinstance(item, self.excluded_node_types):
                         raise TransformationError(
                             "Nodes of type '{0}' cannot be enclosed by a {1} "
-                            "transformation".format(type(item), self.name))
+                            "transformation".format(type(item).__name__,
+                                                    self.name))
 
         # If we've been passed a list that contains one or more Schedules
         # then something is wrong. e.g. two Schedules that are both children

--- a/src/psyclone/tests/domain/gocean/transformations/gocean1p0_transformations_test.py
+++ b/src/psyclone/tests/domain/gocean/transformations/gocean1p0_transformations_test.py
@@ -994,7 +994,7 @@ def test_omp_region_invalid_node():
 
     with pytest.raises(TransformationError) as err:
         _, _ = ompr.apply(new_sched.children)
-    assert ("ACCParallelDirective'>' cannot be enclosed by a "
+    assert ("ACCParallelDirective' cannot be enclosed by a "
             "OMPParallelTrans transformation" in str(err.value))
 
     # Check that the test can be disabled with the appropriate option:
@@ -1609,7 +1609,7 @@ def test_acc_parallel_invalid_node():
     # Attempt to enclose the enter-data directive within a parallel region
     with pytest.raises(TransformationError) as err:
         _, _ = accpara.apply(new_sched.children[0])
-    assert ("GOACCEnterDataDirective'>' cannot be enclosed by a "
+    assert ("'GOACCEnterDataDirective' cannot be enclosed by a "
             "ACCParallelTrans transformation" in str(err.value))
 
 

--- a/src/psyclone/tests/domain/lfric/transformations/dynamo0p3_transformations_test.py
+++ b/src/psyclone/tests/domain/lfric/transformations/dynamo0p3_transformations_test.py
@@ -1360,8 +1360,8 @@ def test_omp_par_and_halo_exchange_error():
     # Enclose the invoke code within a single region
     with pytest.raises(TransformationError) as excinfo:
         schedule, _ = rtrans.apply(schedule.children)
-    assert "A halo exchange within a parallel region is not supported" \
-        in str(excinfo.value)
+    assert ("type 'DynHaloExchange' cannot be enclosed by a OMPParallelTrans "
+            "transformation" in str(excinfo.value))
 
 
 def test_module_inline(monkeypatch, annexed, dist_mem):

--- a/src/psyclone/tests/domain/lfric/transformations/lfric_extract_test.py
+++ b/src/psyclone/tests/domain/lfric/transformations/lfric_extract_test.py
@@ -49,6 +49,7 @@ from psyclone.psyir.nodes import ExtractNode, Loop
 from psyclone.psyir.transformations import TransformationError
 from psyclone.tests.utilities import get_invoke
 from psyclone.tests.lfric_build import LFRicBuild
+from psyclone.configuration import Config
 
 # API names
 DYNAMO_API = "dynamo0.3"
@@ -119,14 +120,12 @@ def test_distmem_error(monkeypatch):
     # Try applying Extract transformation to Node(s) containing HaloExchange
     # We have to disable distributed memory, otherwise an earlier test
     # will be triggered
-    from psyclone.configuration import Config
     config = Config.get()
     monkeypatch.setattr(config, "distributed_memory", False)
     with pytest.raises(TransformationError) as excinfo:
         _, _ = etrans.apply(schedule.children[2:4])
-    assert ("Nodes of type '<class 'psyclone.dynamo0p3.DynHaloExchange'>' "
-            "cannot be enclosed by a LFRicExtractTrans "
-            "transformation") in str(excinfo.value)
+    assert ("Nodes of type 'DynHaloExchange' cannot be enclosed by a "
+            "LFRicExtractTrans transformation") in str(excinfo.value)
 
     # Try applying Extract transformation to Node(s) containing GlobalSum
     # This will set config.distributed_mem to True again.
@@ -141,9 +140,8 @@ def test_distmem_error(monkeypatch):
     with pytest.raises(TransformationError) as excinfo:
         _, _ = etrans.apply(glob_sum)
 
-    assert ("Nodes of type '<class 'psyclone.dynamo0p3.DynGlobalSum'>' "
-            "cannot be enclosed by a LFRicExtractTrans "
-            "transformation") in str(excinfo.value)
+    assert ("Nodes of type 'DynGlobalSum' cannot be enclosed by a "
+            "LFRicExtractTrans transformation") in str(excinfo.value)
 
 
 def test_repeat_extract():
@@ -160,10 +158,8 @@ def test_repeat_extract():
     # Now try applying it again on the ExtractNode
     with pytest.raises(TransformationError) as excinfo:
         _, _ = etrans.apply(schedule.children[0])
-    assert ("Nodes of type '<class "
-            "'psyclone.psyir.nodes.extract_node.ExtractNode'>' "
-            "cannot be enclosed by a LFRicExtractTrans "
-            "transformation") in str(excinfo.value)
+    assert ("Nodes of type 'ExtractNode' cannot be enclosed by a "
+            "LFRicExtractTrans transformation") in str(excinfo.value)
 
 
 def test_kern_builtin_no_loop():

--- a/src/psyclone/tests/nemo/transformations/openacc/data_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/data_directive_test.py
@@ -379,11 +379,11 @@ def test_no_code_blocks(parser):
     acc_trans = TransInfo().get_trans_name('ACCDataTrans')
     with pytest.raises(TransformationError) as err:
         _, _ = acc_trans.apply(schedule.children[0:1])
-    assert ("CodeBlock'>' cannot be enclosed by a ACCDataTrans"
+    assert ("'CodeBlock' cannot be enclosed by a ACCDataTrans"
             in str(err.value))
     with pytest.raises(TransformationError) as err:
         _, _ = acc_trans.apply(schedule.children[1:2])
-    assert ("CodeBlock'>' cannot be enclosed by a ACCDataTrans"
+    assert ("'CodeBlock' cannot be enclosed by a ACCDataTrans"
             in str(err.value))
 
 

--- a/src/psyclone/tests/nemo/transformations/openacc/kernels_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/kernels_directive_test.py
@@ -230,7 +230,7 @@ def test_no_code_block_kernels(parser):
     acc_trans = ACCKernelsTrans()
     with pytest.raises(TransformationError) as err:
         _, _ = acc_trans.apply(schedule.children)
-    assert ("CodeBlock'>' cannot be enclosed by a ACCKernelsTrans "
+    assert ("'CodeBlock' cannot be enclosed by a ACCKernelsTrans "
             in str(err.value))
 
 

--- a/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
+++ b/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
@@ -524,3 +524,20 @@ def test_only_profile():
     correct_re = "PSyData.update is only supported for a ProfileNode, not " \
         "for a node of type .*DummyNode'>."
     assert re.search(correct_re, str(err.value))
+
+
+def test_no_return_in_profiling(parser):
+    ''' Check that the transformation refuses to include a Return node within
+    a profiled region. '''
+    psy, schedule = get_nemo_schedule(
+        parser,
+        "function my_test()\n"
+        "  integer :: my_test\n"
+        "  real :: my_array(3,3)\n"
+        "  my_array(:,:) = 0.0\n"
+        "  my_test = 1\n"
+        "  return\n"
+        "end function my_test\n")
+    with pytest.raises(TransformationError) as err:
+        PTRANS.apply(schedule.children)
+    assert "hohoho" in str(err.value)

--- a/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
+++ b/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
@@ -529,7 +529,7 @@ def test_only_profile():
 def test_no_return_in_profiling(parser):
     ''' Check that the transformation refuses to include a Return node within
     a profiled region. '''
-    psy, schedule = get_nemo_schedule(
+    _, schedule = get_nemo_schedule(
         parser,
         "function my_test()\n"
         "  integer :: my_test\n"
@@ -540,4 +540,5 @@ def test_no_return_in_profiling(parser):
         "end function my_test\n")
     with pytest.raises(TransformationError) as err:
         PTRANS.apply(schedule.children)
-    assert "hohoho" in str(err.value)
+    assert ("Nodes of type 'Return' cannot be enclosed by a ProfileTrans "
+            "transformation" in str(err.value))

--- a/src/psyclone/tests/psyir/transformations/region_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/region_trans_test.py
@@ -43,6 +43,7 @@ from psyclone.psyir.transformations import TransformationError
 from psyclone.psyir.nodes import Node, Schedule
 from psyclone.psyir.transformations import RegionTrans
 from psyclone.tests.utilities import get_invoke
+from psyclone.gocean1p0 import GOLoop
 
 
 class MyRegionTrans(RegionTrans):
@@ -161,13 +162,15 @@ def test_validate_errors():
     assert "Transformation apply method options argument must be a " \
         "dictionary" in str(err.value)
 
-    my_rt.valid_node_types = ()
+    # Check that the tuple of excluded node types is used correctly (by
+    # resetting it here to a Loop which is within the region)
+    my_rt.excluded_node_types = (GOLoop,)
     node_list = [schedule.children[0], schedule.children[1],
                  schedule.children[2]]
     with pytest.raises(TransformationError) as err:
         my_rt.validate(node_list)
-    assert "Transformation Error: Nodes of type '<class 'psyclone.gocean1p0."\
-        "GOLoop'>' cannot be enclosed" in str(err.value)
+    assert ("Transformation Error: Nodes of type 'GOLoop' cannot be enclosed"
+            in str(err.value))
 
 
 # -----------------------------------------------------------------------------

--- a/src/psyclone/tests/psyir/transformations/region_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/region_trans_test.py
@@ -51,7 +51,7 @@ class MyRegionTrans(RegionTrans):
     abstract, so create a simple class that can be instantiated
     by adding dummy implementations of the missing methods.
     '''
-    valid_node_types = (Node, )
+    excluded_node_types = ()
 
     def apply(self, node, options=None):
         '''Dummy only to make this not abstract.'''


### PR DESCRIPTION
This PR fixes #820. It also changes the way transformation validation is done so that each transformation now has a list of node types that must be *excluded* instead of a list of nodes that are permitted. As such, it also fixes #493 although I think we have to permit Subroutine calls as that's precisely what both the GOcean and LFRic APIs are designed to do.