### PR TITLE
(closes #833) Add PSyIR support for NINT()

### DIFF
--- a/changelog
+++ b/changelog
@@ -48,6 +48,10 @@
 	18) #796 for #412. Adds a transformation to convert an assignment
 	to an array range into an explicit loop in the PSyIR.
 
+	19) #834 for #833. Adds the NINT intrinsic to the PSyIR and adds
+	support in fparser2reader for translating Fortran NINT into this
+	intrinsic.
+
 release 1.9.0 20th May 2020
 
 	1) #602 for #597. Modify Node.ancestor() to optionally include

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -470,6 +470,7 @@ class Fparser2Reader(object):
         ('atan', UnaryOperation.Operator.ATAN),
         ('sqrt', UnaryOperation.Operator.SQRT),
         ('real', UnaryOperation.Operator.REAL),
+        ('nint', UnaryOperation.Operator.NINT),
         ('int', UnaryOperation.Operator.INT)])
 
     binary_operators = OrderedDict([

--- a/src/psyclone/psyir/nodes/operation.py
+++ b/src/psyclone/psyir/nodes/operation.py
@@ -135,7 +135,7 @@ class UnaryOperation(Operation):
         # Other Maths Operators
         'ABS', 'CEIL',
         # Casting Operators
-        'REAL', 'INT'
+        'REAL', 'INT', 'NINT'
         ])
 
     @staticmethod

--- a/src/psyclone/tests/psyir/frontend/fparser2_nint_intrinsic_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_nint_intrinsic_test.py
@@ -1,0 +1,74 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2020, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Author A. R. Porter, STFC Daresbury Laboratory
+
+''' Module containing pytest tests for the handling of the NINT intrinsic
+in the PSyIR. '''
+
+from __future__ import absolute_import
+
+from fparser.common.readfortran import FortranStringReader
+from psyclone.psyir.frontend.fparser2 import Fparser2Reader
+
+TEST_CODE = '''
+ PROGRAM my_test
+  INTEGER :: irgb
+  REAL :: zchl, zekb(10, 10)
+
+  irgb = NINT(41 + 20. * LOG10(zchl) + 1.E-15)
+  irgb = irgb + NINT(zekb(1,1) + 4.5 + zchl)
+
+END PROGRAM my_test
+'''
+
+
+def test_nint(parser):
+    ''' Basic test that the NINT intrinsic is recognised and represented
+    in the PSyIR.
+
+    '''
+    from psyclone.psyir.nodes import Assignment, UnaryOperation, \
+        BinaryOperation
+    processor = Fparser2Reader()
+    reader = FortranStringReader(TEST_CODE)
+    ptree = parser(reader)
+    sched = processor.generate_schedule("my_test", ptree)
+    assert isinstance(sched[0], Assignment)
+    assert isinstance(sched[0].rhs, UnaryOperation)
+    assert sched[0].rhs.operator == UnaryOperation.Operator.NINT
+    assert isinstance(sched[0].rhs.children[0], BinaryOperation)
+    assert isinstance(sched[1], Assignment)
+    assert isinstance(sched[1].rhs, BinaryOperation)
+    assert isinstance(sched[1].rhs.children[1], UnaryOperation)
+    assert sched[1].rhs.children[1].operator == UnaryOperation.Operator.NINT


### PR DESCRIPTION
A small PR that just extends the existing UnaryOperator support to include NINT.