### PR TITLE
(closes #1120) add bibtex_bibfiles entry to conf.py for UG and DG

### DIFF
--- a/changelog
+++ b/changelog
@@ -354,11 +354,16 @@
         114) PR #1054 for #1047. Adds check that the intrinsic types of
         scalar arguments in the LFRic API are consistent. Extends argument-
         filtering routines to additionally filter on intrinsic type.
-	
+
 	115) PR #1102 towards #1031. Improves PSyIR fparser2 frontend support for
 	structures types.
 
 	116) PR #1111 for #1110. The Call create method is a classmethod.
+
+	117) PR #1121 for #1120. Introduce bibtex_bibfiles to Sphinx UG
+	and DG config files to fix latex build errors in the latest
+	version of Sphinx which were causing read the docs to fail to
+	build the documentation.
 
 release 1.9.0 20th May 2020
 

--- a/doc/developer_guide/conf.py
+++ b/doc/developer_guide/conf.py
@@ -32,6 +32,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
               'sphinx.ext.imgmath', 'sphinx.ext.viewcode',
               'sphinxcontrib.bibtex']
+bibtex_bibfiles = ['../bibliography/references.bib']
 
 # Enable numbered referencing of figures (use with :numref:`my-fig-reference`)
 numfig = True

--- a/doc/user_guide/conf.py
+++ b/doc/user_guide/conf.py
@@ -32,6 +32,7 @@ extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest',
               'sphinx.ext.intersphinx', 'sphinx.ext.coverage',
               'sphinx.ext.imgmath', 'sphinx.ext.viewcode',
               'sphinxcontrib.bibtex']
+bibtex_bibfiles = ['../bibliography/references.bib']
 
 # Enable numbered referencing of figures (use with :numref:`my-fig-reference`)
 numfig = True


### PR DESCRIPTION
Tiny PR that just fixes build errors on Read The Docs. I could reproduce those errors locally by doing `pip install --upgrade sphinxcontrib-bibtex` and then attempting to build the docs.