### PR TITLE
(closes #1334) Extend psyir_from_expression to support symbols

### DIFF
--- a/examples/gocean/eg2/acc_transform.py
+++ b/examples/gocean/eg2/acc_transform.py
@@ -69,7 +69,7 @@ def trans(psy):
 
     # Put an 'acc routine' directive inside each kernel
     for kern in schedule.coded_kernels():
-        ktrans.apply(kern)
+        ktrans.apply(kern, options={"ignore-global-var-list": ["go_wp"]})
         # Ideally we would module-inline the kernel here (to save having to
         # rely on the compiler to do it) but this does not currently work
         # for the fparser2 AST (issue #229).

--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -8778,7 +8778,7 @@ class DynKernelArgument(KernelArgument):
 
         if self.is_literal:
             reader = FortranReader()
-            return reader.psyir_from_expression(self.name)
+            return reader.psyir_from_expression(self.name, symbol_table)
 
         if self.is_scalar:
             try:

--- a/src/psyclone/tests/domain/lfric/lfric_builtins_test.py
+++ b/src/psyclone/tests/domain/lfric/lfric_builtins_test.py
@@ -2135,6 +2135,8 @@ def test_inc_X_powreal_a(tmpdir, monkeypatch, annexed, dist_mem):
         if not annexed:
             output = output.replace("dof_annexed", "dof_owned")
         assert output in code
+        assert ("f1_proxy%data(df) = f1_proxy%data(df) ** 1.0e-3_r_def\n"
+                in code)
 
 
 def test_inc_X_powint_n(tmpdir, monkeypatch, annexed, dist_mem):
@@ -2190,7 +2192,7 @@ def test_inc_X_powint_n(tmpdir, monkeypatch, annexed, dist_mem):
             output = output.replace("dof_annexed", "dof_owned")
         assert output in code
 
-        assert "f1_proxy%data(df) = f1_proxy%data(df) ** (-2)\n" in code
+        assert "f1_proxy%data(df) = f1_proxy%data(df) ** (-2_i_def)\n" in code
         assert ("f1_proxy%data(df) = f1_proxy%data(df) ** my_var_a_scalar\n"
                 in code)
 

--- a/src/psyclone/tests/nemo/nemo_psy_test.py
+++ b/src/psyclone/tests/nemo/nemo_psy_test.py
@@ -172,6 +172,7 @@ def test_fn_call_no_kernel(parser):
     ''' Check that we don't create a kernel if the loop body contains a
     function call. '''
     reader = FortranStringReader("program fn_call\n"
+                                 "use types_mod, only: wp\n"
                                  "integer :: ji, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "do ji = 1,jpj\n"
@@ -254,6 +255,7 @@ def test_kern_sched_parents(parser):
     ''' Check that the children of a Kernel schedule have that schedule
     as their parent. '''
     reader = FortranStringReader("program fake_kern\n"
+                                 "use types_mod, only: wp\n"
                                  "integer :: ji, jj, jpi, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5,5)\n"
                                  "do ji = 1,jpi\n"

--- a/src/psyclone/tests/nemo/transformations/openacc/data_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/data_directive_test.py
@@ -315,6 +315,7 @@ END subroutine data_ref
 def test_data_ref_read(parser):
     ''' Check support for reading from derived types. '''
     reader = FortranStringReader("program dtype_read\n"
+                                 "use types_mod, only: wp\n"
                                  "use field_mod, only: fld_type\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "integer :: ji\n"
@@ -349,6 +350,7 @@ def test_kind_parameter(parser):
     ''' Check that we don't attempt to put kind parameters into the list
     of variables to copyin/out. '''
     reader = FortranStringReader("program kind_param\n"
+                                 "use types_mod, only: wp\n"
                                  "integer :: ji, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "do ji = 1,jpj\n"
@@ -373,6 +375,7 @@ def test_no_copyin_intrinsics(parser):
                       "mod(ji, 5)"]:
         reader = FortranStringReader(
             "program call_intrinsic\n"
+            "use types_mod, only: wp\n"
             "integer :: ji, jpj\n"
             "real(kind=wp) :: sto_tmp(5)\n"
             "do ji = 1,jpj\n"
@@ -392,6 +395,7 @@ def test_no_code_blocks(parser):
     ''' Check that we refuse to include CodeBlocks (i.e. code that we
     don't recognise) within a data region. '''
     reader = FortranStringReader("program write_out\n"
+                                 "use types_mod, only: wp\n"
                                  " integer :: ji, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "do ji = 1,jpj\n"
@@ -419,6 +423,7 @@ def test_kernels_in_data_region(parser):
     ''' Check that directives end up in the correct locations when enclosing
     a kernels region inside a data region. '''
     reader = FortranStringReader("program one_loop\n"
+                                 "use types_mod, only: wp\n"
                                  "integer :: ji, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "do ji = 1,jpj\n"
@@ -464,6 +469,7 @@ def test_array_access_in_ifblock(parser):
     ''' Check that we generate the necessary copyin clause when a data region
     contains an IF clause with an array access. '''
     code = ("program ifclause\n"
+            "  use types_mod, only: wp\n"
             "  real(kind=wp) :: zmask(8,8), zdta(8,8)\n"
             "  integer :: ji, jj\n"
             "  zmask(:,:) = 1.0\n"
@@ -492,6 +498,7 @@ def test_array_access_loop_bounds(parser):
     ''' Check that we raise the expected error if our code that identifies
     read and write accesses misses an array access. '''
     code = ("program do_bound\n"
+            "  use types_mod, only: wp\n"
             "  real(kind=wp) :: trim_width(8), zdta(8,8)\n"
             "  integer :: ji, jj, dom\n"
             "  do jj = 1, trim_width(dom)\n"
@@ -516,6 +523,7 @@ def test_missed_array_case(parser):
     sanity check spots that we've missed an array access.
     TODO #309 - remove this test. '''
     code = ("program do_bound\n"
+            "  use types_mod, only: wp\n"
             "  integer :: ice_mask(8,8)\n"
             "  real(kind=wp) :: trim_width(8), zdta(8,8)\n"
             "  integer :: ji, jj, dom\n"

--- a/src/psyclone/tests/nemo/transformations/openacc/kernels_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/kernels_directive_test.py
@@ -54,6 +54,7 @@ from psyclone.errors import GenerationError
 API = "nemo"
 
 EXPLICIT_LOOP = ("program do_loop\n"
+                 "use types_mod, only: wp\n"
                  "integer :: ji\n"
                  "integer, parameter :: jpj=32\n"
                  "real(kind=wp) :: sto_tmp(jpj)\n"
@@ -101,6 +102,7 @@ def test_no_kernels_error(parser):
     ''' Check that the transformation rejects an attempt to put things
     that aren't kernels inside a kernels region. '''
     reader = FortranStringReader("program write_out\n"
+                                 "use types_mod, only: wp\n"
                                  "integer :: ji, jpj\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"
                                  "do ji = 1,jpj\n"
@@ -143,6 +145,7 @@ def test_implicit_loop(parser):
     ''' Check that the transformation generates correct code when applied
     to an implicit loop. '''
     reader = FortranStringReader("program implicit_loop\n"
+                                 "use types_mod, only: wp\n"
                                  "real(kind=wp) :: sto_tmp(5,5)\n"
                                  "sto_tmp(:,:) = 0.0_wp\n"
                                  "end program implicit_loop\n")
@@ -161,6 +164,7 @@ def test_multikern_if(parser):
     ''' Check that we can include an if-block containing multiple
     loops within a kernels region. '''
     reader = FortranStringReader("program implicit_loop\n"
+                                 "use types_mod, only: wp\n"
                                  "logical :: do_this\n"
                                  "integer :: jk\n"
                                  "real(kind=wp) :: sto_tmp(5)\n"

--- a/src/psyclone/tests/nemo/transformations/openacc/loop_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/loop_directive_test.py
@@ -119,6 +119,7 @@ def test_explicit_loop(parser):
 
 
 SINGLE_LOOP = ("program do_loop\n"
+               "use types_mod, only: wp\n"
                "integer :: ji\n"
                "integer, parameter :: jpj=12\n"
                "real(kind=wp) :: sto_tmp(jpj)\n"
@@ -128,6 +129,7 @@ SINGLE_LOOP = ("program do_loop\n"
                "end program do_loop\n")
 
 DOUBLE_LOOP = ("program do_loop\n"
+               "use types_mod, only: wp\n"
                "integer :: ji, jj\n"
                "integer, parameter :: jpi=16, jpj=16\n"
                "real(kind=wp) :: sto_tmp(jpi, jpj)\n"

--- a/src/psyclone/tests/nemo/transformations/openacc/parallel_directive_test.py
+++ b/src/psyclone/tests/nemo/transformations/openacc/parallel_directive_test.py
@@ -48,6 +48,7 @@ API = "nemo"
 
 
 SINGLE_LOOP = ("program do_loop\n"
+               "use type_mod, only: wp\n"
                "integer :: ji\n"
                "integer, parameter :: jpj=128\n"
                "real(kind=wp) :: sto_tmp(jpj)\n"
@@ -68,20 +69,21 @@ def test_parallel_single_loop(parser):
     acc_trans = TransInfo().get_trans_name('ACCParallelTrans')
     acc_trans.apply(schedule[0:1])
     data_trans.apply(schedule[0])
-    code = str(psy.gen)
+    code = str(psy.gen).lower()
 
-    assert ("PROGRAM do_loop\n"
-            "  INTEGER :: ji\n"
-            "  INTEGER, PARAMETER :: jpj = 128\n"
-            "  REAL(KIND = wp) :: sto_tmp(jpj)\n"
-            "  !$ACC DATA COPYOUT(sto_tmp)\n"
-            "  !$ACC PARALLEL DEFAULT(PRESENT)\n"
-            "  DO ji = 1, jpj\n"
-            "    sto_tmp(ji) = 1.0D0\n"
-            "  END DO\n"
-            "  !$ACC END PARALLEL\n"
-            "  !$ACC END DATA\n"
-            "END PROGRAM do_loop" in code)
+    assert ("program do_loop\n"
+            "  use type_mod, only: wp\n"
+            "  integer :: ji\n"
+            "  integer, parameter :: jpj = 128\n"
+            "  real(kind = wp) :: sto_tmp(jpj)\n"
+            "  !$acc data copyout(sto_tmp)\n"
+            "  !$acc parallel default(present)\n"
+            "  do ji = 1, jpj\n"
+            "    sto_tmp(ji) = 1.0d0\n"
+            "  end do\n"
+            "  !$acc end parallel\n"
+            "  !$acc end data\n"
+            "end program do_loop" in code)
 
 
 def test_parallel_two_loops(parser):

--- a/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
+++ b/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
@@ -298,6 +298,7 @@ def test_profiling_case(parser):
     to the fparser2 parse tree. '''
     code = (
         "subroutine my_test()\n"
+        "   use kind_params_mod, only: wp\n"
         "   integer :: ji, jj, ii, je_2, jpi, jpj, nldj_crs\n"
         "   integer :: nistr, niend, njstr, njend, nn_factx, nn_facty\n"
         "   integer, dimension(:) :: mje_crs, mjs_crs, mis_crs\n"

--- a/src/psyclone/tests/psyGen_test.py
+++ b/src/psyclone/tests/psyGen_test.py
@@ -1948,6 +1948,7 @@ def test_acckernelsdirective_update(parser, default_present):
 
     '''
     reader = FortranStringReader("program implicit_loop\n"
+                                 "use types_mod, only: wp\n"
                                  "real(kind=wp) :: sto_tmp(5,5)\n"
                                  "sto_tmp(:,:) = 0.0_wp\n"
                                  "end program implicit_loop\n")

--- a/src/psyclone/tests/psyir/backend/psyir_openacc_test.py
+++ b/src/psyclone/tests/psyir/backend/psyir_openacc_test.py
@@ -67,6 +67,7 @@ end subroutine tmp
 end module test'''
 
 DOUBLE_LOOP = ("program do_loop\n"
+               "use kind_params_mod, only: wp\n"
                "integer :: ji, jj\n"
                "integer, parameter :: jpi=16, jpj=16\n"
                "real(kind=wp) :: sto_tmp(jpi, jpj)\n"

--- a/src/psyclone/tests/psyir/frontend/fortran_test.py
+++ b/src/psyclone/tests/psyir/frontend/fortran_test.py
@@ -44,6 +44,8 @@ from psyclone.psyir.frontend.fortran import FortranReader
 from psyclone.psyir.frontend.fparser2 import Fparser2Reader
 from psyclone.psyir.nodes import Routine, FileContainer, UnaryOperation, \
     BinaryOperation, Literal
+from psyclone.psyir.symbols import SymbolTable, DataSymbol, \
+    ScalarType, SymbolError, ContainerSymbol
 
 
 # The 'contiguous' keyword is just valid with Fortran 2008
@@ -86,46 +88,68 @@ def test_fortran_psyir_from_source():
 def test_fortran_psyir_from_expression(fortran_reader):
     ''' Test that the psyir_from_expression method generates the
     expected PSyIR. '''
-    psyir = fortran_reader.psyir_from_expression("3.0")
+    table = SymbolTable()
+    psyir = fortran_reader.psyir_from_expression("3.0", table)
     assert isinstance(psyir, Literal)
     assert psyir.value == "3.0"
-    psyir = fortran_reader.psyir_from_expression("-3.0 + 1.0")
+    psyir = fortran_reader.psyir_from_expression("-3.0 + 1.0", table)
     assert isinstance(psyir, BinaryOperation)
     assert psyir.operator == BinaryOperation.Operator.ADD
     assert isinstance(psyir.children[0], UnaryOperation)
     assert psyir.children[0].operator == UnaryOperation.Operator.MINUS
     assert isinstance(psyir.children[0].children[0], Literal)
     assert psyir.children[0].children[0].value == "3.0"
-    psyir = fortran_reader.psyir_from_expression("ABS(-3.0)")
+    psyir = fortran_reader.psyir_from_expression("ABS(-3.0)", table)
     assert isinstance(psyir, UnaryOperation)
     assert psyir.operator == UnaryOperation.Operator.ABS
     assert isinstance(psyir.children[0], UnaryOperation)
     assert psyir.children[0].operator == UnaryOperation.Operator.MINUS
     assert isinstance(psyir.children[0].children[0], Literal)
-    with pytest.raises(NotImplementedError) as err:
-        fortran_reader.psyir_from_expression("3.0 + a")
-    assert "Expression must contain only literals: '3.0 + a'" in str(err.value)
-    with pytest.raises(NotImplementedError) as err:
-        fortran_reader.psyir_from_expression("3.0 + sin(a)")
-    assert ("Expression must contain only literals: '3.0 + sin(a)'" in
+    # With kind specified by a kind parameter. Add a ContainerSymbol with a
+    # wildcard import so there's some way that 'r_def' can be brought into
+    # scope.
+    csym = table.new_symbol("kind_params_mod", symbol_type=ContainerSymbol)
+    csym.wildcard_import = True
+    fortran_reader.psyir_from_expression("3.0_r_def", table)
+    assert "r_def" in table
+    psyir = fortran_reader.psyir_from_expression("3.0_r_def", table)
+    assert isinstance(psyir, Literal)
+    assert isinstance(psyir.datatype, ScalarType)
+    assert isinstance(psyir.datatype.precision, DataSymbol)
+    assert psyir.datatype.precision is table.lookup("r_def")
+    # Symbol not found in supplied table
+    with pytest.raises(SymbolError) as err:
+        fortran_reader.psyir_from_expression("3.0 + a", SymbolTable())
+    assert ("Expression contains unresolved symbols: '3.0 + a'" in
             str(err.value))
+    # Now use the table with the container that has the wildcard import
+    psyir = fortran_reader.psyir_from_expression("3.0 + a", table)
+    assert isinstance(psyir, BinaryOperation)
+    assert "a" in table
 
 
 def test_fortran_psyir_from_expression_invalid(fortran_reader):
     ''' Test that the psyir_from_expression method raises the expected
     error when given something that is not an expression. '''
-    with pytest.raises(NotImplementedError) as err:
-        fortran_reader.psyir_from_expression("return")
-    assert "Expression must contain only literals: 'return'" in str(err.value)
+    # No supplied table
+    with pytest.raises(TypeError) as err:
+        fortran_reader.psyir_from_expression("3.0 + sin(a)", None)
+    assert ("Must be supplied with a valid SymbolTable but got 'NoneType'" in
+            str(err.value))
+    table = SymbolTable()
+    with pytest.raises(SymbolError) as err:
+        fortran_reader.psyir_from_expression("return", table)
+    assert ("Expression contains unresolved symbols: 'return'" in
+            str(err.value))
     with pytest.raises(ValueError) as err:
-        fortran_reader.psyir_from_expression("a = b")
+        fortran_reader.psyir_from_expression("a = b", table)
     assert "not represent a Fortran expression: 'a = b'" in str(err.value)
     with pytest.raises(ValueError) as err:
-        fortran_reader.psyir_from_expression("if(3 == 2)then")
+        fortran_reader.psyir_from_expression("if(3 == 2)then", table)
     assert ("not represent a Fortran expression: 'if(3 == 2)then'" in
             str(err.value))
     with pytest.raises(ValueError) as err:
-        fortran_reader.psyir_from_expression("this is not Fortran")
+        fortran_reader.psyir_from_expression("this is not Fortran", table)
     assert ("not represent a Fortran expression: 'this is not Fortran'" in
             str(err.value))
 

--- a/src/psyclone/tests/test_files/dynamo0p3/15.6.1_inc_X_powreal_a_builtin.f90
+++ b/src/psyclone/tests/test_files/dynamo0p3/15.6.1_inc_X_powreal_a_builtin.f90
@@ -1,7 +1,7 @@
 ! -----------------------------------------------------------------------------
 ! BSD 3-Clause License
 !
-! Copyright (c) 2017-2020, Science and Technology Facilities Council.
+! Copyright (c) 2017-2021, Science and Technology Facilities Council.
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,8 @@
 ! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ! POSSIBILITY OF SUCH DAMAGE.
 ! -----------------------------------------------------------------------------
-! Author I. Kavcic Met Office
+! Author: I. Kavcic Met Office
+! Modified: A. R. Porter, STFC Daresbury Laboratory
 
 program single_invoke
 
@@ -45,6 +46,7 @@ program single_invoke
   type(field_type) :: f1
   real(r_def)      :: a_scalar
 
-  call invoke( inc_X_powreal_a(f1, a_scalar) )
+  call invoke( inc_X_powreal_a(f1, a_scalar), &
+               inc_X_powreal_a(f1, 1.0e-3_r_def) )
 
 end program single_invoke

--- a/src/psyclone/tests/test_files/dynamo0p3/15.6.2_inc_X_powint_n_builtin.f90
+++ b/src/psyclone/tests/test_files/dynamo0p3/15.6.2_inc_X_powint_n_builtin.f90
@@ -1,7 +1,7 @@
 ! -----------------------------------------------------------------------------
 ! BSD 3-Clause License
 !
-! Copyright (c) 2017-2020, Science and Technology Facilities Council.
+! Copyright (c) 2017-2021, Science and Technology Facilities Council.
 ! All rights reserved.
 !
 ! Redistribution and use in source and binary forms, with or without
@@ -31,7 +31,8 @@
 ! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 ! POSSIBILITY OF SUCH DAMAGE.
 ! -----------------------------------------------------------------------------
-! Author I. Kavcic Met Office
+! Author: I. Kavcic Met Office
+! Modified: A. R. Porter, STFC Daresbury Laboratory
 
 program single_invoke
 
@@ -52,7 +53,7 @@ program single_invoke
   type(my_type) :: my_var
 
   call invoke( inc_X_powint_n(f1, i_scalar), &
-               inc_X_powint_n(f1, -2),       &
+               inc_X_powint_n(f1, -2_i_def),       &
                inc_X_powint_n(f1, my_var%a_scalar) )
 
 end program single_invoke

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -115,6 +115,9 @@ class KernelTrans(Transformation):
         :type kern: :py:class:`psyclone.psyGen.Kern` or sub-class
         :param options: a dictionary with options for transformations.
         :type options: dictionary of string:values or None
+        :param list options["ignore-global-var-list"]: the names of any global\
+            variables to ignore when checking that all variables referenced by\
+            a kernel are local/arguments (useful e.g. for kind parameters).
 
         :raises TransformationError: if the target node is not a sub-class of \
                                      psyGen.Kern.
@@ -155,11 +158,14 @@ class KernelTrans(Transformation):
                 var.scope.symbol_table.lookup(
                     var.name, scope_limit=var.ancestor(nodes.KernelSchedule))
             except KeyError as err:
-                six.raise_from(TransformationError(
-                    "Kernel '{0}' contains accesses to data (variable '{1}') "
-                    "that are not captured in the PSyIR Symbol Table(s) "
-                    "within KernelSchedule scope. Cannot transform such a "
-                    "kernel.".format(kern.name, var.name)), err)
+                ignore_list = options.get("ignore-global-var-list", [])
+                if var.name not in ignore_list:
+                    six.raise_from(TransformationError(
+                        "Kernel '{0}' contains accesses to data (variable "
+                        "'{1}') that are not captured in the PSyIR Symbol "
+                        "Table(s) within KernelSchedule scope. Cannot "
+                        "transform such a kernel.".format(kern.name,
+                                                          var.name)), err)
 
 
 @six.add_metaclass(abc.ABCMeta)

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -153,12 +153,14 @@ class KernelTrans(Transformation):
         # Check that all kernel symbols are declared in the kernel
         # symbol table(s). At this point they may be declared in a
         # container containing this kernel which is not supported.
+        ignore_list = []
+        if options:
+            ignore_list = options.get("ignore-global-var-list", [])
         for var in kernel_schedule.walk(nodes.Reference):
             try:
                 var.scope.symbol_table.lookup(
                     var.name, scope_limit=var.ancestor(nodes.KernelSchedule))
             except KeyError as err:
-                ignore_list = options.get("ignore-global-var-list", [])
                 if var.name not in ignore_list:
                     six.raise_from(TransformationError(
                         "Kernel '{0}' contains accesses to data (variable "


### PR DESCRIPTION
Also alters the handling of kind parameters in the frontend - there is now a check that there is some way for them to be brought into scope rather than just creating a new, local symbol.