### PR TITLE
(towards 1338) Support for OpenMP Master directive

### DIFF
--- a/changelog
+++ b/changelog
@@ -129,6 +129,9 @@
 	43) PR #1342 towards #1338. Adds the OMPSingleTrans transformation for
 	creating an OMP SINGLE region.
 
+	44) PR #1352 towards #1338. Adds the OMPMasterTrans transformation for
+	creating an OMP MASTER region.
+
 release 2.0.0 28th April 2021
 
 	1) #778 for #713. Use 'make' to execute all examples.

--- a/doc/reference_guide/Makefile
+++ b/doc/reference_guide/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
+SPHINXBUILD   = python3 -m sphinx
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/doc/reference_guide/Makefile
+++ b/doc/reference_guide/Makefile
@@ -3,7 +3,7 @@
 
 # You can set these variables from the command line.
 SPHINXOPTS    =
-SPHINXBUILD   = python3 -m sphinx
+SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -265,7 +265,7 @@ can be found in the API-specific sections).
 
 .. autoclass:: psyclone.transformations.OMPParallelTrans
     :inherited-members:
-    :exclude-members: name, psyGen
+    :exclude-members: name
     :noindex:
 
 .. note:: PSyclone does not support (distributed-memory) halo swaps or
@@ -282,7 +282,7 @@ can be found in the API-specific sections).
 
 .. autoclass:: psyclone.transformations.OMPSingleTrans
     :inherited-members:
-    :exclude-members: name, psyGen
+    :exclude-members: name
     :noindex:
 
 .. note:: PSyclone does not support (distributed-memory) halo swaps or
@@ -299,7 +299,7 @@ can be found in the API-specific sections).
 
 .. autoclass:: psyclone.transformations.OMPMasterTrans
     :inherited-members:
-    :exclude-members: name, psyGen, omp_nowait
+    :exclude-members: name
     :noindex:
 
 .. note:: PSyclone does not support (distributed-memory) halo swaps or

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -32,6 +32,7 @@
 .. POSSIBILITY OF SUCH DAMAGE.
 .. -----------------------------------------------------------------------------
 .. Written by: R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab.
+..             A. B. G. Chalk, STFC Daresbury Lab.
 ..             I. Kavcic, Met Office.
 
 .. _transformations:
@@ -275,7 +276,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the parallel region. The
-	  :ref:`MoveTrans <sec_move_trans>` transformation may be used
+      :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -292,7 +293,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the single region. The
-	  :ref:`MoveTrans <sec_move_trans>` transformation may be used
+      :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -309,7 +310,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the single region. The
-	  :ref:`MoveTrans <sec_move_trans>` transformation may be used
+      :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -332,8 +333,8 @@ can be found in the API-specific sections).
 
 .. warning:: This transformation assumes that the SIGN Operator acts
              on PSyIR Real scalar data and does not check whether or not
-	     this is the case. Once issue #658 is on master then this
-	     limitation can be fixed.
+         this is the case. Once issue #658 is on master then this
+         limitation can be fixed.
 
 Kernels
 -------
@@ -442,7 +443,7 @@ forbid the ``bc_ssh_code`` kernel from accessing the ``forbidden_var``
 variable that is available to it from the enclosing module scope.
 
 .. note:: these rules *only* apply to kernels that are the target of
-	  PSyclone kernel transformations.
+      PSyclone kernel transformations.
 
 Available Kernel Transformations
 ++++++++++++++++++++++++++++++++
@@ -588,7 +589,7 @@ PSyclone also provides the same functionality via a function (which is
 what the **psyclone** script calls internally).
 
 .. autofunction:: psyclone.generator.generate
-		  :noindex:
+          :noindex:
 
 A valid script file must contain a **trans** function which accepts a **PSy**
 object as an argument and returns a **PSy** object, i.e.:
@@ -604,13 +605,13 @@ below does the same thing as the example in the
 ::
 
     def trans(psy):
-	from psyclone.transformations import OMPParallelLoopTrans
+    from psyclone.transformations import OMPParallelLoopTrans
         invoke = psy.invokes.get('invoke_0_v3_kernel_type')
         schedule = invoke.schedule
         ol = OMPParallelLoopTrans()
         new_schedule, _ = ol.apply(schedule.children[0])
         invoke.schedule = new_schedule
-	return psy
+    return psy
 
 Of course the script may apply as many transformations as is required
 for a particular schedule and may apply transformations to all the

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -297,6 +297,23 @@ can be found in the API-specific sections).
 
 ####
 
+.. autoclass:: psyclone.transformations.OMPMasterTrans
+    :inherited-members:
+    :exclude-members: name, psyGen, omp_nowait
+    :noindex:
+
+.. note:: PSyclone does not support (distributed-memory) halo swaps or
+          global sums within OpenMP master regions.  Attempting to
+          create a master region for a set of nodes that includes
+          halo swaps or global sums will produce an error. In such
+          cases it may be possible to re-order the nodes in the
+          Schedule such that the halo swaps or global sums are
+          performed outside the single region. The
+	  :ref:`MoveTrans <sec_move_trans>` transformation may be used
+          for this.
+
+####
+
 .. autoclass:: psyclone.psyir.transformations.ProfileTrans
     :members: apply
     :noindex:
@@ -609,13 +626,13 @@ examples/check_examples script).
 OpenMP
 ------
 
-OpenMP is added to a code by using transformations. The four
+OpenMP is added to a code by using transformations. The five
 transformations currently supported allow the addition of an
 **OpenMP Parallel** directive, an **OpenMP Do** directive, an
-**OpenMP Single** directive and an **OpenMP Parallel Do** 
-directive, respectively, to a code.
+**OpenMP Single** directive, an **OpenMP Master** directive, 
+and an **OpenMP Parallel Do** directive, respectively, to a code.
 
-The generic versions of these four transformations (i.e. ones that
+The generic versions of these five transformations (i.e. ones that
 theoretically work for all APIs) were given in the
 :ref:`sec_transformations_available` section. The API-specific versions
 of these transformations are described in the API-specific sections of

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -276,7 +276,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the parallel region. The
-      :ref:`MoveTrans <sec_move_trans>` transformation may be used
+          :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -293,7 +293,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the single region. The
-      :ref:`MoveTrans <sec_move_trans>` transformation may be used
+          :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -310,7 +310,7 @@ can be found in the API-specific sections).
           cases it may be possible to re-order the nodes in the
           Schedule such that the halo swaps or global sums are
           performed outside the single region. The
-      :ref:`MoveTrans <sec_move_trans>` transformation may be used
+          :ref:`MoveTrans <sec_move_trans>` transformation may be used
           for this.
 
 ####
@@ -333,8 +333,8 @@ can be found in the API-specific sections).
 
 .. warning:: This transformation assumes that the SIGN Operator acts
              on PSyIR Real scalar data and does not check whether or not
-         this is the case. Once issue #658 is on master then this
-         limitation can be fixed.
+             this is the case. Once issue #658 is on master then this
+             limitation can be fixed.
 
 Kernels
 -------
@@ -605,13 +605,13 @@ below does the same thing as the example in the
 ::
 
     def trans(psy):
-    from psyclone.transformations import OMPParallelLoopTrans
+        from psyclone.transformations import OMPParallelLoopTrans
         invoke = psy.invokes.get('invoke_0_v3_kernel_type')
         schedule = invoke.schedule
         ol = OMPParallelLoopTrans()
         new_schedule, _ = ol.apply(schedule.children[0])
         invoke.schedule = new_schedule
-    return psy
+        return psy
 
 Of course the script may apply as many transformations as is required
 for a particular schedule and may apply transformations to all the

--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -78,7 +78,7 @@ from psyclone.psyir.nodes.acc_directives import ACCDirective, \
     ACCKernelsDirective, ACCDataDirective
 from psyclone.psyir.nodes.omp_directives import OMPDirective, OMPDoDirective, \
     OMPParallelDirective, OMPParallelDoDirective, OMPSingleDirective, \
-    OMPMasterDirective
+    OMPMasterDirective, OMPSerialDirective
 
 
 # The entities in the __all__ list are made available to import directly from
@@ -131,6 +131,7 @@ __all__ = [
         'ACCKernelsDirective',
         'OMPDirective',
         'OMPParallelDirective',
+        'OMPSerialDirective',
         'OMPSingleDirective',
         'OMPMasterDirective',
         'OMPDoDirective',

--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -77,7 +77,8 @@ from psyclone.psyir.nodes.acc_directives import ACCDirective, \
     ACCLoopDirective, ACCEnterDataDirective, ACCParallelDirective, \
     ACCKernelsDirective, ACCDataDirective
 from psyclone.psyir.nodes.omp_directives import OMPDirective, OMPDoDirective, \
-    OMPParallelDirective, OMPParallelDoDirective, OMPSingleDirective
+    OMPParallelDirective, OMPParallelDoDirective, OMPSingleDirective, \
+    OMPMasterDirective
 
 
 # The entities in the __all__ list are made available to import directly from
@@ -131,6 +132,7 @@ __all__ = [
         'OMPDirective',
         'OMPParallelDirective',
         'OMPSingleDirective',
+        'OMPMasterDirective',
         'OMPDoDirective',
         'OMPParallelDoDirective'
         ]

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -255,10 +255,6 @@ class OMPMasterDirective(OMPSerialDirective):
     '''
     Class representing an OpenMP MASTER directive in the PSyclone AST.
 
-    :param list children: list of Nodes that are children of this Node.
-    :param parent: the Node in the AST that has this directive as a child.
-    :type parent: :py:class:`psyclone.psyir.nodes.Node`
-
     '''
 
     @property

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 #         I. Kavcic,    Met Office
 #         C.M. Maynard, Met Office / University of Reading
 #         J. Henrichs, Bureau of Meteorology
@@ -259,11 +260,6 @@ class OMPMasterDirective(OMPSerialDirective):
     :type parent: :py:class:`psyclone.psyir.nodes.Node`
 
     '''
-    def __init__(self, children=None, parent=None):
-
-        # Call the init method of the base class
-        super(OMPMasterDirective, self).__init__(children=children,
-                                                 parent=parent)
 
     @property
     def dag_name(self):

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -243,9 +243,6 @@ class OMPMasterDirective(OMPSingleDirective):
     '''
     def __init__(self, children=None, parent=None):
 
-        if children is None:
-            children = []
-
         # Call the init method of the base class
         super(OMPMasterDirective, self).__init__(children=children,
                                                  parent=parent, nowait=False)

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # -----------------------------------------------------------------------------
 
@@ -287,16 +288,8 @@ def test_omp_single_strings(nowait):
 
 def test_omp_single_node_str():
     ''' Test the node_str() method of the OMPSingle directive '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
-                           api="dynamo0.3")
-    single = OMPSingleTrans()
-    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
-        create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-
-    single.apply(schedule.children[0])
-    omp_single_loop = schedule.children[0]
-    out = OMPSingleDirective.node_str(omp_single_loop)
+    single_directive = OMPSingleDirective()
+    out = single_directive.node_str()
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP single]"
     assert expected_output in out
@@ -400,16 +393,8 @@ def test_omp_master_strings():
 
 def test_omp_master_node_str():
     ''' Test the node_str() method of the OMPMaster directive '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
-                           api="dynamo0.3")
-    master = OMPMasterTrans()
-    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
-        create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-
-    master.apply(schedule.children[0])
-    omp_master = schedule.children[0]
-    out = OMPMasterDirective.node_str(omp_master)
+    master_directive = OMPMasterDirective()
+    out = master_directive.node_str()
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP master]"
     assert expected_output in out

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # Modified J. Henrichs, Bureau of Meteorology
 
@@ -45,7 +46,7 @@ import pytest
 
 from psyclone.errors import InternalError
 from psyclone.psyir.nodes import CodeBlock, IfBlock, Literal, Loop, Node, \
-    Reference, Schedule, Statement, ACCLoopDirective
+    Reference, Schedule, Statement, ACCLoopDirective, OMPMasterDirective
 from psyclone.psyir.symbols import DataSymbol, INTEGER_TYPE, BOOLEAN_TYPE
 from psyclone.psyir.transformations import ProfileTrans, RegionTrans, \
     TransformationError
@@ -242,7 +243,11 @@ def test_ompmaster_nested():
         create(invoke_info)
     schedule = psy.invokes.invoke_list[0].schedule
 
-    master.apply(schedule[0])
+    #Successful transformation test
+    node = schedule[0]
+    master.apply(node)
+    assert isinstance(schedule[0], OMPMasterDirective)
+    assert schedule[0].dir_body[0] is node
     with pytest.raises(TransformationError) as err:
         master.apply(schedule[0])
     assert("Transformation Error: Nodes of type 'OMPMasterDirective' cannot" +

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -243,7 +243,7 @@ def test_ompmaster_nested():
         create(invoke_info)
     schedule = psy.invokes.invoke_list[0].schedule
 
-    #Successful transformation test
+    # Successful transformation test
     node = schedule[0]
     master.apply(node)
     assert isinstance(schedule[0], OMPMasterDirective)

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -231,6 +231,25 @@ def test_ompmaster():
     assert str(trans) == "Insert an OpenMP Master region"
 
 
+def test_ompmaster_nested():
+    '''Tests to check OMPMasterTrans rejects being applied to another
+    OMPMasterTrans'''
+
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    master = OMPMasterTrans()
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+
+    master.apply(schedule[0])
+    with pytest.raises(TransformationError) as err:
+        master.apply(schedule[0])
+    assert("Transformation Error: Nodes of type 'OMPMasterDirective' cannot" +
+           " be enclosed by a OMPMasterTrans transformation"
+           in str(err.value))
+
+
 # Tests for ProfileTrans
 
 

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -52,7 +52,7 @@ from psyclone.psyir.transformations import ProfileTrans, RegionTrans, \
 from psyclone.tests.utilities import get_invoke
 from psyclone.transformations import ACCEnterDataTrans, ACCLoopTrans, \
     ACCParallelTrans, OMPLoopTrans, OMPParallelLoopTrans, OMPParallelTrans, \
-    OMPSingleTrans
+    OMPSingleTrans, OMPMasterTrans
 from psyclone.parse.algorithm import parse
 from psyclone.psyGen import PSyFactory
 
@@ -221,6 +221,15 @@ def test_ompsingle_nested():
     assert("Transformation Error: Nodes of type 'OMPSingleDirective' cannot" +
            " be enclosed by a OMPSingleTrans transformation"
            in str(err.value))
+
+
+# Tests for OMPMasterTrans
+def test_ompmaster():
+    ''' Generic tests for the OMPMasterTrans transformation class '''
+    trans = OMPMasterTrans()
+    assert trans.name == "OMPMasterTrans"
+    assert str(trans) == "Insert an OpenMP Master region"
+
 
 # Tests for ProfileTrans
 

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -1392,7 +1392,7 @@ class OMPSingleTrans(ParallelRegionTrans):
 
 class OMPMasterTrans(OMPSingleTrans):
     '''
-    Create an OpenMP SINGLE region by inserting directives. The most
+    Create an OpenMP MASTER region by inserting directives. The most
     likely use case for this transformation is to wrap around task-based
     transformations. The parent region for this should usually also be
     a OMPParallelTrans. For example:


### PR DESCRIPTION
This adds the OpenMP Master directive. This has potential uses for tasking, as dependencies are based upon the spawning thread only. Since `master` is similar to `single nowait` but forces a specific thread, the relevant classes inherit the bulk of their code from the `OMPSingleTrans` and `OMPSingleDirective` and hence this cannot be merged until #1342 is finished - at which point this branch will be rebased to the master branch at that point.

For now it shows all the commits from #1342 as incorrectly part of this PR.