### PR TITLE
(Towards 1338) Implementation of the taskloop directive

### DIFF
--- a/changelog
+++ b/changelog
@@ -137,6 +137,9 @@
 	46) PR #1353 for #1324. Add support for generating structure accesses in
 	the C backends.
 
+	47) PR #1358 towards #1338. Add the OpenMP Taskloop directive and its
+	corresponding insertion transformation.
+
 release 2.0.0 28th April 2021
 
 	1) #778 for #713. Use 'make' to execute all examples.

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -32,7 +32,6 @@
 .. POSSIBILITY OF SUCH DAMAGE.
 .. -----------------------------------------------------------------------------
 .. Written by: R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab.
-..             A. B. G. Chalk, STFC Daresbury Lab.
 ..             I. Kavcic, Met Office.
 
 .. _transformations:
@@ -443,7 +442,7 @@ forbid the ``bc_ssh_code`` kernel from accessing the ``forbidden_var``
 variable that is available to it from the enclosing module scope.
 
 .. note:: these rules *only* apply to kernels that are the target of
-      PSyclone kernel transformations.
+	  PSyclone kernel transformations.
 
 Available Kernel Transformations
 ++++++++++++++++++++++++++++++++
@@ -589,7 +588,7 @@ PSyclone also provides the same functionality via a function (which is
 what the **psyclone** script calls internally).
 
 .. autofunction:: psyclone.generator.generate
-          :noindex:
+		  :noindex:
 
 A valid script file must contain a **trans** function which accepts a **PSy**
 object as an argument and returns a **PSy** object, i.e.:

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -32,6 +32,7 @@
 .. POSSIBILITY OF SUCH DAMAGE.
 .. -----------------------------------------------------------------------------
 .. Written by: R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab.
+..             A. B. G. Chalk, STFC Daresbury Lab.
 ..             I. Kavcic, Met Office.
 
 .. _transformations:
@@ -442,7 +443,7 @@ forbid the ``bc_ssh_code`` kernel from accessing the ``forbidden_var``
 variable that is available to it from the enclosing module scope.
 
 .. note:: these rules *only* apply to kernels that are the target of
-	  PSyclone kernel transformations.
+      PSyclone kernel transformations.
 
 Available Kernel Transformations
 ++++++++++++++++++++++++++++++++
@@ -588,7 +589,7 @@ PSyclone also provides the same functionality via a function (which is
 what the **psyclone** script calls internally).
 
 .. autofunction:: psyclone.generator.generate
-		  :noindex:
+          :noindex:
 
 A valid script file must contain a **trans** function which accepts a **PSy**
 object as an argument and returns a **PSy** object, i.e.:

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -258,6 +258,12 @@ can be found in the API-specific sections).
 
 ####
 
+.. autoclass:: psyclone.transformations.OMPTaskloopTrans
+    :members: apply, omp_grainsize, omp_num_tasks
+    :noindex:
+
+####
+
 .. autoclass:: psyclone.transformations.OMPParallelLoopTrans
     :members: apply
     :noindex:
@@ -627,13 +633,14 @@ examples/check_examples script).
 OpenMP
 ------
 
-OpenMP is added to a code by using transformations. The five
+OpenMP is added to a code by using transformations. The six
 transformations currently supported allow the addition of an
 **OpenMP Parallel** directive, an **OpenMP Do** directive, an
 **OpenMP Single** directive, an **OpenMP Master** directive, 
-and an **OpenMP Parallel Do** directive, respectively, to a code.
+an **OpenMP Taskloop** directive, and an 
+**OpenMP Parallel Do** directive, respectively, to a code.
 
-The generic versions of these five transformations (i.e. ones that
+The generic versions of these six transformations (i.e. ones that
 theoretically work for all APIs) were given in the
 :ref:`sec_transformations_available` section. The API-specific versions
 of these transformations are described in the API-specific sections of

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -635,6 +635,7 @@ OpenMP
 
 OpenMP is added to a code by using transformations. The OpenMP
 transformations currently supported allow the addition of:
+
 * an **OpenMP Parallel** directive
 * an **OpenMP Do** directive
 * an **OpenMP Single** directive

--- a/doc/user_guide/transformations.rst
+++ b/doc/user_guide/transformations.rst
@@ -633,14 +633,16 @@ examples/check_examples script).
 OpenMP
 ------
 
-OpenMP is added to a code by using transformations. The six
-transformations currently supported allow the addition of an
-**OpenMP Parallel** directive, an **OpenMP Do** directive, an
-**OpenMP Single** directive, an **OpenMP Master** directive, 
-an **OpenMP Taskloop** directive, and an 
-**OpenMP Parallel Do** directive, respectively, to a code.
+OpenMP is added to a code by using transformations. The OpenMP
+transformations currently supported allow the addition of:
+* an **OpenMP Parallel** directive
+* an **OpenMP Do** directive
+* an **OpenMP Single** directive
+* an **OpenMP Master** directive
+* an **OpenMP Taskloop** directive; and
+* an **OpenMP Parallel Do** directive.
 
-The generic versions of these six transformations (i.e. ones that
+The generic versions of these transformations (i.e. ones that
 theoretically work for all APIs) were given in the
 :ref:`sec_transformations_available` section. The API-specific versions
 of these transformations are described in the API-specific sections of

--- a/src/psyclone/f2pygen.py
+++ b/src/psyclone/f2pygen.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford and A. R. Porter, STFC Daresbury Lab
+# Modified: A. B. G. Chalk, STFC Daresbury Lab
 
 ''' Fortran code-generation library. This wraps the f2py fortran parser to
     provide routines which can be used to generate fortran code. '''

--- a/src/psyclone/f2pygen.py
+++ b/src/psyclone/f2pygen.py
@@ -139,7 +139,8 @@ class OMPDirective(Directive):
                          'parallel do').
     '''
     def __init__(self, root, line, position, dir_type):
-        self._types = ["parallel do", "parallel", "do", "master", "single"]
+        self._types = ["parallel do", "parallel", "do", "master", "single",
+                       "taskloop"]
         self._positions = ["begin", "end"]
 
         super(OMPDirective, self).__init__(root, line, position, dir_type)

--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -78,7 +78,7 @@ from psyclone.psyir.nodes.acc_directives import ACCDirective, \
     ACCKernelsDirective, ACCDataDirective
 from psyclone.psyir.nodes.omp_directives import OMPDirective, OMPDoDirective, \
     OMPParallelDirective, OMPParallelDoDirective, OMPSingleDirective, \
-    OMPMasterDirective, OMPSerialDirective
+    OMPMasterDirective, OMPSerialDirective, OMPTaskloopDirective
 
 
 # The entities in the __all__ list are made available to import directly from
@@ -134,6 +134,7 @@ __all__ = [
         'OMPSerialDirective',
         'OMPSingleDirective',
         'OMPMasterDirective',
+        'OMPTaskloopDirective',
         'OMPDoDirective',
         'OMPParallelDoDirective'
         ]

--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -34,6 +34,7 @@
 # Author S. Siso, STFC Daresbury Lab
 # Modified: A. R. Porter and R. W. Ford, STFC Daresbury Lab
 # Modified: J. Henrichs, Bureau of Meteorology
+# Modified: A. B. G. Chalk, STFC Daresbury Lab
 # -----------------------------------------------------------------------------
 
 ''' PSyIR nodes package module '''

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 #         I. Kavcic,    Met Office
 #         C.M. Maynard, Met Office / University of Reading
 #         J. Henrichs, Bureau of Meteorology
@@ -255,11 +256,6 @@ class OMPMasterDirective(OMPSerialDirective):
     Class representing an OpenMP MASTER directive in the PSyclone AST.
 
     '''
-    def __init__(self, children=None, parent=None):
-
-        # Call the init method of the base class
-        super(OMPMasterDirective, self).__init__(children=children,
-                                                 parent=parent)
 
     @property
     def dag_name(self):

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
-#         A. B. G. Chalk, STFC Daresbury Lab
 #         I. Kavcic,    Met Office
 #         C.M. Maynard, Met Office / University of Reading
 #         J. Henrichs, Bureau of Meteorology
@@ -256,6 +255,11 @@ class OMPMasterDirective(OMPSerialDirective):
     Class representing an OpenMP MASTER directive in the PSyclone AST.
 
     '''
+    def __init__(self, children=None, parent=None):
+
+        # Call the init method of the base class
+        super(OMPMasterDirective, self).__init__(children=children,
+                                                 parent=parent)
 
     @property
     def dag_name(self):

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -696,7 +696,8 @@ class OMPTaskloopDirective(OMPDirective):
         if self._num_tasks is not None:
             extra_clauses = "num_tasks({0})".format(self._num_tasks)
 
-        parent.add(DirectiveGen(parent, "omp", "begin", "taskloop", extra_clauses))
+        parent.add(DirectiveGen(parent, "omp", "begin", "taskloop",
+                                extra_clauses))
 
         for child in self.children:
             child.gen_code(parent)
@@ -715,7 +716,6 @@ class OMPTaskloopDirective(OMPDirective):
         :rtype: str
 
         '''
-        # pylint: disable=no-self-use
         clauses = ""
         if self._grainsize is not None:
             clauses = " grainsize({0})".format(self._grainsize)

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -126,9 +126,9 @@ class OMPSerialDirective(OMPDirective):
         time.
 
         :raises GenerationError: if this OMPSerial is not enclosed \
-                            within some OpenMP parallel region.
+                                 within some OpenMP parallel region.
         :raises GenerationError: if this OMPSerial is enclosed within \
-                            any OMPSerialDirective subclass region.
+                                 any OMPSerialDirective subclass region.
 
         '''
         # It is only at the point of code generation that we can check for
@@ -630,11 +630,11 @@ class OMPTaskloopDirective(OMPDirective):
         time.
 
         :raises GenerationError: if this OMPTaskloopDirective is not \
-                                 enclsed within an OpenMP serial region.
+                                 enclosed within an OpenMP serial region.
         '''
         # It is only at the point of code generation that we can check for
         # correctness (given that we don't mandate the order that a user
-        # can apply transformations to the code). As an  taskloop
+        # can apply transformations to the code). A taskloop
         # directive, we must have an OMPSerialDirective as an
         # ancestor back up the tree.
         if not self.ancestor(OMPSerialDirective):

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
-#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # -----------------------------------------------------------------------------
 
@@ -288,8 +287,16 @@ def test_omp_single_strings(nowait):
 
 def test_omp_single_node_str():
     ''' Test the node_str() method of the OMPSingle directive '''
-    single_directive = OMPSingleDirective()
-    out = single_directive.node_str()
+    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
+                           api="dynamo0.3")
+    single = OMPSingleTrans()
+    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+
+    single.apply(schedule.children[0])
+    omp_single_loop = schedule.children[0]
+    out = OMPSingleDirective.node_str(omp_single_loop)
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP single]"
     assert expected_output in out
@@ -393,8 +400,16 @@ def test_omp_master_strings():
 
 def test_omp_master_node_str():
     ''' Test the node_str() method of the OMPMaster directive '''
-    master_directive = OMPMasterDirective()
-    out = master_directive.node_str()
+    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
+                           api="dynamo0.3")
+    master = OMPMasterTrans()
+    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+
+    master.apply(schedule.children[0])
+    omp_master = schedule.children[0]
+    out = OMPMasterDirective.node_str(omp_master)
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP master]"
     assert expected_output in out

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # -----------------------------------------------------------------------------
 
@@ -287,16 +288,8 @@ def test_omp_single_strings(nowait):
 
 def test_omp_single_node_str():
     ''' Test the node_str() method of the OMPSingle directive '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
-                           api="dynamo0.3")
-    single = OMPSingleTrans()
-    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
-        create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-
-    single.apply(schedule.children[0])
-    omp_single_loop = schedule.children[0]
-    out = OMPSingleDirective.node_str(omp_single_loop)
+    single_directive = OMPSingleDirective()
+    out = single_directive.node_str()
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP single]"
     assert expected_output in out
@@ -400,16 +393,8 @@ def test_omp_master_strings():
 
 def test_omp_master_node_str():
     ''' Test the node_str() method of the OMPMaster directive '''
-    _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
-                           api="dynamo0.3")
-    master = OMPMasterTrans()
-    psy = PSyFactory("dynamo0.3", distributed_memory=False).\
-        create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-
-    master.apply(schedule.children[0])
-    omp_master = schedule.children[0]
-    out = OMPMasterDirective.node_str(omp_master)
+    master_directive = OMPMasterDirective()
+    out = master_directive.node_str()
     directive = colored("Directive", Directive._colour)
     expected_output = directive + "[OMP master]"
     assert expected_output in out

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -290,9 +290,9 @@ def test_omp_single_node_str():
     ''' Test the node_str() method of the OMPSingle directive '''
     single_directive = OMPSingleDirective()
     out = single_directive.node_str()
-    directive = colored("Directive", Directive._colour)
+    directive = colored("OMPSingleDirective", Directive._colour)
     expected_output = directive + "[OMP single]"
-    assert expected_output in out
+    assert expected_output == out
 
 
 def test_omp_single_validate_global_constraints():
@@ -395,9 +395,9 @@ def test_omp_master_node_str():
     ''' Test the node_str() method of the OMPMaster directive '''
     master_directive = OMPMasterDirective()
     out = master_directive.node_str()
-    directive = colored("Directive", Directive._colour)
+    directive = colored("OMPMasterDirective", Directive._colour)
     expected_output = directive + "[OMP master]"
-    assert expected_output in out
+    assert expected_output == out
 
 
 def test_omp_master_gencode():

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -470,6 +470,7 @@ def test_omp_master_nested_validate_global_constraints(monkeypatch):
     assert ("OMPMasterDirective must not be inside another OpenMP serial " +
             "region") in str(excinfo.value)
 
+
 def test_omp_taskloop_dag_name():
     '''Test the omp_taskloop dag_name method'''
     _, invoke_info = parse(os.path.join(BASE_PATH, "1_single_invoke.f90"),
@@ -483,7 +484,7 @@ def test_omp_taskloop_dag_name():
 
 
 def test_omp_taskloop_strings():
-    ''' Test the begin_string and end_string methods of the 
+    ''' Test the begin_string and end_string methods of the
         OMPTaskloop directive '''
     omp_taskloop = OMPTaskloopDirective()
 
@@ -507,7 +508,9 @@ def test_omp_taskloop_node_str():
     expected_output = directive + "[OMP taskloop]"
     assert expected_output in out
 
-@pytest.mark.parametrize("grainsize,num_tasks", [(None,None),(32,None),(None,32)])
+
+@pytest.mark.parametrize("grainsize,num_tasks", [(None, None), (32, None),
+                                                 (None, 32)])
 def test_omp_taskloop_gencode(grainsize, num_tasks):
     '''Check that the gen_code method in the OMPTaskloopDirective
     class generates the expected code. Use the gocean API.
@@ -522,6 +525,7 @@ def test_omp_taskloop_gencode(grainsize, num_tasks):
     schedule = psy.invokes.invoke_list[0].schedule
 
     taskloop.apply(schedule.children[0])
+    taskloop_node = schedule.children[0]
     master.apply(schedule.children[0])
     parallel.apply(schedule.children[0])
     goceantrans = GOceanExtractTrans()
@@ -546,6 +550,8 @@ def test_omp_taskloop_gencode(grainsize, num_tasks):
         "      !$omp end master\n" +
         "      !$omp end parallel" in code)
 
+    assert taskloop_node.begin_string() == "omp taskloop{0}".format(clauses)
+
 
 def test_omp_taskloop_validate_global_constraints(monkeypatch):
     ''' Test the validate_global_constraints method of the OMPTaskloop
@@ -562,8 +568,7 @@ def test_omp_taskloop_validate_global_constraints(monkeypatch):
         schedule.children[0].validate_global_constraints()
     assert ("OMPTaskloopDirective must be inside an OMP parallel region "
             "and an OMP Serial region but could not find both "
-            "ancestor nodes" in \
-        str(excinfo.value))
+            "ancestor nodes" in str(excinfo.value))
     taskloop_sched = schedule.children[0]
     parallel = OMPParallelTrans()
     parallel.apply(schedule.children[0])
@@ -571,8 +576,7 @@ def test_omp_taskloop_validate_global_constraints(monkeypatch):
         taskloop_sched.validate_global_constraints()
     assert ("OMPTaskloopDirective must be inside an OMP parallel region "
             "and an OMP Serial region but could not find both "
-            "ancestor nodes" in \
-        str(excinfo.value))
+            "ancestor nodes" in str(excinfo.value))
 
     # To test that validate_global_constaints fails when both the
     # grainsize and num_tasks clauses are applied we need to use
@@ -599,5 +603,3 @@ def test_omp_taskloop_validate_global_constraints(monkeypatch):
         sched.validate_global_constraints()
     assert ("OMPTaskloopDirective must not have both grainsize and "
             "numtasks clauses specified." in str(excinfo.value))
-    
-

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -108,6 +108,7 @@ def test_omploop_no_collapse():
     assert ("The COLLAPSE clause is not yet supported for '!$omp do' "
             "directives" in str(err.value))
 
+
 def test_omptaskloop_no_collapse():
     ''' Check that the OMPTaskloopTrans.directive() method rejects
     the collapse argument '''
@@ -139,7 +140,7 @@ def test_omptaskloop_getters_and_setters():
     assert trans.omp_num_tasks == 32
     trans.omp_grainsize = 32
     assert trans.omp_grainsize == 32
-    
+
     trans = OMPTaskloopTrans(grainsize=32, num_tasks=32)
     assert trans.omp_num_tasks == 32
     assert trans.omp_grainsize == 32
@@ -148,7 +149,6 @@ def test_omptaskloop_getters_and_setters():
         a = trans._directive(children=None)
     assert("The grainsize and num_tasks clauses are both "
            "specified for this Taskloop transformation" in str(err.value))
-
 
 
 def test_ifblock_children_region():

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # Modified J. Henrichs, Bureau of Meteorology
 
@@ -45,7 +46,7 @@ import pytest
 
 from psyclone.errors import InternalError
 from psyclone.psyir.nodes import CodeBlock, IfBlock, Literal, Loop, Node, \
-    Reference, Schedule, Statement, ACCLoopDirective
+    Reference, Schedule, Statement, ACCLoopDirective, OMPMasterDirective
 from psyclone.psyir.symbols import DataSymbol, INTEGER_TYPE, BOOLEAN_TYPE
 from psyclone.psyir.transformations import ProfileTrans, RegionTrans, \
     TransformationError

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -126,29 +126,40 @@ def test_omptaskloop_getters_and_setters():
     trans = OMPTaskloopTrans()
     with pytest.raises(TransformationError) as err:
         trans.omp_num_tasks = "String"
-    assert("num_tasks must be an integer, got str" in str(err.value))
+    assert "num_tasks must be an integer or None, got str" in str(err.value)
     with pytest.raises(TransformationError) as err:
         trans.omp_num_tasks = -1
-    assert("num_tasks must be a positive integer, got -1" in str(err.value))
+    assert "num_tasks must be a positive integer, got -1" in str(err.value)
     with pytest.raises(TransformationError) as err:
         trans.omp_grainsize = "String"
-    assert("grainsize must be an integer, got str" in str(err.value))
+    assert "grainsize must be an integer or None, got str" in str(err.value)
     with pytest.raises(TransformationError) as err:
         trans.omp_grainsize = -1
-    assert("grainsize must be a positive integer, got -1" in str(err.value))
+    assert "grainsize must be a positive integer, got -1" in str(err.value)
     trans.omp_num_tasks = 32
     assert trans.omp_num_tasks == 32
+    with pytest.raises(TransformationError) as err:
+        trans.omp_grainsize = 32
+    assert("The grainsize and num_tasks clauses would both "
+           "be specified for this Taskloop transformation"
+           in str(err.value))
+    trans.omp_num_tasks = None
+    assert trans.omp_num_tasks is None
     trans.omp_grainsize = 32
     assert trans.omp_grainsize == 32
+    trans.grainsize = None
+    assert trans.grainsize is None
 
-    trans = OMPTaskloopTrans(grainsize=32, num_tasks=32)
+    trans = OMPTaskloopTrans(num_tasks=32)
     assert trans.omp_num_tasks == 32
+    trans = OMPTaskloopTrans(grainsize=32)
     assert trans.omp_grainsize == 32
 
     with pytest.raises(TransformationError) as err:
-        a = trans._directive(children=None)
-    assert("The grainsize and num_tasks clauses are both "
-           "specified for this Taskloop transformation" in str(err.value))
+        trans = OMPTaskloopTrans(grainsize=32, num_tasks=32)
+    assert("The grainsize and num_tasks clauses would both "
+           "be specified for this Taskloop transformation"
+           in str(err.value))
 
 
 def test_ifblock_children_region():

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -152,6 +152,7 @@ def test_omptaskloop_getters_and_setters():
 
     trans = OMPTaskloopTrans(num_tasks=32)
     assert trans.omp_num_tasks == 32
+    trans = None
     trans = OMPTaskloopTrans(grainsize=32)
     assert trans.omp_grainsize == 32
 

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -53,7 +53,7 @@ from psyclone.psyir.transformations import ProfileTrans, RegionTrans, \
 from psyclone.tests.utilities import get_invoke
 from psyclone.transformations import ACCEnterDataTrans, ACCLoopTrans, \
     ACCParallelTrans, OMPLoopTrans, OMPParallelLoopTrans, OMPParallelTrans, \
-    OMPSingleTrans, OMPMasterTrans
+    OMPSingleTrans, OMPMasterTrans, OMPTaskloopTrans
 from psyclone.parse.algorithm import parse
 from psyclone.psyGen import PSyFactory
 
@@ -107,6 +107,16 @@ def test_omploop_no_collapse():
         _ = trans._directive(cnode, collapse=2)
     assert ("The COLLAPSE clause is not yet supported for '!$omp do' "
             "directives" in str(err.value))
+
+def test_omptaskloop_no_collapse():
+    ''' Check that the OMPTaskloopTrans.directive() method rejects
+    the collapse argument '''
+    trans = OMPTaskloopTrans()
+    cnode = Node()
+    with pytest.raises(NotImplementedError) as err:
+        trans._directive(cnode, collapse=True)
+    assert ("The COLLAPSE clause is not yet supported for "
+            "'!$omp taskloop' directives" in str(err.value))
 
 
 def test_ifblock_children_region():

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -152,7 +152,6 @@ def test_omptaskloop_getters_and_setters():
 
     trans = OMPTaskloopTrans(num_tasks=32)
     assert trans.omp_num_tasks == 32
-    trans = None
     trans = OMPTaskloopTrans(grainsize=32)
     assert trans.omp_grainsize == 32
 

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -119,6 +119,38 @@ def test_omptaskloop_no_collapse():
             "'!$omp taskloop' directives" in str(err.value))
 
 
+def test_omptaskloop_getters_and_setters():
+    ''' Check that the OMPTaskloopTrans getters and setters
+    correctly throw TransformationErrors on illegal values '''
+    trans = OMPTaskloopTrans()
+    with pytest.raises(TransformationError) as err:
+        trans.omp_num_tasks = "String"
+    assert("num_tasks must be an integer, got str" in str(err.value))
+    with pytest.raises(TransformationError) as err:
+        trans.omp_num_tasks = -1
+    assert("num_tasks must be a positive integer, got -1" in str(err.value))
+    with pytest.raises(TransformationError) as err:
+        trans.omp_grainsize = "String"
+    assert("grainsize must be an integer, got str" in str(err.value))
+    with pytest.raises(TransformationError) as err:
+        trans.omp_grainsize = -1
+    assert("grainsize must be a positive integer, got -1" in str(err.value))
+    trans.omp_num_tasks = 32
+    assert trans.omp_num_tasks == 32
+    trans.omp_grainsize = 32
+    assert trans.omp_grainsize == 32
+    
+    trans = OMPTaskloopTrans(grainsize=32, num_tasks=32)
+    assert trans.omp_num_tasks == 32
+    assert trans.omp_grainsize == 32
+
+    with pytest.raises(TransformationError) as err:
+        a = trans._directive(children=None)
+    assert("The grainsize and num_tasks clauses are both "
+           "specified for this Taskloop transformation" in str(err.value))
+
+
+
 def test_ifblock_children_region():
     ''' Check that we reject attempts to transform the conditional part of
     an If statement or to include both the if- and else-clauses in a region

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -32,7 +32,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # ----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
-#         A. B. G. Chalk, STFC Daresbury Lab
 # Modified I. Kavcic, Met Office
 # Modified J. Henrichs, Bureau of Meteorology
 
@@ -46,7 +45,7 @@ import pytest
 
 from psyclone.errors import InternalError
 from psyclone.psyir.nodes import CodeBlock, IfBlock, Literal, Loop, Node, \
-    Reference, Schedule, Statement, ACCLoopDirective, OMPMasterDirective
+    Reference, Schedule, Statement, ACCLoopDirective
 from psyclone.psyir.symbols import DataSymbol, INTEGER_TYPE, BOOLEAN_TYPE
 from psyclone.psyir.transformations import ProfileTrans, RegionTrans, \
     TransformationError

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -453,6 +453,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
         :raises NotImplementedError: if a collapse argument is supplied
         '''
+        # TODO 1370: OpenMP loop functions don't support collapse
         if collapse:
             raise NotImplementedError(
                 "The COLLAPSE clause is not yet supported for "
@@ -572,6 +573,7 @@ class OMPLoopTrans(ParallelLoopTrans):
         :rtype: :py:class:`psyclone.psyir.nodes.OMPDoDirective`
         :raises NotImplementedError: if a collapse argument is supplied
         '''
+        # TODO 1370: OpenMP loop functions don't support collapse
         if collapse:
             raise NotImplementedError(
                 "The COLLAPSE clause is not yet supported for '!$omp do' "

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -316,9 +316,15 @@ class ParallelLoopTrans(LoopTrans):
 class OMPTaskloopTrans(ParallelLoopTrans):
 
     '''
-    Adds an OpenMP taskloop directive to a loop.
+    Adds an OpenMP taskloop directive to a loop. Only one of grainsize or
+    num_tasks must be specified.
 
     TODO: #1364 Taskloops do not yet support reduction clauses.
+
+    :param grainsize: the grainsize to use in for this transformation.
+    :type grainsize: int or None
+    :param num_tasks: the num_tasks to use for this transformation.
+    :type num_tasks: int or None
 
     For example:
 
@@ -338,11 +344,12 @@ class OMPTaskloopTrans(ParallelLoopTrans):
     >>> schedule = psy.invokes.get('invoke_0').schedule
     >>> schedule.view()
     >>>
-    # Apply the OpenMP Taskloop transformation to *every* loop
-    # in the schedule.
-    # This ignores loop dependencies. These must be manually handled
-    # either through end of regions.
-    # TODO: #1368 These can also be handled through the taskwait directive
+    >>> # Apply the OpenMP Taskloop transformation to *every* loop
+    >>> # in the schedule.
+    >>> # This ignores loop dependencies. These must be manually handled
+    >>> # either through end of regions.
+    >>> # TODO: #1368 These can also be handled through the taskwait
+    >>> # directive
     >>> for child in schedule.children:
     >>>     tasklooptrans.apply(child)
     >>> # Enclose all of these loops within a single OpenMP
@@ -367,12 +374,12 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
     @property
     def omp_grainsize(self):
-        ''' 
+        '''
         Returns the grainsize that will be specified by
         this transformation. By default the grainsize
         clause is not applied, so grainsize is None.
 
-        :returns: The grainsize specified by this transformation
+        :returns: The grainsize specified by this transformation.
         :rtype: int or None
         '''
         return self._grainsize
@@ -384,11 +391,11 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         this transformation. Checks the grainsize is
         a positive integer value or None.
 
-        :param value: Integer value to use in the grainsize clause.
+        :param value: integer value to use in the grainsize clause.
         :type value: int or None
 
-        :raises TransformationError: If value is not an int and is not None.
-        :raises TransformationError: If value is negative.
+        :raises TransformationError: if value is not an int and is not None.
+        :raises TransformationError: if value is negative.
         :raises TransformationError: if grainsize and num_tasks are \
                                      both specified.
         '''
@@ -408,12 +415,12 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
     @property
     def omp_num_tasks(self):
-        ''' 
+        '''
         Returns the num_tasks that will be specified
         by this transformation. By default the num_tasks
         clause is not applied so num_tasks is None.
 
-        :returns: The grainsize specified by this transformation
+        :returns: The grainsize specified by this transformation.
         :rtype: int or None
         '''
         return self._num_tasks
@@ -425,11 +432,11 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         this transformation. Checks that num_tasks is
         a positive integer value or None.
 
-        :param value: Integer value to use in the num_tasks clause.
+        :param value: integer value to use in the num_tasks clause.
         :type value: int or None
 
-        :raises TransformationError: If value is not an int and is not None.
-        :raises TransformationError: If value is negative.
+        :raises TransformationError: if value is not an int and is not None.
+        :raises TransformationError: if value is negative.
         :raises TransformationError: if grainsize and num_tasks are \
                                      both specified.
 
@@ -458,7 +465,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         :type children: list of :py:class:`psyclone.psyir.nodes.Node`
         :param int collapse: currently un-used but required to keep \
                              interface the same as in base class.
-        :returns: the new node representing the directive in the AST
+        :returns: the new node representing the directive in the AST.
         :rtype: :py:class:`psyclone.psyir.nodes.OMPTaskloopDirective`
 
         :raises NotImplementedError: if a collapse argument is supplied
@@ -581,7 +588,7 @@ class OMPLoopTrans(ParallelLoopTrans):
                              interface the same as in base class.
         :returns: the new node representing the directive in the AST
         :rtype: :py:class:`psyclone.psyir.nodes.OMPDoDirective`
-        :raises NotImplementedError: if a collapse argument is supplied
+        :raises NotImplementedError: if a collapse argument is supplied.
         '''
         # TODO 1370: OpenMP loop functions don't support collapse
         if collapse:

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -322,6 +322,8 @@ class OMPTaskloopTrans(ParallelLoopTrans):
     (OMP Master or OMP Single). These conditions are tested at
     code-generation time.
 
+    TODO: #1364 Taskloops do not yet support reduction clauses.
+
     For example:
 
     >>> from pysclone.parse.algorithm import parse

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -370,7 +370,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
     @property
     def omp_grainsize(self):
         ''' Returns the grainsize that will be specified by
-            this transformation. By default the grainsize  
+            this transformation. By default the grainsize
             clause is not applied, so grainsize is None.'''
         return self._grainsize
 
@@ -379,7 +379,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         '''
         Sets the grainsize that will be specified by
         this transformation. Checks the grainsize is
-        a positive integer value 
+        a positive integer value.
 
         :param value: Integer value to use in the grainsize clause.
         :type value: int
@@ -406,17 +406,17 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
     @omp_num_tasks.setter
     def omp_num_tasks(self, value):
-        ''' 
+        '''
         Sets the num_tasks that will be specified by
         this transformation. Checks the num_tasks is
         a positive integer value
-        
+
         :param value: Integer value to use in the num_tasks clause.
         :type value: int
 
         :raises TransformationError: If value is not an int.
         :raises TransformationError: If value is negative.
-        
+
         '''
         if not isinstance(value, int):
             raise TransformationError("num_tasks must be an integer, "
@@ -425,7 +425,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         if value <= 0:
             raise TransformationError("num_tasks must be a positive "
                                       "integer, got {0}".format(value))
-        
+
         self._num_tasks = value
 
     def _directive(self, children, collapse=None):

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -340,7 +340,9 @@ class OMPTaskloopTrans(ParallelLoopTrans):
     >>>
     # Apply the OpenMP Taskloop transformation to *every* loop
     # in the schedule.
-    # FIXME: This ignores loop dependencies
+    # This ignores loop dependencies. These must be manually handled
+    # either through end of regions.
+    # TODO: #1368 These can also be handled through the taskwait directive
     >>> for child in schedule.children:
     >>>     tasklooptrans.apply(child)
     >>> # Enclose all of these loops within a single OpenMP
@@ -355,10 +357,8 @@ class OMPTaskloopTrans(ParallelLoopTrans):
     def __init__(self, grainsize=None, num_tasks=None):
         self._grainsize = None
         self._num_tasks = None
-        if grainsize is not None:
-            self.omp_grainsize = grainsize
-        if num_tasks is not None:
-            self.omp_num_tasks = num_tasks
+        self.omp_grainsize = grainsize
+        self.omp_num_tasks = num_tasks
 
         super(OMPTaskloopTrans, self).__init__()
 
@@ -367,9 +367,14 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
     @property
     def omp_grainsize(self):
-        ''' Returns the grainsize that will be specified by
-            this transformation. By default the grainsize
-            clause is not applied, so grainsize is None.'''
+        ''' 
+        Returns the grainsize that will be specified by
+        this transformation. By default the grainsize
+        clause is not applied, so grainsize is None.
+
+        :returns: The grainsize specified by this transformation
+        :rtype: int or None
+        '''
         return self._grainsize
 
     @omp_grainsize.setter
@@ -380,9 +385,9 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         a positive integer value or None.
 
         :param value: Integer value to use in the grainsize clause.
-        :type value: int
+        :type value: int or None
 
-        :raises TransformationError: If value is not an int.
+        :raises TransformationError: If value is not an int and is not None.
         :raises TransformationError: If value is negative.
         :raises TransformationError: if grainsize and num_tasks are \
                                      both specified.
@@ -395,7 +400,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
             raise TransformationError("grainsize must be a positive "
                                       "integer, got {0}".format(value))
 
-        if self.omp_num_tasks is not None:
+        if value is not None and self.omp_num_tasks is not None:
             raise TransformationError(
                 "The grainsize and num_tasks clauses would both "
                 "be specified for this Taskloop transformation")
@@ -403,9 +408,14 @@ class OMPTaskloopTrans(ParallelLoopTrans):
 
     @property
     def omp_num_tasks(self):
-        ''' Returns the num_tasks that will be specified
-            by this transformation. By default the num_tasks
-            clause is not applied so num_tasks is None. '''
+        ''' 
+        Returns the num_tasks that will be specified
+        by this transformation. By default the num_tasks
+        clause is not applied so num_tasks is None.
+
+        :returns: The grainsize specified by this transformation
+        :rtype: int or None
+        '''
         return self._num_tasks
 
     @omp_num_tasks.setter
@@ -416,9 +426,9 @@ class OMPTaskloopTrans(ParallelLoopTrans):
         a positive integer value or None.
 
         :param value: Integer value to use in the num_tasks clause.
-        :type value: int
+        :type value: int or None
 
-        :raises TransformationError: If value is not an int or None.
+        :raises TransformationError: If value is not an int and is not None.
         :raises TransformationError: If value is negative.
         :raises TransformationError: if grainsize and num_tasks are \
                                      both specified.
@@ -432,7 +442,7 @@ class OMPTaskloopTrans(ParallelLoopTrans):
             raise TransformationError("num_tasks must be a positive "
                                       "integer, got {0}".format(value))
 
-        if self.omp_grainsize is not None:
+        if value is not None and self.omp_grainsize is not None:
             raise TransformationError(
                 "The grainsize and num_tasks clauses would both "
                 "be specified for this Taskloop transformation")


### PR DESCRIPTION
This PR contains the implementation of the taskloop directive and transformation for PSyclone.

Still to do:

- [x] Selection of `grainsize` or `num_tasks` options. These should be exclusive (as they override each other).
- [x] Documentation of the transformation

To discuss as some point (@rupertford perhaps next monthly meeting?):

- [x] Should `taskwait` be included in this PR since it is realistically a required directive to use this for any more complex code.
- [x] Should `taskloop` directives care about data requirements explicitly, and should they support reductions? I need to double check what happens (I believe they inherit data clauses from parent regions) for the former, but probably they do need to explicitly handle reductions with their `in_reduction` clauses.

Also this currently is built off #1352 so will be rebased to master once that is merged.