### PR TITLE
1367 support real constants arguments in gocean

### DIFF
--- a/changelog
+++ b/changelog
@@ -140,6 +140,8 @@
 	47) PR #1358 towards #1338. Add the OpenMP Taskloop directive and its
 	corresponding insertion transformation.
 
+	48) PR #1369 for #1367. GOcean supports REAL literals in kernel arguments.
+
 release 2.0.0 28th April 2021
 
 	1) #778 for #713. Use 'make' to execute all examples.

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -61,9 +61,9 @@ from psyclone.errors import GenerationError, InternalError
 import psyclone.expression as expr
 from psyclone.f2pygen import CallGen, DeclGen, AssignGen, CommentGen, \
     IfThenGen, UseGen, ModuleGen, SubroutineGen, TypeDeclGen, PSyIRGen
+from psyclone.parse.algorithm import Arg
 from psyclone.parse.kernel import Descriptor, KernelType
 from psyclone.parse.utils import ParseError
-from psyclone.parse.algorithm import Arg
 from psyclone.psyGen import PSy, Invokes, Invoke, InvokeSchedule, \
     CodedKern, Arguments, Argument, KernelArgument, args_filter, \
     AccessType, HaloExchange
@@ -76,7 +76,7 @@ from psyclone.psyir.nodes import Loop, Literal, Schedule, Node, \
 from psyclone.psyir.symbols import SymbolTable, ScalarType, ArrayType, \
     INTEGER_TYPE, DataSymbol, ArgumentInterface, RoutineSymbol, \
     ContainerSymbol, DeferredType, DataTypeSymbol, UnresolvedInterface, \
-    UnknownFortranType, LocalInterface, BOOLEAN_TYPE
+    UnknownFortranType, LocalInterface, BOOLEAN_TYPE, REAL_TYPE
 
 
 # Specify which OpenCL command queue to use for management operations like
@@ -2534,6 +2534,13 @@ class GOKernelArgument(KernelArgument):
         # six.text_type is needed in Python2 to use the isnumeric method
         if six.text_type(self.name).isnumeric():
             return Literal(self.name, INTEGER_TYPE)
+
+        # Now try for a real value:
+        try:
+            float(self.name)
+            return Literal(self.name, REAL_TYPE)
+        except ValueError:
+            pass
 
         # Otherwise it's some form of Reference
         symbol = self._call.scope.symbol_table.lookup(self.name)

--- a/src/psyclone/gocean1p0.py
+++ b/src/psyclone/gocean1p0.py
@@ -2535,9 +2535,9 @@ class GOKernelArgument(KernelArgument):
         if six.text_type(self.name).isnumeric():
             return Literal(self.name, INTEGER_TYPE)
 
-        # Now try for a real value:
+        # Now try for a real value. The constructor will raise an exception
+        # if the string is not a valid floating point number.
         try:
-            float(self.name)
             return Literal(self.name, REAL_TYPE)
         except ValueError:
             pass

--- a/src/psyclone/psyir/nodes/literal.py
+++ b/src/psyclone/psyir/nodes/literal.py
@@ -74,7 +74,7 @@ class Literal(DataNode):
     _children_valid_format = "<LeafNode>"
     _text_name = "Literal"
     _colour = "yellow"
-    _real_value = r'^[+-]?[0-9]+(\.[0-9]*)?(e[+-]?[0-9]+)?$'
+    _real_value = r'^[+-]?[0-9]+(\.[0-9]*)?([eE][+-]?[0-9]+)?$'
 
     def __init__(self, value, datatype, parent=None):
         super(Literal, self).__init__(parent=parent)

--- a/src/psyclone/psyir/nodes/literal.py
+++ b/src/psyclone/psyir/nodes/literal.py
@@ -102,7 +102,7 @@ class Literal(DataNode):
                 "'false' but found '{0}'.".format(value))
 
         if (datatype.intrinsic == ScalarType.Intrinsic.REAL and not
-                re.search(Literal._real_value, value)):
+                re.match(Literal._real_value, value)):
             raise ValueError(
                 "A scalar real literal value must conform to the "
                 "supported format ('{0}') but found '{1}'."

--- a/src/psyclone/tests/gocean1p0_test.py
+++ b/src/psyclone/tests/gocean1p0_test.py
@@ -58,7 +58,7 @@ from psyclone.psyir.symbols import SymbolTable, DeferredType, \
     ContainerSymbol, DataSymbol, GlobalInterface, ScalarType, INTEGER_TYPE, \
     ArgumentInterface, DataTypeSymbol
 from psyclone.psyir.nodes import Node, StructureReference, Member, \
-    StructureMember, Reference
+    StructureMember, Reference, Literal
 
 API = "gocean1.0"
 BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
@@ -1559,6 +1559,32 @@ def test_gokernelargument_psyir_expression():
         _ = argument_list.args[0].psyir_expression()
     assert ("GOcean expects the Argument.argument_type() to be 'field' or "
             "'scalar' but found 'incompatible'." in str(excinfo.value))
+
+
+def test_gokernelargument_constant_psyir_expression():
+    '''Test various constant arguments and their conversion to PSyIR.
+    '''
+
+    # Parse an invoke with a scalar int and a field
+    _, invoke_info = parse(os.path.join(os.path.
+                                        dirname(os.path.
+                                                abspath(__file__)),
+                                        "test_files", "gocean1p0",
+                                        "single_invoke_scalar_float_arg.f90"),
+                           api=API)
+    psy = PSyFactory(API).create(invoke_info)
+    invoke = psy.invokes.invoke_list[0]
+    kernelcall = invoke.schedule.coded_kernels()[0]
+    argument_list = kernelcall.arguments
+
+    for (const, intr_type) in [("1", ScalarType.Intrinsic.INTEGER),
+                               ("1.0", ScalarType.Intrinsic.REAL),
+                               ("1.0e+0", ScalarType.Intrinsic.REAL),
+                               ("1.0E-0", ScalarType.Intrinsic.REAL)]:
+        argument_list.args[0]._name = const
+        expr = argument_list.args[0].psyir_expression()
+        assert isinstance(expr, Literal)
+        assert expr.datatype.intrinsic == intr_type
 
 
 def test_gokernelargument_type(monkeypatch):

--- a/src/psyclone/tests/psyir/nodes/literal_test.py
+++ b/src/psyclone/tests/psyir/nodes/literal_test.py
@@ -130,7 +130,7 @@ def test_literal_init_invalid_2(value):
     with pytest.raises(ValueError) as err:
         Literal(value, REAL_DOUBLE_TYPE)
     assert ("A scalar real literal value must conform to the supported "
-            "format ('^[+-]?[0-9]+(\\.[0-9]*)?(e[+-]?[0-9]+)?$') but "
+            "format ('^[+-]?[0-9]+(\\.[0-9]*)?([eE][+-]?[0-9]+)?$') but "
             "found '{0}'.".format(value) in str(err.value))
 
 


### PR DESCRIPTION
This is a small fix for #1367.

Note that it would be quite easy to support double precision values (`float` does not support 'd', so we would have to replace all 'd's with 'e' in the string before calling `float`, then extend the `Literal` re to support 'dD')  - but I wasn't sure of any other implications (would double need a new intrinsic type, ...).

Assigning to @sergisiso , since I assume the changes (and future plans for) `Literal` are in his court :)