### PR TITLE
 [LFRic] Bug fix for stencil depth list (for #1689)

### DIFF
--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -4773,7 +4773,7 @@ class DynBasisFunctions(DynCollection):
                 for var in self._qr_vars[shape]:
                     var_names.append(
                         self._symbol_table.find_or_create_tag(var+"_proxy")
-                                          .name)
+                        .name)
                 parent.add(
                     TypeDeclGen(
                         parent,
@@ -5956,19 +5956,24 @@ class DynHaloExchange(HaloExchange):
         :rtype: str
 
         '''
-        # get information about reading from the halo from all read fields
+        # Get information about reading from the halo from all "read" fields
         # dependendent on this halo exchange
         depth_info_list = self._compute_halo_read_depth_info()
 
-        # if there is only one entry in the list we can just return
-        # the depth
-        if len(depth_info_list) == 1:
-            return str(depth_info_list[0])
-        # the depth information can't be reduced to a single
-        # expression, therefore we need to determine the maximum
-        # of all expresssions
+        # Create string representation of depth info list and filter
+        # out empty entries
         depth_str_list = [str(depth_info) for depth_info in
                           depth_info_list]
+        depth_str_list = " ".join(depth_str_list).split()
+
+        # If there is only one entry in the list we can just return
+        # the depth
+        if len(depth_str_list) == 1:
+            return str(depth_str_list[0])
+
+        # The depth information can't be reduced to a single
+        # expression, therefore we need to determine the maximum
+        # of all expresssions
         return "max("+",".join(depth_str_list)+")"
 
     def _compute_halo_read_depth_info(self, ignore_hex_dep=False):
@@ -9759,13 +9764,12 @@ class DynKernelArgument(KernelArgument):
 
             '''
             return root_table.find_or_create(
-                    type_name,
-                    symbol_type=DataTypeSymbol,
-                    datatype=DeferredType(),
-                    interface=ImportInterface(root_table.find_or_create(
-                        mod_name,
-                        symbol_type=ContainerSymbol)
-                        ))
+                type_name,
+                symbol_type=DataTypeSymbol,
+                datatype=DeferredType(),
+                interface=ImportInterface(root_table.find_or_create(
+                    mod_name,
+                    symbol_type=ContainerSymbol)))
 
         if self.is_scalar:
             # Find or create the DataType for the appropriate scalar type.

--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -5973,7 +5973,7 @@ class DynHaloExchange(HaloExchange):
 
         # The depth information can't be reduced to a single
         # expression, therefore we need to determine the maximum
-        # of all expresssions
+        # of all expressions
         return "max("+",".join(depth_str_list)+")"
 
     def _compute_halo_read_depth_info(self, ignore_hex_dep=False):

--- a/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
+++ b/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
@@ -1953,8 +1953,7 @@ def test_discontinuous_stencil_w3_writer(tmpdir):
         "        CALL f2_proxy%halo_exchange(depth=extent)\n"
         "      END IF\n"
         "      !\n"
-        "      CALL f4_proxy%halo_exchange(depth=extent)\n"
-        "      !\n")
+        "      CALL f4_proxy%halo_exchange(depth=extent)\n")
     assert output3 in result
 
 

--- a/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
+++ b/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
@@ -1916,7 +1916,7 @@ def test_discontinuous_stencil_w3_writer(tmpdir):
         api=TEST_API)
     psy = PSyFactory(TEST_API,
                      distributed_memory=True).create(invoke_info)
-    result = str(psy.gen); print(result)
+    result = str(psy.gen)
 
     # Check compilation
     assert LFRicBuild(tmpdir).code_compiles(psy)
@@ -1945,15 +1945,19 @@ def test_discontinuous_stencil_w3_writer(tmpdir):
     # Check halo exchanges for the second invoke with the reverse
     # ordering of kernel calls
     output3 = (
-        "      ! Set halos dirty/clean for fields modified in the above loop\n"
+        "      ! Call kernels and communication routines\n"
         "      !\n"
-        "      CALL f4_proxy%set_dirty()\n"
-        "      !\n"
-        "      IF (f2_proxy%is_dirty(depth=extent)) THEN\n"
-        "        CALL f2_proxy%halo_exchange(depth=extent)\n"
+        "      IF (f1_proxy%is_dirty(depth=1)) THEN\n"
+        "        CALL f1_proxy%halo_exchange(depth=1)\n"
         "      END IF\n"
         "      !\n"
-        "      CALL f4_proxy%halo_exchange(depth=extent)\n")
+        "      IF (f2_proxy%is_dirty(depth=max(1,extent))) THEN\n"
+        "        CALL f2_proxy%halo_exchange(depth=max(1,extent))\n"
+        "      END IF\n"
+        "      !\n"
+        "      IF (f3_proxy%is_dirty(depth=1)) THEN\n"
+        "        CALL f3_proxy%halo_exchange(depth=1)\n"
+        "      END IF\n")
     assert output3 in result
 
 

--- a/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
+++ b/src/psyclone/tests/domain/lfric/lfric_stencil_test.py
@@ -1916,7 +1916,7 @@ def test_discontinuous_stencil_w3_writer(tmpdir):
         api=TEST_API)
     psy = PSyFactory(TEST_API,
                      distributed_memory=True).create(invoke_info)
-    result = str(psy.gen)
+    result = str(psy.gen); print(result)
 
     # Check compilation
     assert LFRicBuild(tmpdir).code_compiles(psy)

--- a/src/psyclone/tests/test_files/dynamo0p3/19.27_discontinuous_stencil_w3_writer.f90
+++ b/src/psyclone/tests/test_files/dynamo0p3/19.27_discontinuous_stencil_w3_writer.f90
@@ -1,0 +1,67 @@
+! -----------------------------------------------------------------------------
+! BSD 3-Clause License
+!
+! Copyright (c) 2022, Science and Technology Facilities Council
+! All rights reserved.
+!
+! Redistribution and use in source and binary forms, with or without
+! modification, are permitted provided that the following conditions are met:
+!
+! * Redistributions of source code must retain the above copyright notice, this
+!   list of conditions and the following disclaimer.
+!
+! * Redistributions in binary form must reproduce the above copyright notice,
+!   this list of conditions and the following disclaimer in the documentation
+!   and/or other materials provided with the distribution.
+!
+! * Neither the name of the copyright holder nor the names of its
+!   contributors may be used to endorse or promote products derived from
+!   this software without specific prior written permission.
+!
+! THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+! "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+! LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+! FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+! COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+! INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+! BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+! LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+! CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+! LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+! ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+! POSSIBILITY OF SUCH DAMAGE.
+! -----------------------------------------------------------------------------
+! Author I. Kavcic, Met Office
+
+program discontinuous_stencil_w3_writer
+  ! Description: Check stencil depth list when a kernel call with discontinuous
+  ! stencil readers is followed by a kernel call with a discontinuous writer in
+  ! the same invoke. Also check the reverse order of kernel calls.
+
+  use constants_mod,      only: i_def, r_solver
+  use r_solver_field_mod, only: r_solver_field_type
+  use testkern_w3_mod,    only: testkern_w3_type
+  use testkern_different_any_dscnt_space_stencil_mod, &
+                          only: testkern_different_any_dscnt_space_stencil_type
+
+  implicit none
+
+  type(r_solver_field_type) :: f1, f2, f3, f4
+  real(r_solver)            :: a
+  integer(i_def)            :: extent = 2
+
+  call invoke(name="stencils_first",                                &
+       testkern_different_any_dscnt_space_stencil_type(f1,          &
+                                                       f2, extent,  &
+                                                       f4, extent), &
+       testkern_w3_type(a, f1, f2, f3, f4)                          &
+       )
+
+  call invoke(name="stencils_second",                               &
+       testkern_w3_type(a, f1, f2, f3, f4),                         &
+       testkern_different_any_dscnt_space_stencil_type(f1,          &
+                                                       f2, extent,  &
+                                                       f4, extent)  &
+       )
+
+end program discontinuous_stencil_w3_writer


### PR DESCRIPTION
Create correct stencil depth list when we have a kernel that has discontinuous stencil readers followed by a kernel that has discontinuous writers in a single invoke (more details in the issue).

Also cleaned up some `pylint` issues in `dynamo0p3.py`.

I generated PSy-layer code with optimisations for the `bl_exp_alg_mod.F90` in Ian's branch  [LFRic/branches/dev/ianboutle/r34895_bl_exp_split@35124](https://code.metoffice.gov.uk/trac/lfric/browser/LFRic/branches/dev/ianboutle/r34895_bl_exp_split?rev=35124) from this bug fix branch, placed it into `um_physics/source/psy` directory and ran the `lfric_atm` test suite with it. It is all fine. Command-line build without optimisations also works fine. 