### PR TITLE
(Closes #1744) Otter tracing linking

### DIFF
--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -87,6 +87,10 @@ from psyclone.psyir.nodes.omp_directives import OMPDirective, OMPDoDirective, \
 from psyclone.psyir.nodes.clause import Clause
 from psyclone.psyir.nodes.omp_clauses import OMPGrainsizeClause, \
     OMPNogroupClause, OMPNowaitClause, OMPNumTasksClause
+from psyclone.psyir.nodes.otter_nodes import OtterTraceSetupNode, \
+        OtterParallelNode, OtterTaskNode, OtterTaskSingleNode, \
+        OtterLoopNode, OtterLoopIterationNode, OtterSynchroniseChildrenNode, \
+        OtterSynchroniseDescendantTasksNode, OtterTraceNode, OtterNode
 
 
 # The entities in the __all__ list are made available to import directly from
@@ -162,5 +166,16 @@ __all__ = [
         'OMPGrainsizeClause',
         'OMPNogroupClause',
         'OMPNowaitClause',
-        'OMPNumTasksClause'
+        'OMPNumTasksClause',
+        # Otter Nodes
+        'OtterNode',
+        'OtterTraceSetupNode',
+        'OtterParallelNode',
+        'OtterTaskNode',
+        'OtterTaskSingleNode',
+        'OtterLoopNode',
+        'OtterLoopIterationNode',
+        'OtterSynchroniseChildrenNode',
+        'OtterSynchroniseDescendantTasksNode',
+        'OtterTraceNode'
         ]

--- a/src/psyclone/psyir/nodes/otter_nodes.py
+++ b/src/psyclone/psyir/nodes/otter_nodes.py
@@ -33,8 +33,7 @@
 # -----------------------------------------------------------------------------
 # Authors A. B. G. Chalk, STFC Daresbury Lab
 # -----------------------------------------------------------------------------
-''' This module contains the implementation of the various Otter Directive
-nodes.'''
+''' This module contains the implementation of the various Otter nodes.'''
 
 from __future__ import absolute_import
 import abc
@@ -101,7 +100,7 @@ class OtterNode(Statement, metaclass=abc.ABCMeta):
         routine_name = routine_schedule.name
 
 
-        if self._start_subroutine_call is not "":
+        if self._start_subroutine_call != "":
             file_symbol = DataSymbol("__FILE__", CHARACTER_TYPE)
             routine = RoutineSymbol(self._start_subroutine_call)
             line_symbol = DataSymbol("__LINE__", INTEGER_TYPE)
@@ -118,7 +117,7 @@ class OtterNode(Statement, metaclass=abc.ABCMeta):
         for child in self.children[0].pop_all_children():
             self.parent.children.insert(self.position, child)
 
-        if self._end_subroutine_call is not "":
+        if self._end_subroutine_call != "":
             routine = RoutineSymbol(self._end_subroutine_call)
             argument_list = []
             end_call = Call.create(routine, argument_list)
@@ -265,7 +264,7 @@ class OtterTraceNode(OtterNode):
         routine_name = routine_schedule.name
 
 
-        if self._start_subroutine_call is not "":
+        if self._start_subroutine_call != "":
             routine = RoutineSymbol(self._start_subroutine_call)
             argument_list = []
             start_call = Call.create(routine, argument_list)
@@ -277,7 +276,7 @@ class OtterTraceNode(OtterNode):
         for child in self.children[0].pop_all_children():
             self.parent.children.insert(self.position, child)
 
-        if self._end_subroutine_call is not "":
+        if self._end_subroutine_call != "":
             routine = RoutineSymbol(self._end_subroutine_call)
             argument_list = []
             end_call = Call.create(routine, argument_list)

--- a/src/psyclone/psyir/nodes/otter_nodes.py
+++ b/src/psyclone/psyir/nodes/otter_nodes.py
@@ -1,0 +1,288 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors A. B. G. Chalk, STFC Daresbury Lab
+# -----------------------------------------------------------------------------
+''' This module contains the implementation of the various Otter Directive
+nodes.'''
+
+from __future__ import absolute_import
+import abc
+import six
+
+
+from psyclone.configuration import Config
+from psyclone.core import AccessType, VariablesAccessInfo
+from psyclone.errors import GenerationError, InternalError
+from psyclone.f2pygen import (AssignGen, UseGen, DeclGen, DirectiveGen,
+                              CommentGen)
+from psyclone.psyir.nodes.call import Call
+from psyclone.psyir.nodes.directive import StandaloneDirective, \
+    RegionDirective
+from psyclone.psyir.nodes.statement import Statement
+from psyclone.psyir.nodes.literal import Literal
+from psyclone.psyir.nodes.routine import Routine
+from psyclone.psyir.nodes.reference import Reference
+from psyclone.psyir.nodes.schedule import Schedule
+from psyclone.psyir.symbols import DataSymbol, INTEGER_TYPE, CHARACTER_TYPE, \
+    RoutineSymbol
+
+
+class OtterNode(Statement, metaclass=abc.ABCMeta):
+    '''
+    This class can be inserted into a schedule to instrument a set of nodes.
+    Instrument means that calls to a Otter,
+    https://github.com/Otter-Taskification/otter will be inserted before
+    and after the list of child nodes, which will be used to generate
+    data for use with Otter and pyOtter.
+
+    :param children: the psyIR nodes that are children of this node. These \
+                     will be made children of the child Schedule of otterNode.
+    :type children: list of :py:class:`psyclone.psyir.nodes.Node`
+    :param parent: the parent of this node in the PSyIR tree.
+    :type parent: :py:class:`psyclone.psyir.nodes.Node`
+
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterNode"
+    _colour = "green"
+
+    _start_subroutine_call = ""
+    _end_subroutine_call = ""
+
+
+    def __init__(self, children=None, parent=None):
+        super().__init__(parent=parent)
+        sched = Schedule(children=children)
+        self.addchild(sched)
+
+
+    def lower_to_language_level(self, options=None):
+        '''TODO'''
+        # TODO Add otter module into use modules in routine
+        for child in self.children:
+            child.lower_to_language_level()
+        routine_schedule = self.ancestor(Routine)
+        if routine_schedule is None:
+            raise GenerationError(
+                f"An OtterNode must be inside a Routine context when "
+                f"lowering but '{self}' is not.")
+
+        routine_name = routine_schedule.name
+
+
+        if self._start_subroutine_call is not "":
+            file_symbol = DataSymbol("__FILE__", CHARACTER_TYPE)
+            routine = RoutineSymbol(self._start_subroutine_call)
+            line_symbol = DataSymbol("__LINE__", INTEGER_TYPE)
+            argument_list = []
+            argument_list.append(Reference(file_symbol))
+            argument_list.append(Literal(routine_name, CHARACTER_TYPE))
+            argument_list.append(Reference(line_symbol))
+            start_call = Call.create(routine, argument_list)
+
+            self.parent.children.insert(self.position, start_call)
+
+        # Insert the body of the profiled region between the start and
+        # end calls
+        for child in self.children[0].pop_all_children():
+            self.parent.children.insert(self.position, child)
+
+        if self._end_subroutine_call is not "":
+            routine = RoutineSymbol(self._end_subroutine_call)
+            argument_list = []
+            end_call = Call.create(routine, argument_list)
+
+            self.parent.children.insert(self.position, end_call)
+
+        # Finally we can detach this node
+        self.detach()
+
+    @staticmethod
+    def _validate_child(position, child):
+        '''
+        :param int position: the position to be validated.
+        :param child: a child to be validated.
+        :type child: :py:class:`psyclone.psyir.nodes.Node`
+
+        :return: whether the given child and position are valid for this node.
+        :rtype: bool
+
+        '''
+        return position == 0 and isinstance(child, Schedule)
+
+
+class OtterTraceSetupNode(OtterNode):
+    '''
+    Node to represent the OtterTraceInitialise and OtterTraceFinalise
+    calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterTraceSetupNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterTraceInitialise_i"
+    _end_subroutine_call = "fortran_otterTraceFinalise"
+
+
+class OtterParallelNode(OtterNode):
+    '''
+    Node to represent OtterParallelBegin and OtterParallelEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterParallelNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterParallelBegin_i"
+    _end_subroutine_call = "fortran_otterParallelEnd"
+
+
+class OtterTaskNode(OtterNode):
+    '''
+    Node to represent OtterTaskBegin and OtterTaskEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterTaskNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterTaskBegin_i"
+    _end_subroutine_call = "fortran_otterTaskEnd"
+
+
+class OtterTaskSingleNode(OtterNode):
+    '''
+    Node to represent OtterTaskSingleBegin and OtterTaskSingleEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterTaskSingleNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterTaskSingleBegin_i"
+    _end_subroutine_call = "fortran_otterTaskSingleEnd"
+
+
+class OtterLoopNode(OtterNode):
+    '''
+    Node to represent OtterLoopBegin and OtterLoopEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterLoopNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterLoopBegin_i"
+    _end_subroutine_call = "fortran_otterLoopEnd"
+
+
+class OtterLoopIterationNode(OtterNode):
+    '''
+    Node to represent OtterLoopIterationBegin and OtterLoopIterationEnd
+    cals.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterLoopIterationNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterLoopIterationBegin_i"
+    _end_subroutine_call = "fortran_otterLoopIterationEnd"
+
+
+class OtterSynchroniseChildrenNode(OtterNode):
+    '''
+    Node to represent OtterSynchroniseChildTasks call.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterSynchroniseChildrenNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterSynchroniseChildTasks_i"
+
+
+class OtterSynchroniseDescendantTasksNode(OtterNode):
+    '''
+    Node to represent OtterSynchroniseDescendantTasksBegin and 
+    OtterSynchroniseDescendantTasksEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterSynchroniseDescendantTasksNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterSynchroniseDescendantTasksBegin_i"
+    _end_subroutine_call = "fortran_otterSynchroniseDescendantTasksEnd"
+
+
+class OtterTraceNode(OtterNode):
+    '''
+    Node to represent OtterTraceStart and OtterTraceEnd calls.
+    '''
+    _children_valid_format = "Schedule"
+    _text_name = "otterTraceNode"
+    _colour = "green"
+
+    _start_subroutine_call = "fortran_otterTraceStart"
+    _end_subroutine_call = "fortran_otterTraceStop"
+
+    def lower_to_language_level(self, options=None):
+        '''TODO'''
+        # TODO Add otter module into use modules in routine
+        for child in self.children:
+            child.lower_to_language_level()
+        routine_schedule = self.ancestor(Routine)
+        if routine_schedule is None:
+            raise GenerationError(
+                f"An OtterNode must be inside a Routine context when "
+                f"lowering but '{self}' is not.")
+
+        routine_name = routine_schedule.name
+
+
+        if self._start_subroutine_call is not "":
+            routine = RoutineSymbol(self._start_subroutine_call)
+            argument_list = []
+            start_call = Call.create(routine, argument_list)
+
+            self.parent.children.insert(self.position, start_call)
+
+        # Insert the body of the profiled region between the start and
+        # end calls
+        for child in self.children[0].pop_all_children():
+            self.parent.children.insert(self.position, child)
+
+        if self._end_subroutine_call is not "":
+            routine = RoutineSymbol(self._end_subroutine_call)
+            argument_list = []
+            end_call = Call.create(routine, argument_list)
+
+            self.parent.children.insert(self.position, end_call)
+
+        # Finally we can detach this node
+        self.detach()

--- a/src/psyclone/psyir/nodes/otter_nodes.py
+++ b/src/psyclone/psyir/nodes/otter_nodes.py
@@ -113,7 +113,10 @@ class OtterNode(Statement, metaclass=abc.ABCMeta):
             file_symbol = DataSymbol("__FILE__", CHARACTER_TYPE)
             routine = RoutineSymbol(self._start_subroutine_call,
                                     interface=ImportInterface(csymbol))
-            symtab.add(routine)
+            try:
+                symtab.lookup(self._start_subroutine_call)
+            except KeyError:
+                symtab.add(routine)
             line_symbol = DataSymbol("__LINE__", INTEGER_TYPE)
             argument_list = []
             argument_list.append(Reference(file_symbol))
@@ -131,7 +134,10 @@ class OtterNode(Statement, metaclass=abc.ABCMeta):
         if self._end_subroutine_call != "":
             routine = RoutineSymbol(self._end_subroutine_call,
                                     interface=ImportInterface(csymbol))
-            symtab.add(routine)
+            try:
+                symtab.lookup(self._end_subroutine_call)
+            except KeyError:
+                symtab.add(routine)
             argument_list = []
             end_call = Call.create(routine, argument_list)
 
@@ -287,7 +293,10 @@ class OtterTraceNode(OtterNode):
         if self._start_subroutine_call != "":
             routine = RoutineSymbol(self._start_subroutine_call,
                                     interface=ImportInterface(csymbol))
-            symtab.add(routine)
+            try:
+                symtab.lookup(self._start_subroutine_call)
+            except KeyError:
+                symtab.add(routine)
             argument_list = []
             start_call = Call.create(routine, argument_list)
 
@@ -301,7 +310,10 @@ class OtterTraceNode(OtterNode):
         if self._end_subroutine_call != "":
             routine = RoutineSymbol(self._end_subroutine_call,
                                     interface=ImportInterface(csymbol))
-            symtab.add(routine)
+            try:
+                symtab.lookup(self._end_subroutine_call)
+            except KeyError:
+                symtab.add(routine)
             argument_list = []
             end_call = Call.create(routine, argument_list)
 

--- a/src/psyclone/psyir/transformations/__init__.py
+++ b/src/psyclone/psyir/transformations/__init__.py
@@ -68,6 +68,10 @@ from psyclone.psyir.transformations.loop_tiling_2d_trans \
 from psyclone.psyir.transformations.loop_trans import LoopTrans
 from psyclone.psyir.transformations.nan_test_trans import NanTestTrans
 from psyclone.psyir.transformations.omp_taskwait_trans import OMPTaskwaitTrans
+from psyclone.psyir.transformations.otter_trans import OtterTraceSetupTrans, \
+        OtterParallelTrans, OtterTaskloopTrans, OtterTaskSingleTrans, \
+        OtterLoopTrans, OtterSynchroniseChildrenTrans, \
+        OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans
 from psyclone.psyir.transformations.profile_trans import ProfileTrans
 from psyclone.psyir.transformations.psy_data_trans import PSyDataTrans
 from psyclone.psyir.transformations.read_only_verify_trans \
@@ -98,6 +102,14 @@ __all__ = ['ArrayRange2LoopTrans',
            'LoopTrans',
            'NanTestTrans',
            'OMPTaskwaitTrans',
+           'OtterTraceSetupTrans'
+           'OtterParallelTrans',
+           'OtterTaskloopTrans',
+           'OtterTaskSingleTrans',
+           'OtterLoopTrans',
+           'OtterSynchroniseChildrenTrans',
+           'OtterSynchroniseDescendantsTrans',
+           'OtterTraceStartEndTrans',
            'ProfileTrans',
            'PSyDataTrans',
            'ReadOnlyVerifyTrans',

--- a/src/psyclone/psyir/transformations/__init__.py
+++ b/src/psyclone/psyir/transformations/__init__.py
@@ -71,7 +71,8 @@ from psyclone.psyir.transformations.omp_taskwait_trans import OMPTaskwaitTrans
 from psyclone.psyir.transformations.otter_trans import OtterTraceSetupTrans, \
         OtterParallelTrans, OtterTaskloopTrans, OtterTaskSingleTrans, \
         OtterLoopTrans, OtterSynchroniseChildrenTrans, \
-        OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans
+        OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans, \
+        OtterSynchroniseRegionTrans
 from psyclone.psyir.transformations.profile_trans import ProfileTrans
 from psyclone.psyir.transformations.psy_data_trans import PSyDataTrans
 from psyclone.psyir.transformations.read_only_verify_trans \
@@ -108,6 +109,7 @@ __all__ = ['ArrayRange2LoopTrans',
            'OtterTaskSingleTrans',
            'OtterLoopTrans',
            'OtterSynchroniseChildrenTrans',
+           'OtterSynchroniseRegionTrans',
            'OtterSynchroniseDescendantsTrans',
            'OtterTraceStartEndTrans',
            'ProfileTrans',

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -36,15 +36,20 @@
 ''' This module contains the implementation of the various Otter
 transformations.'''
 
+from psyclone.core import VariablesAccessInfo
+from psyclone.errors import LazyString
 from psyclone.psyGen import Transformation
 from psyclone.psyir.transformations.chunk_loop_trans import ChunkLoopTrans
 from psyclone.psyir.transformations.loop_trans import LoopTrans
 from psyclone.psyir.transformations.region_trans import RegionTrans
+from psyclone.psyir import nodes
 from psyclone.psyir.nodes import Loop, Schedule, \
     OtterTraceSetupNode, OtterParallelNode, OtterTaskNode, \
     OtterTaskSingleNode, OtterLoopNode, OtterLoopIterationNode, \
     OtterSynchroniseChildrenNode, OtterSynchroniseDescendantTasksNode, \
     OtterTraceNode
+from psyclone.psyir.transformations.transformation_error import \
+        TransformationError
 
 class OtterTraceSetupTrans(RegionTrans):
     '''
@@ -400,7 +405,7 @@ class OtterSynchroniseRegionTrans(RegionTrans):
             dependence_node[i] = forward_dep
         # Forward dependency positions are now computed for this region.
         dependence_position, dependence_node = \
-            OMPTaskwaitTrans._eliminate_unneeded_dependencies(
+            OtterSynchroniseRegionTrans._eliminate_unneeded_dependencies(
                         taskloop_positions, dependence_position,
                         dependence_node)
         # dependence_position now contains only the required dependencies

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -196,6 +196,229 @@ class OtterSynchroniseChildrenTrans(Transformation):
         otter_sync_node = OtterSynchroniseChildrenNode()
         parent.children.insert(position+1, otter_sync_node)
 
+class OtterSynchroniseRegionTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval =  ("Adds 'Otter Synchronise Children' calls to a region of code "
+                "to satisfy data dependencies between 'Otter Task' calls")
+
+    @staticmethod
+    def get_forward_dependence(taskloop, root):
+        # root is OtterParallelNode
+        # taskloop is a Loop containing OtterTaskNode
+        # Check supplied the correct type for root
+        if not isinstance(root, OtterParallelNode):
+            raise TransformationError(f"Expected the root of the tree in which"
+                                      f" to look for a forward dependence to "
+                                      f"be an instance of OtterParallelNode"
+                                      f", but was supplied an instance of "
+                                      f"'{type(root).__name__}'")
+        # We only look for specific types
+        node_list = root.walk((Loop, OtterLoopNode,
+                               OtterSynchroniseChildrenNode))
+        # Find the taskloop's variable access info. We need to skip over the
+        # Loop variable writes from the Loop, so we skip the Loop children.
+        taskloop_vars = VariablesAccessInfo()
+        for child in taskloop.walk(nodes.Node):
+            if child is not taskloop and not isinstance(child,
+                                                        (Schedule, Loop)):
+                taskloop_vars.merge(VariablesAccessInfo(child))
+        taskloop_signatures = taskloop_vars.all_signatures
+        # Find our parent parallel region
+        parent_parallel = taskloop.ancestor(OtterParallelNode)
+        # Raise an error if there is no parent_parallel region
+        if parent_parallel is None:
+            fwriter = FortranWriter()
+            # Since "Backslashes may not appear inside the expression
+            # portions of f-strings" via PEP 498, use chr(10) for '\n'
+            raise InternalError(
+                    LazyString(lambda: f"No parent otter parallel node was "
+                                       f"found for the taskloop region: "
+                                       f"{fwriter(taskloop).rstrip(chr(10))}"))
+
+        for node in node_list:
+            if node.abs_position <= taskloop.abs_position:
+                continue
+            # Ignore any children of the taskloop directive
+            anc = node.ancestor(Loop)
+            if anc is taskloop:
+                continue
+            node_vars = None
+            if (isinstance(node, OtterSynchroniseChildrenNode)):
+                # If we find a synchronise children node, then it acts as a 
+                # barrier for dependencies as well, so we return it
+                return node
+            if not isinstance(node, OtterSynchroniseChildrenNode):
+                # For all our other node types we calculate their own
+                # variable accesses
+                node_vars = VariablesAccessInfo()
+                for child in node.walk(nodes.Node):
+                    if child is not node and not isinstance(child,
+                                                            (Schedule, Loop)):
+                        refs = VariablesAccessInfo(child)
+                        if refs is not None:
+                            node_vars.merge(refs)
+            node_signatures = node_vars.all_signatures
+            # Once we have the node's variable accesses, check for collisions
+            for sig1 in taskloop_signatures:
+                # If this signature is not in the node signatures then continue
+                if sig1 not in node_signatures:
+                    continue
+                access1 = taskloop_vars[sig1]
+                access2 = node_vars[sig1]
+                # If both are only read we can ignore this signature
+                # Otherwise, one of them writes so return this node as
+                # we have a WaW, WaR or RaW dependency
+                if access1.is_written() or access2.is_written():
+                    return node
+        # If we found no dependencies, then return that!
+        return None
+
+    @staticmethod
+    def _eliminate_unneeded_dependencies(taskloop_positions,
+                                         dependence_positions,
+                                         dependence_nodes):
+        '''
+        Eliminates unneeded dependencies from a set of taskloop positions,
+        dependence_positions and dependence_nodes for a region of code.
+
+        :param taskloop_positions: positions of the taskloops.
+        :type taskloop_positions: list of int
+        :param dependence_positions: positions of the taskloops' dependencies.
+        :type dependence_positions: list of int
+        :param dependence_nodes: the nodes respresenting the forward \
+                                 dependency of each taskloop node.
+        :type dependence_nodes: list of :py:class:`psyclone.psyir.nodes.Node`
+
+        :returns: the updated dependence_positions and dependence_nodes arrays
+        :rval: 2-tuple of (list of int, list of
+               :py:class:`psyclone.psyir.nodes.Node`)
+
+        '''
+        # We loop over each dependence and perform the same operation:
+        # For each dependence we loop over all other
+        # taskloops whose position is after this taskloop, but before
+        # this taskloop's forward dependency. If that dependence is
+        # fulfilled by this dependence (i.e.
+        # dependence_position[this] < dependence_position[that]) then
+        # we remove that dependence. If this dependence is fulfilled
+        # by that dependence (i.e. dependence_position[that] <
+        # dependence_position[this]) then we remove this dependence.
+        # This assumes that taskloop_positions is in ascending order,
+        # which I believe to be true by construction.
+        for i, dep_pos in enumerate(dependence_positions):
+            # Corresponding taskloop has no dependency or was satisfied
+            # by another dependency being resolved.
+            if dep_pos is None:
+                continue
+            # Grab the position of the next dependence
+            next_dependence = dep_pos
+            # Loop over the other taskloops
+            for j in range(i+1, len(dependence_positions)):
+                # If this taskloop happens after the next_dependence
+                # then we can just stop.
+                if taskloop_positions[j] >= next_dependence:
+                    break
+                # If the jth taskloop has no dependency then continue
+                if dependence_positions[j] is None:
+                    continue
+                # Check if next_dependence will satisfy the jth
+                # taskloops dependency
+                if next_dependence <= dependence_positions[j]:
+                    dependence_positions[j] = None
+                    dependence_nodes[j] = None
+                    continue
+                # Check if the jth taskloop's dependence will satisfy
+                # the next_dependence
+                if dependence_positions[j] < next_dependence:
+                    dependence_positions[i] = None
+                    dependence_nodes[i] = None
+                    # If it does then we can move to the next taskloop
+                    break
+        return dependence_positions, dependence_nodes
+
+    def apply(self, node, options=None):
+        '''
+        Apply an OMPTaskwait Transformation to the supplied node
+        (which must be an OMPParallelDirective). In the generated code this
+        corresponds to adding zero or more OMPTaskwaitDirectives as
+        appropriate:
+
+        .. code-block:: fortran
+
+          !$OMP PARALLEL
+            ...
+            !$OMP TASKWAIT
+            ...
+            !$OMP TASKWAIT
+            ...
+          !$OMP END PARALLEL
+
+        :param node: the node to which to apply the transformation.
+        :type node: :py:class:`psyclone.psyir.nodes.OMPParallelDirective`
+        :param options: a dictionary with options for transformations\
+                        and validation.
+        :type options: dict of string:values or None
+        :param bool options["fail_on_no_taskloop"]:
+                indicating whether this should throw an error if no \
+                OMPTaskloop nodes are found in this tree. This can be \
+                safely disabled as if there are no Taskloop nodes the \
+                result of this transformation is valid OpenMP code. Default \
+                is True
+
+        '''
+        self.validate(node, options=options)
+
+        # Find all of the taskloops
+        taskloops = []
+        for loop in node.walk(Loop):
+            if loop.walk(OtterTaskNode):
+                taskloops.append(loop)
+        # Get the positions of all of the taskloops
+        taskloop_positions = [-1] * len(taskloops)
+        # Get the forward_dependence position of all of the taskloops
+        dependence_position = [None] * len(taskloops)
+        dependence_node = [None] * len(taskloops)
+        for i, taskloop in enumerate(taskloops):
+            taskloop_positions[i] = taskloop.abs_position
+            # Only set forward_dep for taskloops with nogroup set
+            forward_dep = None
+            if taskloop.nogroup:
+                forward_dep = \
+                        OtterSynchroniseRegionTrans.get_forward_dependence(
+                        taskloop, node)
+                # If the forward_dependence is one of our parents then we
+                # should ignore it
+                if (forward_dep is not None and
+                        forward_dep.abs_position < taskloop.abs_position):
+                    continue
+            if forward_dep is None:
+                continue
+            dependence_position[i] = forward_dep.abs_position
+            dependence_node[i] = forward_dep
+        # Forward dependency positions are now computed for this region.
+        dependence_position, dependence_node = \
+            OMPTaskwaitTrans._eliminate_unneeded_dependencies(
+                        taskloop_positions, dependence_position,
+                        dependence_node)
+        # dependence_position now contains only the required dependencies
+        # to satisfy the full superset of dependencies. We can loop over
+        # these by index, and if dependence_position[i] is not None then
+        # go to its forward dependency, and insert a TaskwaitDirective
+        # immediately before.
+        for i, dep_pos in enumerate(dependence_position):
+            if dep_pos is not None:
+                forward_dep = dependence_node[i]
+                fdep_parent = forward_dep.parent
+                # Find the position of the forward_dep in its parent's
+                # children list
+                loc = forward_dep.position
+                # We've found the position, so we now insert an
+                # OMPTaskwaitDirective in that location instead
+                fdep_parent.addchild(OtterSynchroniseChildrenNode(), loc)
+
 class OtterSynchroniseDescendantsTrans(RegionTrans):
     '''
     TODO

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -51,7 +51,7 @@ class OtterTraceSetupTrans(RegionTrans):
     TODO
     '''
     def __str__(self):
-        rval = ("Adds a Otter Trace setup node to a region of code"
+        rval = ("Adds a Otter Trace setup node to a region of code "
                 "to enable Otter instrumentation of PSyclone")
         return rval
 
@@ -103,7 +103,7 @@ class OtterTaskloopTrans(LoopTrans):
     TODO
     '''
     def __str__(self):
-        rval = "Adds a set of Otter Tasking nodes to a Loop"
+        rval = "Adds a set of Otter Tasking nodes to a Loop by chunking."
         return rval
 
     def apply(self, node, options=None):
@@ -153,6 +153,7 @@ class OtterLoopTrans(LoopTrans):
     '''
     def __str__(self):
         rval = "Adds an Otter Loop node to a Loop"
+        return rval
 
     def apply(self, node, options=None):
         '''
@@ -199,7 +200,7 @@ class OtterSynchroniseDescendantsTrans(RegionTrans):
     '''
     TODO
     '''
-    def ___str__(self):
+    def __str__(self):
         rval = ("Adds an Otter Synchronise Descendents node around the"
                 " supplied nodes.")
         return rval
@@ -223,7 +224,7 @@ class OtterTraceStartEndTrans(RegionTrans):
     '''
     TODO
     '''
-    def __str(self):
+    def __str__(self):
         rval = ("Adds an Otter Trace Start and End node around the supplied "
                 "nodes.")
         return rval

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -208,6 +208,7 @@ class OtterSynchroniseRegionTrans(RegionTrans):
     def __str__(self):
         rval =  ("Adds 'Otter Synchronise Children' calls to a region of code "
                 "to satisfy data dependencies between 'Otter Task' calls")
+        return rval
 
     @staticmethod
     def get_forward_dependence(taskloop, root):

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -37,8 +37,9 @@
 transformations.'''
 
 from psyclone.core import VariablesAccessInfo
-from psyclone.errors import LazyString
+from psyclone.errors import LazyString, InternalError
 from psyclone.psyGen import Transformation
+from psyclone.psyir.backend.fortran import FortranWriter
 from psyclone.psyir.transformations.chunk_loop_trans import ChunkLoopTrans
 from psyclone.psyir.transformations.loop_trans import LoopTrans
 from psyclone.psyir.transformations.region_trans import RegionTrans

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -1,0 +1,243 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors A. B. G. Chalk, STFC Daresbury Lab
+# -----------------------------------------------------------------------------
+''' This module contains the implementation of the various Otter
+transformations.'''
+
+from psyclone.psyGen import Transformation
+from psyclone.psyir.transformations.chunk_loop_trans import ChunkLoopTrans
+from psyclone.psyir.transformations.loop_trans import LoopTrans
+from psyclone.psyir.transformations.region_trans import RegionTrans
+from psyclone.psyir.nodes import Loop, Schedule, \
+    OtterTraceSetupNode, OtterParallelNode, OtterTaskNode, \
+    OtterTaskSingleNode, OtterLoopNode, OtterLoopIterationNode, \
+    OtterSynchroniseChildrenNode, OtterSynchroniseDescendantTasksNode, \
+    OtterTraceNode
+
+class OtterTraceSetupTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = ("Adds a Otter Trace setup node to a region of code"
+                "to enable Otter instrumentation of PSyclone")
+        return rval
+
+    def validate(self, node_list, options=None):
+        return True
+
+    def apply(self, nodes, options=None):
+        '''TODO'''
+        node_list = self.get_node_list(nodes)
+        self.validate(node_list, options)
+
+        # Get useful references
+        parent = node_list[0].parent
+        position = node_list[0].position
+
+        otter_trace_node = OtterTraceSetupNode()
+        parent.children.insert(position, otter_trace_node)
+        for child in node_list:
+            child.detach()
+            otter_trace_node.children[0].addchild(child)
+
+
+class OtterParallelTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = "Adds a Otter Parallel node to a region of code"
+        return rval
+
+    def apply(self, nodes, options=None):
+        '''TODO'''
+        node_list = self.get_node_list(nodes)
+        self.validate(node_list, options)
+
+        # Get useful references
+        parent = node_list[0].parent
+        position = node_list[0].position
+
+        otter_parallel_node = OtterParallelNode()
+        parent.children.insert(position, otter_parallel_node)
+        for child in node_list:
+            child.detach()
+            otter_parallel_node.children[0].addchild(child)
+
+
+class OtterTaskloopTrans(LoopTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = "Adds a set of Otter Tasking nodes to a Loop"
+        return rval
+
+    def apply(self, node, options=None):
+        '''TODO'''
+        self.validate(node, options)
+
+        # Chunk the Loop
+        ctrans = ChunkLoopTrans()
+        ctrans.apply(node)
+
+        # Get the info about the loop and its position
+        parent = node.parent
+        position = node.position
+
+        task_node = OtterTaskNode()
+        parent.children.insert(position, task_node)
+        node.detach()
+        task_node.children[0].addchild(node)
+
+
+class OtterTaskSingleTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = "Adds a Otter TaskSingle node to a region of code"
+        return rval
+
+    def apply(self, nodes, options=None):
+        '''TODO'''
+        node_list = self.get_node_list(nodes)
+        self.validate(node_list, options)
+
+        # Get useful references
+        parent = node_list[0].parent
+        position = node_list[0].position
+
+        otter_tasksingle_node = OtterTaskSingleNode()
+        parent.children.insert(position, otter_tasksingle_node)
+        for child in node_list:
+            child.detach()
+            otter_tasksingle_node.children[0].addchild(child)
+
+class OtterLoopTrans(LoopTrans):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = "Adds an Otter Loop node to a Loop"
+
+    def apply(self, node, options=None):
+        '''
+        TODO
+        '''
+        self.validate(node, options)
+
+        parent = node.parent
+        position = node.position
+
+        otter_loop_node = OtterLoopNode()
+        parent.children.insert(position, otter_loop_node)
+        node.detach()
+        otter_loop_node.children[0].addchild(node)
+    
+        otter_loopit_node = OtterLoopIterationNode()
+        for child in node.children[3].children:
+            child.detach()
+            otter_loopit_node.children[0].addchild(child)
+        node.children[3].addchild(otter_loopit_node)
+
+class OtterSynchroniseChildrenTrans(Transformation):
+    '''
+    TODO
+    '''
+    def __str__(self):
+        rval = ("Adds an Otter Synchronise Children Transformation after the"
+                " supplied node.")
+        return rval
+
+    def apply(self, node, options=None):
+        '''
+        TODO
+        '''
+        self.validate(node, options)
+
+        parent = node.parent
+        position = node.position
+    
+        otter_sync_node = OtterSynchroniseChildrenNode()
+        parent.children.insert(position+1, otter_sync_node)
+
+class OtterSynchroniseDescendantsTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def ___str__(self):
+        rval = ("Adds an Otter Synchronise Descendents node around the"
+                " supplied nodes.")
+        return rval
+
+    def apply(self, nodes, options=None):
+        '''TODO'''
+        node_list = self.get_node_list(nodes)
+        self.validate(node_list, options)
+
+        parent = node_list[0].parent
+        position = node_list[0].position
+
+        otter_syncdecs_node = OtterSynchroniseDescendantTasksNode()
+        parent.children.insert(position, otter_syncdecs_node)
+        for child in node_list:
+            child.detach()
+            otter_syncdecs_node.children[0].addchild(child)
+
+
+class OtterTraceStartEndTrans(RegionTrans):
+    '''
+    TODO
+    '''
+    def __str(self):
+        rval = ("Adds an Otter Trace Start and End node around the supplied "
+                "nodes.")
+        return rval
+
+    def apply(self, nodes, options=None):
+        '''TODO'''
+        node_list = self.get_node_list(nodes)
+        self.validate(node_list, options)
+
+        parent = node_list[0].parent
+        position = node_list[0].position
+
+        otter_trace_node = OtterTraceNode()
+        parent.children.insert(position, otter_trace_node)
+        for child in node_list:
+            child.detach()
+            otter_trace_node.children[0].addchild(child)

--- a/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
+++ b/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
@@ -1,0 +1,308 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Science and Technology Facilities Council
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Author A. B. G. Chalk, STFC Daresbury Lab 
+
+''' Module containing the tests for OtterNodes. '''
+
+import pytest
+from psyclone.errors import InternalError, GenerationError
+from psyclone.f2pygen import ModuleGen
+from psyclone.psyir.nodes import PSyDataNode, Schedule, Return, Routine, \
+        Call
+from psyclone.psyir.nodes.statement import Statement
+from psyclone.psyir.nodes.otter_nodes import OtterTraceSetupNode, \
+        OtterParallelNode, OtterTaskNode, OtterTaskSingleNode, \
+        OtterLoopNode, OtterLoopIterationNode, OtterSynchroniseChildrenNode, \
+        OtterSynchroniseDescendantTasksNode, OtterTraceNode
+from psyclone.psyir.symbols import ContainerSymbol, ImportInterface, \
+    SymbolTable, DataTypeSymbol, DeferredType, DataSymbol, UnknownFortranType
+from psyclone.tests.utilities import get_invoke
+
+
+def test_ottertracesetup_lower_to_language():
+    ''' Test that the OtterTraceSetupNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterTraceSetupNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterTraceSetupNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterTraceSetupNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterTraceInitialise_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterTraceFinalise"
+    assert len(calls[1].children) == 0
+
+
+def test_otterparallelnode_lower_to_language():
+    ''' Test that the OtterParallelNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterParallelNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterParallelNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterParallelNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterParallelBegin_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterParallelEnd"
+    assert len(calls[1].children) == 0
+
+
+def test_ottertasknode_lower_to_language():
+    ''' Test that the OtterTaskNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterTaskNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterTaskNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterTaskNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterTaskBegin_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterTaskEnd"
+    assert len(calls[1].children) == 0
+
+
+def test_ottertasksinglenode_lower_to_language():
+    ''' Test that the OtterTaskSingleNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterTaskSingleNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterTaskSingleNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterTaskSingleNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterTaskSingleBegin_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterTaskSingleEnd"
+    assert len(calls[1].children) == 0
+
+
+def test_otterloopnode_lower_to_language():
+    ''' Test that the OtterLoopNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterLoopNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterLoopNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterLoopNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterLoopBegin_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterLoopEnd"
+    assert len(calls[1].children) == 0
+
+
+def test_otterloopiterationnode_lower_to_language():
+    ''' Test that the OtterLoopIterationNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterLoopIterationNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterLoopIterationNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterLoopIterationNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterLoopIterationBegin_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert calls[1].routine.name == "fortran_otterLoopIterationEnd"
+    assert len(calls[1].children) == 0
+
+
+def test_ottersyncorhonisechildrennode_lower_to_language():
+    ''' Test that the OtterSynchroniseChildrenNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterSynchroniseChildrenNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterSynchroniseChildrenNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterSynchroniseChildrenNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 1
+    assert calls[0].routine.name == "fortran_otterSynchroniseChildTasks_i"
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+
+def test_ottersyncorhonisedescendenttasksnode_lower_to_language():
+    ''' Test that the OtterSynchroniseDescendantTasksNode is lowered as 
+    expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterSynchroniseDescendantTasksNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterSynchroniseDescendantTasksNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterSynchroniseDescendantTasksNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert (calls[0].routine.name == 
+            "fortran_otterSynchroniseDescendantTasksBegin_i")
+    assert len(calls[0].children) == 3
+    assert calls[0].children[0].name == "__FILE__"
+    assert calls[0].children[1].value == "my_routine"
+    assert calls[0].children[2].name == "__LINE__"
+
+    assert (calls[1].routine.name == 
+            "fortran_otterSynchroniseDescendantTasksEnd")
+    assert len(calls[1].children) == 0
+
+
+def test_ottertracenode_lower_to_language():
+    ''' Test that the OtterTraceNode is lowered as expected. '''
+
+    # Try without an ancestor Routine
+    psy_node = OtterTraceNode()
+    with pytest.raises(GenerationError) as excinfo:
+        psy_node.lower_to_language_level()
+    assert ("An OtterNode must be inside a Routine context when"
+            " lowering but 'otterTraceNode[]' is not."
+            in str(excinfo.value))
+
+    # Add the ancestor Routine and empty body
+    routine = Routine("my_routine")
+    routine.addchild(psy_node)
+    psy_node.lower_to_language_level()
+
+    assert not routine.walk(OtterTraceNode)
+    calls = routine.walk(Call)
+    assert len(calls) == 2
+    assert calls[0].routine.name == "fortran_otterTraceStart"
+    assert len(calls[0].children) == 0
+
+    assert calls[1].routine.name == "fortran_otterTraceStop"
+    assert len(calls[1].children) == 0

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -62,6 +62,8 @@ def test_ottersetuptrace_trans_apply():
     tracetrans = OtterTraceSetupTrans()
     tracetrans.apply(schedule.children[:])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: fortran_otterTraceFinalise, "
+            "fortran_otterTraceInitialise_i" in code)
     assert ("CALL fortran_otterTraceInitialise_i(__FILE__, 'invoke_0_compute_cu'"
             ", __LINE__)" in code)
     assert "CALL fortran_otterTraceFinalise" in code
@@ -80,6 +82,8 @@ def test_otterparallel_trans_apply():
     paralleltrans = OtterParallelTrans()
     paralleltrans.apply(schedule.children[:])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: fortran_otterParallelBegin_i, "
+            "fortran_otterParallelEnd" in code)
     assert ("CALL fortran_otterParallelBegin_i(__FILE__, 'invoke_0_compute_cu'"
             ", __LINE__)" in code)
     assert "CALL fortran_otterParallelEnd" in code
@@ -98,6 +102,8 @@ def test_ottertaskloop_trans_apply():
     chunktrans = OtterTaskloopTrans()
     chunktrans.apply(schedule.children[0])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: fortran_otterTaskBegin_i, "
+            "fortran_otterTaskEnd" in code)
     correct = \
         '''DO j_out_var = cu_fld%internal%ystart, cu_fld%internal%ystop, 32
         j_el_inner = MIN(j_out_var + (32 - 1), cu_fld%internal%ystop)
@@ -125,6 +131,8 @@ def test_ottertasksingle_trans_apply():
     paralleltrans = OtterTaskSingleTrans()
     paralleltrans.apply(schedule.children[:])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: fortran_otterTaskSingleBegin_i, "
+            "fortran_otterTaskSingleEnd" in code)
     assert ("CALL fortran_otterTaskSingleBegin_i(__FILE__, 'invoke_0_compute_cu'"
             ", __LINE__)" in code)
     assert "CALL fortran_otterTaskSingleEnd" in code
@@ -143,6 +151,9 @@ def test_otterloop_trans_apply():
     looptrans = OtterLoopTrans()
     looptrans.apply(schedule.children[0])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: fortran_otterLoopBegin_i, "
+            "fortran_otterLoopEnd, fortran_otterLoopIterationBegin_i, "
+            "fortran_otterLoopIterationEnd" in code)
     correct = \
         '''CALL fortran_otterLoopBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
       DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
@@ -175,6 +186,8 @@ def test_ottersyncchild_trans_apply():
     code = str(psy.gen)
     correct = '''END DO
       CALL fortran_otterSynchroniseChildTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
+    assert ("USE otter_serial, ONLY: fortran_otterSynchroniseChildTasks_i"
+             in code)
     assert correct in code
 
 
@@ -193,6 +206,9 @@ def test_ottersyncdec_trans_apply():
     synctrans = OtterSynchroniseDescendantsTrans()
     synctrans.apply(schedule.children[0])
     code = str(psy.gen)
+    assert ("USE otter_serial, ONLY: "
+            "fortran_otterSynchroniseDescendantTasksBegin_i, "
+            "fortran_otterSynchroniseDescendantTasksEnd" in code)
     correct = \
         '''CALL fortran_otterSynchroniseDescendantTasksBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
       DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
@@ -219,6 +235,9 @@ def test_ottertracestartend_trans_apply():
     tracetrans = OtterTraceStartEndTrans()
     tracetrans.apply(schedule.children[0])
     code = str(psy.gen)
+    print(code)
+    assert ("USE otter_serial, ONLY: fortran_otterTraceStart, "
+            "fortran_otterTraceStop" in code)
     correct = \
         '''CALL fortran_otterTraceStart
       DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -1,0 +1,190 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors A. B. G. Chalk, STFC Daresbury Lab
+# -----------------------------------------------------------------------------
+
+import os
+import pytest
+
+from psyclone.parse.algorithm import parse
+from psyclone.psyGen import PSyFactory
+from psyclone.psyir.transformations import OtterParallelTrans, \
+        OtterTaskloopTrans, OtterTraceSetupTrans, OtterTaskSingleTrans, \
+        OtterLoopTrans, OtterSynchroniseChildrenTrans, \
+        OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans
+
+GOCEAN_BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                                os.pardir, os.pardir, "test_files",
+                                "gocean1p0")
+
+def test_ottertrace_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    tracetrans = OtterTraceSetupTrans()
+    tracetrans.apply(schedule.children[:])
+    code = str(psy.gen)
+    assert ("CALL fortran_otterTraceInitialise_i(__FILE__, 'invoke_0_compute_cu'"
+            ", __LINE__)" in code)
+    assert "CALL fortran_otterTraceFinalise" in code
+
+
+def test_otterparallel_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    paralleltrans = OtterParallelTrans()
+    paralleltrans.apply(schedule.children[:])
+    code = str(psy.gen)
+    assert ("CALL fortran_otterParallelBegin_i(__FILE__, 'invoke_0_compute_cu'"
+            ", __LINE__)" in code)
+    assert "CALL fortran_otterParallelEnd" in code
+
+def test_ottertaskloop_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    chunktrans = OtterTaskloopTrans()
+    chunktrans.apply(schedule.children[0])
+    code = str(psy.gen)
+    correct = \
+        '''DO j_out_var = cu_fld%internal%ystart, cu_fld%internal%ystop, 32
+        j_el_inner = MIN(j_out_var + (32 - 1), cu_fld%internal%ystop)
+        CALL fortran_otterTaskBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+        DO j = j_out_var, j_el_inner, 1
+          DO i = cu_fld%internal%xstart, cu_fld%internal%xstop, 1
+    '''
+    assert correct in code
+    correct = '''END DO
+        END DO
+        CALL fortran_otterTaskEnd
+      END DO'''
+    assert correct in code
+
+def test_ottertasksingle_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    paralleltrans = OtterTaskSingleTrans()
+    paralleltrans.apply(schedule.children[:])
+    code = str(psy.gen)
+    assert ("CALL fortran_otterTaskSingleBegin_i(__FILE__, 'invoke_0_compute_cu'"
+            ", __LINE__)" in code)
+    assert "CALL fortran_otterTaskSingleEnd" in code
+
+
+def test_otterloop_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    looptrans = OtterLoopTrans()
+    looptrans.apply(schedule.children[0])
+    code = str(psy.gen)
+    correct = \
+        '''CALL fortran_otterLoopBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+      DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
+        CALL fortran_otterLoopIterationBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+'''
+    assert correct in code
+
+    correct = \
+            '''END DO
+        CALL fortran_otterLoopIterationEnd
+      END DO
+      CALL fortran_otterLoopEnd'''
+    assert correct in code
+
+def test_ottersyncchild_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    synctrans = OtterSynchroniseChildrenTrans()
+    synctrans.apply(schedule.children[0])
+    code = str(psy.gen)
+    correct = '''END DO
+      CALL fortran_otterSynchroniseChildTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
+    assert correct in code
+
+
+def test_ottersyncdec_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    synctrans = OtterSynchroniseDescendantsTrans()
+    synctrans.apply(schedule.children[0])
+    code = str(psy.gen)
+    correct = \
+        '''CALL fortran_otterSynchroniseDescendantTasksBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+      DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
+'''
+    assert correct in code
+
+    correct = \
+            '''END DO
+      CALL fortran_otterSynchroniseDescendantTasksEnd'''
+    assert correct in code
+
+def test_ottertracestartend_trans_apply():
+    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).\
+        create(invoke_info)
+    schedule = psy.invokes.invoke_list[0].schedule
+    tracetrans = OtterTraceStartEndTrans()
+    tracetrans.apply(schedule.children[0])
+    code = str(psy.gen)
+    correct = \
+        '''CALL fortran_otterTraceStart
+      DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
+'''
+    assert correct in code
+
+    correct = \
+            '''END DO
+      CALL fortran_otterTraceStop'''
+    assert correct in code

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -48,7 +48,12 @@ GOCEAN_BASE_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
                                 os.pardir, os.pardir, "test_files",
                                 "gocean1p0")
 
-def test_ottertrace_trans_apply():
+def test_ottersetuptrace_trans_str():
+    tracetrans = OtterTraceSetupTrans()
+    assert (str(tracetrans) == "Adds a Otter Trace setup node to a region of "
+            "code to enable Otter instrumentation of PSyclone")
+
+def test_ottersetuptrace_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
                            api="gocean1.0")
     psy = PSyFactory("gocean1.0", distributed_memory=False).\
@@ -61,6 +66,10 @@ def test_ottertrace_trans_apply():
             ", __LINE__)" in code)
     assert "CALL fortran_otterTraceFinalise" in code
 
+def test_otterparallel_trans_str():
+    paralleltrans = OtterParallelTrans()
+    assert (str(paralleltrans) == "Adds a Otter Parallel node to a region of "
+            "code")
 
 def test_otterparallel_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
@@ -74,6 +83,11 @@ def test_otterparallel_trans_apply():
     assert ("CALL fortran_otterParallelBegin_i(__FILE__, 'invoke_0_compute_cu'"
             ", __LINE__)" in code)
     assert "CALL fortran_otterParallelEnd" in code
+
+def test_ottertaskloop_trans_str():
+    tlooptrans = OtterTaskloopTrans()
+    assert (str(tlooptrans) == "Adds a set of Otter Tasking nodes to a Loop "
+            "by chunking.")
 
 def test_ottertaskloop_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
@@ -98,6 +112,10 @@ def test_ottertaskloop_trans_apply():
       END DO'''
     assert correct in code
 
+def test_ottertasksingle_trans_str():
+    strans = OtterTaskSingleTrans()
+    assert (str(strans) == "Adds a Otter TaskSingle node to a region of code")
+
 def test_ottertasksingle_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
                            api="gocean1.0")
@@ -111,6 +129,10 @@ def test_ottertasksingle_trans_apply():
             ", __LINE__)" in code)
     assert "CALL fortran_otterTaskSingleEnd" in code
 
+
+def test_otterloop_trans_str():
+    looptrans = OtterLoopTrans()
+    assert (str(looptrans) == "Adds an Otter Loop node to a Loop")
 
 def test_otterloop_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
@@ -135,6 +157,13 @@ def test_otterloop_trans_apply():
       CALL fortran_otterLoopEnd'''
     assert correct in code
 
+
+def test_ottersyncchild_trans_str():
+    synctrans = OtterSynchroniseChildrenTrans()
+    assert (str(synctrans) == "Adds an Otter Synchronise Children "
+            "Transformation after the supplied node.")
+
+
 def test_ottersyncchild_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
                            api="gocean1.0")
@@ -147,6 +176,12 @@ def test_ottersyncchild_trans_apply():
     correct = '''END DO
       CALL fortran_otterSynchroniseChildTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
     assert correct in code
+
+
+def test_ottersyncdec_trans_str():
+    synctrans = OtterSynchroniseDescendantsTrans()
+    assert (str(synctrans) == "Adds an Otter Synchronise Descendents node "
+            "around the supplied nodes.")
 
 
 def test_ottersyncdec_trans_apply():
@@ -168,6 +203,12 @@ def test_ottersyncdec_trans_apply():
             '''END DO
       CALL fortran_otterSynchroniseDescendantTasksEnd'''
     assert correct in code
+
+
+def test_ottertracestratend_trans_str():
+    tracetrans = OtterTraceStartEndTrans()
+    assert (str(tracetrans) == "Adds an Otter Trace Start and End node around "
+            "the supplied nodes.")
 
 def test_ottertracestartend_trans_apply():
     _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),


### PR DESCRIPTION
This is the first commit towards the ability to use Otter.

So far I added the otter nodes & tests for them. At the moment they do no validation - its in theory tricky to do since they don't have to be in the same function call as the `OtterTraceSetupNode` - which in of itself is a bit tricky to have PSyclone apply as it probably should be done in the algorithm layer (@rupertford maybe we have to do this manually for now).

The other things that are needed are:

- [x] Otter Transformations to create the otter Nodes & corresponding tests. NB some transformations need to apply multiple, e.g. OtterTaskloopTrans needs to both chunk & then apply corresponding otter nodes insidee the chunked loop.
- [ ] Ensure `use otter_serial` is added to any place where an otter function is used.
- [ ] Node validation
- [ ] Documentation
- [ ] pylint & pycodestyle.
- [x] NemoLite2D implementation with them.
