### PR TITLE
Update fparser version to 0.0.15 in setup.py (for #1748)

### DIFF
--- a/changelog
+++ b/changelog
@@ -83,6 +83,9 @@
 
 	29) PR #1679. Add a limit parameter to the PSyIR node ancestor method.
 
+	30) PR #1749 for #1748. Updates version of fparser specified in setup.py
+	to 0.0.15.
+
 release 2.2.0 17th March 2022
 
 	1) PR #1439 for #1074. Adds a GOcean example for the use of the NaN-

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ if __name__ == '__main__':
         package_dir={"": "src"},
         # TODO #1193: Pinned jsonschema to support older versions of python
         # TODO #1507: remove dependence on 'six'
-        install_requires=['pyparsing', 'fparser==0.0.14', 'configparser',
+        install_requires=['pyparsing', 'fparser==0.0.15', 'configparser',
                           'six', 'jsonschema==3.0.2', 'sympy'],
         extras_require={
             'dag': ["graphviz"],


### PR DESCRIPTION
As outlined in #1748, when the PSyclone master was updated  to the latest fparser submodule (0.0.15 release) in  #1707, the `setup.py` eas omitted and it still points to fparser 0.0.14 as the prerequisite. When PSyclone and fparser are installed from a working copy of the master by using the fparser from the `external` submodules, fparser 0.0.15 is installed first and from the submodule and then fparser 0.0.14 from the PSyclone's `setup.py`.

I updated the fparser version to 0.0.15 in `setup.py`. I installed PSyclone locally from this branch and can confirm that only fparser 0.0.15 is now installed.