### PR TITLE
Don't use python 3.10.0 specifically, we should roll with minor version updates

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -94,7 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.8, 3.10.0]
+        python-version: [3.6, 3.8, 3.10]
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
From dicussion on teams, PR is mostly to check it installs as we expect.