### PR TITLE
[Otter] Update interface with Otter to reflect upstream changes

### DIFF
--- a/src/psyclone/psyir/nodes/__init__.py
+++ b/src/psyclone/psyir/nodes/__init__.py
@@ -88,7 +88,7 @@ from psyclone.psyir.nodes.clause import Clause
 from psyclone.psyir.nodes.omp_clauses import OMPGrainsizeClause, \
     OMPNogroupClause, OMPNowaitClause, OMPNumTasksClause
 from psyclone.psyir.nodes.otter_nodes import OtterTraceSetupNode, \
-        OtterParallelNode, OtterTaskNode, OtterTaskSingleNode, \
+        OtterParallelNode, OtterTaskNode, \
         OtterLoopNode, OtterLoopIterationNode, OtterSynchroniseChildrenNode, \
         OtterSynchroniseDescendantTasksNode, OtterTraceNode, OtterNode
 
@@ -172,7 +172,6 @@ __all__ = [
         'OtterTraceSetupNode',
         'OtterParallelNode',
         'OtterTaskNode',
-        'OtterTaskSingleNode',
         'OtterLoopNode',
         'OtterLoopIterationNode',
         'OtterSynchroniseChildrenNode',

--- a/src/psyclone/psyir/nodes/otter_nodes.py
+++ b/src/psyclone/psyir/nodes/otter_nodes.py
@@ -197,18 +197,6 @@ class OtterTaskNode(OtterNode):
     _end_subroutine_call = "fortran_otterTaskEnd"
 
 
-class OtterTaskSingleNode(OtterNode):
-    '''
-    Node to represent OtterTaskSingleBegin and OtterTaskSingleEnd calls.
-    '''
-    _children_valid_format = "Schedule"
-    _text_name = "otterTaskSingleNode"
-    _colour = "green"
-
-    _start_subroutine_call = "fortran_otterTaskSingleBegin_i"
-    _end_subroutine_call = "fortran_otterTaskSingleEnd"
-
-
 class OtterLoopNode(OtterNode):
     '''
     Node to represent OtterLoopBegin and OtterLoopEnd calls.

--- a/src/psyclone/psyir/nodes/otter_nodes.py
+++ b/src/psyclone/psyir/nodes/otter_nodes.py
@@ -181,8 +181,8 @@ class OtterParallelNode(OtterNode):
     _text_name = "otterParallelNode"
     _colour = "green"
 
-    _start_subroutine_call = "fortran_otterParallelBegin_i"
-    _end_subroutine_call = "fortran_otterParallelEnd"
+    _start_subroutine_call = "fortran_otterThreadsBegin_i"
+    _end_subroutine_call = "fortran_otterThreadsEnd"
 
 
 class OtterTaskNode(OtterNode):
@@ -242,7 +242,7 @@ class OtterSynchroniseChildrenNode(OtterNode):
     _text_name = "otterSynchroniseChildrenNode"
     _colour = "green"
 
-    _start_subroutine_call = "fortran_otterSynchroniseChildTasks_i"
+    _start_subroutine_call = "fortran_otterSynchroniseTasks_i"
 
 
 class OtterSynchroniseDescendantTasksNode(OtterNode):

--- a/src/psyclone/psyir/transformations/__init__.py
+++ b/src/psyclone/psyir/transformations/__init__.py
@@ -69,7 +69,7 @@ from psyclone.psyir.transformations.loop_trans import LoopTrans
 from psyclone.psyir.transformations.nan_test_trans import NanTestTrans
 from psyclone.psyir.transformations.omp_taskwait_trans import OMPTaskwaitTrans
 from psyclone.psyir.transformations.otter_trans import OtterTraceSetupTrans, \
-        OtterParallelTrans, OtterTaskloopTrans, OtterTaskSingleTrans, \
+        OtterParallelTrans, OtterTaskloopTrans, \
         OtterLoopTrans, OtterSynchroniseChildrenTrans, \
         OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans, \
         OtterSynchroniseRegionTrans
@@ -106,7 +106,6 @@ __all__ = ['ArrayRange2LoopTrans',
            'OtterTraceSetupTrans'
            'OtterParallelTrans',
            'OtterTaskloopTrans',
-           'OtterTaskSingleTrans',
            'OtterLoopTrans',
            'OtterSynchroniseChildrenTrans',
            'OtterSynchroniseRegionTrans',

--- a/src/psyclone/psyir/transformations/otter_trans.py
+++ b/src/psyclone/psyir/transformations/otter_trans.py
@@ -46,7 +46,7 @@ from psyclone.psyir.transformations.region_trans import RegionTrans
 from psyclone.psyir import nodes
 from psyclone.psyir.nodes import Loop, Schedule, Reference, \
     OtterTraceSetupNode, OtterParallelNode, OtterTaskNode, \
-    OtterTaskSingleNode, OtterLoopNode, OtterLoopIterationNode, \
+    OtterLoopNode, OtterLoopIterationNode, \
     OtterSynchroniseChildrenNode, OtterSynchroniseDescendantTasksNode, \
     OtterTraceNode, Assignment
 from psyclone.psyir.transformations.transformation_error import \
@@ -128,30 +128,6 @@ class OtterTaskloopTrans(LoopTrans):
         parent.children.insert(position, task_node)
         node.detach()
         task_node.children[0].addchild(node)
-
-
-class OtterTaskSingleTrans(RegionTrans):
-    '''
-    TODO
-    '''
-    def __str__(self):
-        rval = "Adds a Otter TaskSingle node to a region of code"
-        return rval
-
-    def apply(self, nodes, options=None):
-        '''TODO'''
-        node_list = self.get_node_list(nodes)
-        self.validate(node_list, options)
-
-        # Get useful references
-        parent = node_list[0].parent
-        position = node_list[0].position
-
-        otter_tasksingle_node = OtterTaskSingleNode()
-        parent.children.insert(position, otter_tasksingle_node)
-        for child in node_list:
-            child.detach()
-            otter_tasksingle_node.children[0].addchild(child)
 
 class OtterLoopTrans(LoopTrans):
     '''

--- a/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
+++ b/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
@@ -98,13 +98,13 @@ def test_otterparallelnode_lower_to_language():
     assert not routine.walk(OtterParallelNode)
     calls = routine.walk(Call)
     assert len(calls) == 2
-    assert calls[0].routine.name == "fortran_otterParallelBegin_i"
+    assert calls[0].routine.name == "fortran_otterThreadsBegin_i"
     assert len(calls[0].children) == 3
     assert calls[0].children[0].name == "__FILE__"
     assert calls[0].children[1].value == "my_routine"
     assert calls[0].children[2].name == "__LINE__"
 
-    assert calls[1].routine.name == "fortran_otterParallelEnd"
+    assert calls[1].routine.name == "fortran_otterThreadsEnd"
     assert len(calls[1].children) == 0
 
 
@@ -243,7 +243,7 @@ def test_ottersyncorhonisechildrennode_lower_to_language():
     assert not routine.walk(OtterSynchroniseChildrenNode)
     calls = routine.walk(Call)
     assert len(calls) == 1
-    assert calls[0].routine.name == "fortran_otterSynchroniseChildTasks_i"
+    assert calls[0].routine.name == "fortran_otterSynchroniseTasks_i"
     assert len(calls[0].children) == 3
     assert calls[0].children[0].name == "__FILE__"
     assert calls[0].children[1].value == "my_routine"

--- a/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
+++ b/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
@@ -186,10 +186,7 @@ def test_otterloopnode_lower_to_language():
     calls = routine.walk(Call)
     assert len(calls) == 2
     assert calls[0].routine.name == "fortran_otterLoopBegin_i"
-    assert len(calls[0].children) == 3
-    assert calls[0].children[0].name == "__FILE__"
-    assert calls[0].children[1].value == "my_routine"
-    assert calls[0].children[2].name == "__LINE__"
+    assert len(calls[0].children) == 0
 
     assert calls[1].routine.name == "fortran_otterLoopEnd"
     assert len(calls[1].children) == 0
@@ -215,10 +212,7 @@ def test_otterloopiterationnode_lower_to_language():
     calls = routine.walk(Call)
     assert len(calls) == 2
     assert calls[0].routine.name == "fortran_otterLoopIterationBegin_i"
-    assert len(calls[0].children) == 3
-    assert calls[0].children[0].name == "__FILE__"
-    assert calls[0].children[1].value == "my_routine"
-    assert calls[0].children[2].name == "__LINE__"
+    assert len(calls[0].children) == 0
 
     assert calls[1].routine.name == "fortran_otterLoopIterationEnd"
     assert len(calls[1].children) == 0
@@ -270,10 +264,7 @@ def test_ottersyncorhonisedescendenttasksnode_lower_to_language():
     assert len(calls) == 2
     assert (calls[0].routine.name == 
             "fortran_otterSynchroniseDescendantTasksBegin_i")
-    assert len(calls[0].children) == 3
-    assert calls[0].children[0].name == "__FILE__"
-    assert calls[0].children[1].value == "my_routine"
-    assert calls[0].children[2].name == "__LINE__"
+    assert len(calls[0].children) == 0
 
     assert (calls[1].routine.name == 
             "fortran_otterSynchroniseDescendantTasksEnd")

--- a/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
+++ b/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
@@ -42,7 +42,7 @@ from psyclone.psyir.nodes import PSyDataNode, Schedule, Return, Routine, \
         Call
 from psyclone.psyir.nodes.statement import Statement
 from psyclone.psyir.nodes.otter_nodes import OtterTraceSetupNode, \
-        OtterParallelNode, OtterTaskNode, OtterTaskSingleNode, \
+        OtterParallelNode, OtterTaskNode, \
         OtterLoopNode, OtterLoopIterationNode, OtterSynchroniseChildrenNode, \
         OtterSynchroniseDescendantTasksNode, OtterTraceNode
 from psyclone.psyir.symbols import ContainerSymbol, ImportInterface, \
@@ -134,35 +134,6 @@ def test_ottertasknode_lower_to_language():
     assert calls[0].children[2].name == "__LINE__"
 
     assert calls[1].routine.name == "fortran_otterTaskEnd"
-    assert len(calls[1].children) == 0
-
-
-def test_ottertasksinglenode_lower_to_language():
-    ''' Test that the OtterTaskSingleNode is lowered as expected. '''
-
-    # Try without an ancestor Routine
-    psy_node = OtterTaskSingleNode()
-    with pytest.raises(GenerationError) as excinfo:
-        psy_node.lower_to_language_level()
-    assert ("An OtterNode must be inside a Routine context when"
-            " lowering but 'otterTaskSingleNode[]' is not."
-            in str(excinfo.value))
-
-    # Add the ancestor Routine and empty body
-    routine = Routine("my_routine")
-    routine.addchild(psy_node)
-    psy_node.lower_to_language_level()
-
-    assert not routine.walk(OtterTaskSingleNode)
-    calls = routine.walk(Call)
-    assert len(calls) == 2
-    assert calls[0].routine.name == "fortran_otterTaskSingleBegin_i"
-    assert len(calls[0].children) == 3
-    assert calls[0].children[0].name == "__FILE__"
-    assert calls[0].children[1].value == "my_routine"
-    assert calls[0].children[2].name == "__LINE__"
-
-    assert calls[1].routine.name == "fortran_otterTaskSingleEnd"
     assert len(calls[1].children) == 0
 
 

--- a/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
+++ b/src/psyclone/tests/psyir/nodes/otter_nodes_test.py
@@ -244,10 +244,8 @@ def test_ottersyncorhonisechildrennode_lower_to_language():
     calls = routine.walk(Call)
     assert len(calls) == 1
     assert calls[0].routine.name == "fortran_otterSynchroniseTasks_i"
-    assert len(calls[0].children) == 3
-    assert calls[0].children[0].name == "__FILE__"
-    assert calls[0].children[1].value == "my_routine"
-    assert calls[0].children[2].name == "__LINE__"
+    assert len(calls[0].children) == 1
+    assert calls[0].children[0].value == "0"
 
 
 def test_ottersyncorhonisedescendenttasksnode_lower_to_language():

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -40,7 +40,7 @@ import pytest
 from psyclone.parse.algorithm import parse
 from psyclone.psyGen import PSyFactory
 from psyclone.psyir.transformations import OtterParallelTrans, \
-        OtterTaskloopTrans, OtterTraceSetupTrans, OtterTaskSingleTrans, \
+        OtterTaskloopTrans, OtterTraceSetupTrans, \
         OtterLoopTrans, OtterSynchroniseChildrenTrans, \
         OtterSynchroniseDescendantsTrans, OtterTraceStartEndTrans
 
@@ -117,25 +117,6 @@ def test_ottertaskloop_trans_apply():
         CALL fortran_otterTaskEnd
       END DO'''
     assert correct in code
-
-def test_ottertasksingle_trans_str():
-    strans = OtterTaskSingleTrans()
-    assert (str(strans) == "Adds a Otter TaskSingle node to a region of code")
-
-def test_ottertasksingle_trans_apply():
-    _, invoke_info = parse(os.path.join(GOCEAN_BASE_PATH, "single_invoke.f90"),
-                           api="gocean1.0")
-    psy = PSyFactory("gocean1.0", distributed_memory=False).\
-        create(invoke_info)
-    schedule = psy.invokes.invoke_list[0].schedule
-    paralleltrans = OtterTaskSingleTrans()
-    paralleltrans.apply(schedule.children[:])
-    code = str(psy.gen)
-    assert ("USE otter_serial, ONLY: fortran_otterTaskSingleBegin_i, "
-            "fortran_otterTaskSingleEnd" in code)
-    assert ("CALL fortran_otterTaskSingleBegin_i(__FILE__, 'invoke_0_compute_cu'"
-            ", __LINE__)" in code)
-    assert "CALL fortran_otterTaskSingleEnd" in code
 
 
 def test_otterloop_trans_str():

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -82,11 +82,11 @@ def test_otterparallel_trans_apply():
     paralleltrans = OtterParallelTrans()
     paralleltrans.apply(schedule.children[:])
     code = str(psy.gen)
-    assert ("USE otter_serial, ONLY: fortran_otterParallelBegin_i, "
-            "fortran_otterParallelEnd" in code)
-    assert ("CALL fortran_otterParallelBegin_i(__FILE__, 'invoke_0_compute_cu'"
+    assert ("USE otter_serial, ONLY: fortran_otterThreadsBegin_i, "
+            "fortran_otterThreadsEnd" in code)
+    assert ("CALL fortran_otterThreadsBegin_i(__FILE__, 'invoke_0_compute_cu'"
             ", __LINE__)" in code)
-    assert "CALL fortran_otterParallelEnd" in code
+    assert "CALL fortran_otterThreadsEnd" in code
 
 def test_ottertaskloop_trans_str():
     tlooptrans = OtterTaskloopTrans()
@@ -185,8 +185,8 @@ def test_ottersyncchild_trans_apply():
     synctrans.apply(schedule.children[0])
     code = str(psy.gen)
     correct = '''END DO
-      CALL fortran_otterSynchroniseChildTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
-    assert ("USE otter_serial, ONLY: fortran_otterSynchroniseChildTasks_i"
+      CALL fortran_otterSynchroniseTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
+    assert ("USE otter_serial, ONLY: fortran_otterSynchroniseTasks_i"
              in code)
     assert correct in code
 

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -155,9 +155,9 @@ def test_otterloop_trans_apply():
             "fortran_otterLoopEnd, fortran_otterLoopIterationBegin_i, "
             "fortran_otterLoopIterationEnd" in code)
     correct = \
-        '''CALL fortran_otterLoopBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+        '''CALL fortran_otterLoopBegin_i()
       DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
-        CALL fortran_otterLoopIterationBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+        CALL fortran_otterLoopIterationBegin_i()
 '''
     assert correct in code
 
@@ -210,7 +210,7 @@ def test_ottersyncdec_trans_apply():
             "fortran_otterSynchroniseDescendantTasksBegin_i, "
             "fortran_otterSynchroniseDescendantTasksEnd" in code)
     correct = \
-        '''CALL fortran_otterSynchroniseDescendantTasksBegin_i(__FILE__, 'invoke_0_compute_cu', __LINE__)
+        '''CALL fortran_otterSynchroniseDescendantTasksBegin_i()
       DO j = cu_fld%internal%ystart, cu_fld%internal%ystop, 1
 '''
     assert correct in code

--- a/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/otter_transformations_test.py
@@ -185,7 +185,7 @@ def test_ottersyncchild_trans_apply():
     synctrans.apply(schedule.children[0])
     code = str(psy.gen)
     correct = '''END DO
-      CALL fortran_otterSynchroniseTasks_i(__FILE__, 'invoke_0_compute_cu', __LINE__)'''
+      CALL fortran_otterSynchroniseTasks_i(0)'''
     assert ("USE otter_serial, ONLY: fortran_otterSynchroniseTasks_i"
              in code)
     assert correct in code


### PR DESCRIPTION
This PR is for review by @LonelyCat124 

This PR updates the interface to Otter to reflect the latest changes to Otter in [v0.2.0](https://github.com/Otter-Taskification/otter/tree/v0.2.0). These changes include:

- Renaming several Otter API entrypoints,
- Changing the arguments passed to several entrypoints,
- Removing the `otterTaskSingle[Begin|End]` entrypoint which no longer exists.