### PR TITLE
PSyAD refactoring to specialise Adj generation for API

### DIFF
--- a/src/psyclone/psyad/domain/common/adjoint_utils.py
+++ b/src/psyclone/psyad/domain/common/adjoint_utils.py
@@ -1,0 +1,107 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2022, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors R. W. Ford and A. R. Porter, STFC Daresbury Lab
+
+''' Provides various utilities in support of the PSyAD adjoint
+    functionality. '''
+
+from psyclone.errors import InternalError
+from psyclone.psyir.nodes import Container, FileContainer
+
+#: The prefix we will prepend to a routine, container and metadata
+#: names when generating the adjoint. If the original name contains
+#: the tl prefix, then this is removed.
+ADJOINT_NAME_PREFIX = "adj_"
+TL_NAME_PREFIX = "tl_"
+
+
+def create_adjoint_name(tl_name):
+    '''Create an adjoint name from the supplied tangent linear name. This
+    is done by stripping the TL_NAME_PREFIX from the name if it exists
+    and then adding the ADJOINT_NAME_PREFIX. The adjoint name is also
+    lower-cased.
+
+    :param str: the tangent-linear name.
+
+    :returns: the adjoint name.
+    :rtype: str
+
+    '''
+    adj_name = tl_name.lower()
+    if adj_name.startswith(TL_NAME_PREFIX):
+        adj_name = adj_name[len(TL_NAME_PREFIX):]
+    return ADJOINT_NAME_PREFIX + adj_name
+
+
+def find_container(psyir):
+    ''' Finds the first Container in the supplied PSyIR that is not a
+    FileContainer. Also validates that the PSyIR contains at most one
+    FileContainer which, if present, contains a Container.
+
+    :returns: the first Container that is not a FileContainer or None if \
+              there is none.
+    :rtype: :py:class:`psyclone.psyir.nodes.Container` or NoneType
+
+    :raises InternalError: if there are two Containers and the second is a \
+                           FileContainer.
+    :raises NotImplementedError: if there are two Containers and the first is \
+                                 not a FileContainer.
+    :raises NotImplementedError: if there are more than two Containers.
+
+    '''
+    containers = psyir.walk(Container)
+    if not containers:
+        return None
+
+    if len(containers) == 1:
+        if isinstance(containers[0], FileContainer):
+            return None
+        return containers[0]
+
+    if len(containers) == 2:
+        if isinstance(containers[1], FileContainer):
+            raise InternalError(
+                "The supplied PSyIR contains two Containers but the innermost "
+                "is a FileContainer. This should not be possible.")
+        if not isinstance(containers[0], FileContainer):
+            raise NotImplementedError(
+                "The supplied PSyIR contains two Containers and the outermost "
+                "one is not a FileContainer. This is not supported.")
+        return containers[1]
+
+    raise NotImplementedError("The supplied PSyIR contains more than two "
+                              "Containers. This is not supported.")
+
+
+__all__ = ["create_adjoint_name", "find_container"]

--- a/src/psyclone/psyad/domain/lfric/tl2ad.py
+++ b/src/psyclone/psyad/domain/lfric/tl2ad.py
@@ -1,0 +1,100 @@
+import logging
+
+from psyclone.psyad import AdjointVisitor
+from psyclone.psyad.domain.common import create_adjoint_name, find_container
+from psyclone.errors import InternalError
+from psyclone.psyir.nodes import Routine
+from psyclone.psyir.symbols import RoutineSymbol
+
+
+def generate_lfric_adjoint(tl_psyir, active_variables):
+    '''Takes an LFRic tangent-linear kernel represented in language-level PSyIR
+    and returns its adjoint represented in language-level PSyIR.
+
+    Currently just takes a copy of the supplied PSyIR and re-names the
+    Container (if there is one) and Routine nodes.
+
+    :param tl_psyir: language-level PSyIR containing the LFRic \
+        tangent-linear kernel.
+    :type tl_psyir: :py:class:`psyclone.psyir.Node`
+    :param list of str active_variables: list of active variable names.
+
+    :returns: language-level PSyIR containing the adjoint of the \
+        supplied tangent-linear kernel.
+    :rtype: :py:class:`psyclone.psyir.Node`
+
+    :raises InternalError: if the PSyIR does not contain any Routines.
+    :raises NotImplementedError: if the PSyIR contains >1 Routine.
+
+    '''
+    logger = logging.getLogger(__name__)
+
+    # Translate from TL to AD
+    logger.debug("Translating from TL to AD.")
+    adjoint_visitor = AdjointVisitor(active_variables)
+    ad_psyir = adjoint_visitor(tl_psyir)
+
+    # We permit the input code to be a single Program or Subroutine
+    container = find_container(ad_psyir)
+    if container:
+        # Re-name the Container for the adjoint code. Use the symbol table
+        # for the existing TL code so that we don't accidentally clash with
+        # e.g. the name of the kernel routine.
+        container.name = container.symbol_table.next_available_name(
+            create_adjoint_name(container.name))
+
+    routines = ad_psyir.walk(Routine)
+
+    if not routines:
+        raise InternalError("The supplied PSyIR does not contain any "
+                            "routines.")
+
+    # TODO issue #1782 if this is an LFRic-specific implementation and
+    # the metadata code points to an interface then adjoint all
+    # routines specified in the interface. If it points to a routine
+    # then only translate that routine. If this is a generic
+    # implementation then only support one routine as we don't know
+    # which one to support.
+
+    # TODO issue #1800 if there are multiple
+    # modules/subroutines/program implementations in the file then
+    # raise an exception unless a particular name is specified (by
+    # e.g. command line -kernel_name=xyz. The name can be for a routine
+    # or an interface.)
+
+    # Until we know whether this is meant to be a generic or
+    # LFRic-specific kernel (issue #1782) and, for LFRic, can specify
+    # the particular kernel metadata if multiple versions exist and
+    # then read kernel metadata to determine whether it points to a
+    # kernel or interface (issue #1807), we simply assume that we
+    # should allow multiple routines as they imply an interface. We
+    # further assume that the implementation of the routines in the
+    # interface use the same variable names which allows us to
+    # continue to use a single command line list of active
+    # variables. This is the case for the implementations we care
+    # about but in general may not be the case. Issue #1595 should
+    # help fix this problem as it would only be arguments that would
+    # need to have the same names.
+
+    for routine in routines:
+
+        # We need to re-name the kernel routines. We have to take care
+        # in case we've been supplied with a bare program/subroutine
+        # rather than one or more subroutines within a module (which
+        # we will get with LFRic mixed precision kernels).
+        if container:
+            kernel_sym = container.symbol_table.lookup(routine.name)
+            adj_kernel_name = _create_adjoint_name(routine.name)
+            # A symbol's name is immutable so create a new RoutineSymbol
+            adj_kernel_sym = container.symbol_table.new_symbol(
+                adj_kernel_name, symbol_type=RoutineSymbol,
+                visibility=kernel_sym.visibility)
+            container.symbol_table.remove(kernel_sym)
+            routine.name = adj_kernel_sym.name
+        else:
+            routine.name = routine.symbol_table.next_available_name(
+                _create_adjoint_name(routine.name))
+
+        logger.debug("AD kernel will be named '%s'", routine.name)
+
+    return ad_psyir

--- a/src/psyclone/psyad/main.py
+++ b/src/psyclone/psyad/main.py
@@ -1,7 +1,7 @@
 # -----------------------------------------------------------------------------
 # BSD 3-Clause License
 #
-# Copyright (c) 2021-2022, Science and Technology Facilities Council.
+# Copyright (c) 2021, Science and Technology Facilities Council.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
@@ -42,6 +42,9 @@ import argparse
 import logging
 import sys
 
+import six
+
+from psyclone.generator import write_unicode_file
 from psyclone.psyad.tl2ad import generate_adjoint_str
 from psyclone.psyad.transformations import TangentLinearError
 
@@ -62,11 +65,12 @@ def main(args):
     # reflect this workaround.
     def msg():
         '''Function to overide the argpass usage message'''
-        return ("psyad [-h] [-oad OAD] [-v] [-t] [-otest TEST_FILENAME] "
+        return ("psyad [-h] [-oad OAD] [-v] [-t] [-api API] "
+                "[-otest TEST_FILENAME] "
                 "-a ACTIVE [ACTIVE ...] -- filename")
 
     parser = argparse.ArgumentParser(
-        description="Run the PSyclone adjoint code generator on an LFRic "
+        description="Run the PSyclone adjoint code generator on a "
         "tangent-linear kernel file", usage=msg())
     parser.add_argument(
         '-a', '--active', nargs='+', help='names of active variables',
@@ -78,11 +82,14 @@ def main(args):
         '-t', '--gen-test',
         help='generate a standalone unit test for the adjoint code',
         action='store_true')
+    parser.add_argument('-api', default=None,
+                        help='the PSyclone API that the TL kernel conforms '
+                        'to (if any)')
     parser.add_argument('-otest',
                         help='filename for the unit test (implies -t)',
                         dest='test_filename')
     parser.add_argument('-oad', help='filename for the transformed code')
-    parser.add_argument('filename', help='LFRic tangent-linear kernel source')
+    parser.add_argument('filename', help='tangent-linear kernel source')
 
     args = parser.parse_args(args)
 
@@ -97,8 +104,9 @@ def main(args):
     filename = args.filename
     logger.info("Reading kernel file %s", filename)
     try:
-        with open(filename, mode='r', encoding='utf8') as my_file:
+        with open(filename) as my_file:
             tl_fortran_str = my_file.read()
+            tl_fortran_str = six.text_type(tl_fortran_str)
     except FileNotFoundError:
         logger.error("psyad error: file '%s', not found.", filename)
         sys.exit(1)
@@ -106,7 +114,8 @@ def main(args):
     try:
         # Create the adjoint (and associated test framework if requested)
         ad_fortran_str, test_fortran_str = generate_adjoint_str(
-            tl_fortran_str, args.active, create_test=generate_test)
+            tl_fortran_str, args.active, api=args.api,
+            create_test=generate_test)
     except TangentLinearError as info:
         print(str(info.value))
         sys.exit(1)
@@ -117,8 +126,7 @@ def main(args):
     # Output the Fortran code for the adjoint kernel
     if args.oad:
         logger.info("Writing adjoint of kernel to file %s", args.oad)
-        with open(args.oad, mode='w', encoding='utf8') as adjoint_file:
-            adjoint_file.write(ad_fortran_str)
+        write_unicode_file(ad_fortran_str, args.oad)
     else:
         print(ad_fortran_str, file=sys.stdout)
 
@@ -127,9 +135,7 @@ def main(args):
         if args.test_filename:
             logger.info("Writing test harness for adjoint kernel to file %s",
                         args.test_filename)
-            with open(args.test_filename, mode='w',
-                      encoding='utf8') as harness_file:
-                harness_file.write(test_fortran_str)
+            write_unicode_file(test_fortran_str, args.test_filename)
         else:
             print(test_fortran_str, file=sys.stdout)
 


### PR DESCRIPTION
Broken out of #1782 to simplify things. Adds an `-api` flag to the `psyad` command-line and uses this to specialise the adjoint generation.