### PR TITLE
1840 fix da crash array without indices

### DIFF
--- a/changelog
+++ b/changelog
@@ -50,7 +50,7 @@
 	19) PR #1809. A few fixes for code style issues.
 
 	20) PR #1803 for #1797. Adds support for logical variables to the
- 	PSyData	API.
+	PSyData API.
 
 	21) PR #1804 for #637. Extends the dependence analysis to support
 	LFRic built-in kernels.
@@ -89,7 +89,10 @@
 	CodeBlock nodes.
 
 	33) PR #1830 for #1828. Fixes to enable explicit OpenACC Loop
-	parallelism with UM
+	parallelism with UM.
+
+	34) PR #1855 for #1840. Fix bug with dependency analysis when an
+	expression has the same array reference with and without indices.
 
 release 2.3.1 17th of June 2022
 

--- a/src/psyclone/psyir/tools/dependency_tools.py
+++ b/src/psyclone/psyir/tools/dependency_tools.py
@@ -280,7 +280,14 @@ class DependencyTools():
         #          [ ({"i"}, [(0,0)]), ({"j","k"}, [(0,1)])]
         partition_infos = []
         for i, indx in enumerate(comp_ind1.iterate()):
-            partition_infos.append((indices_1[i].union(indices_2[i]), [indx]))
+            # This can happen if there is a mixture of accesses to an array
+            # with and without indices, e.g.: a(i) = a*a
+            # In this case we don't add this to the partition, which will
+            # result in an empty partition (which in turns will disable
+            # parallelisation).
+            if i < len(indices_2):
+                partition_infos.append((indices_1[i].union(indices_2[i]),
+                                        [indx]))
 
         # Check each loop variable to find subscripts in which they are used:
         for loop_var in loop_variables:

--- a/src/psyclone/tests/psyir/tools/dependency_tools_test.py
+++ b/src/psyclone/tests/psyir/tools/dependency_tools_test.py
@@ -736,7 +736,7 @@ def test_da_array_expression(fortran_reader):
     '''
     source = '''program test
                 integer :: ji, jj, jpi, jpj
-                real :: a(5,5), c(5,5), b
+                real :: a(5,5)
                 do jj = 1, jpj   ! loop 0
                    do ji = 1, jpi
                       a(ji, jj) = a*a

--- a/src/psyclone/tests/psyir/tools/dependency_tools_test.py
+++ b/src/psyclone/tests/psyir/tools/dependency_tools_test.py
@@ -727,3 +727,25 @@ def test_const_argument():
     # Make sure the constant '0' is not listed
     assert "0" not in input_list
     assert Signature("0") not in input_list
+
+
+# -----------------------------------------------------------------------------
+def test_da_array_expression(fortran_reader):
+    '''Test that a mixture of using the same array with and without indices
+    does not cause a crash and correctly disables parallelisation.
+    '''
+    source = '''program test
+                integer :: ji, jj, jpi, jpj
+                real :: a(5,5), c(5,5), b
+                do jj = 1, jpj   ! loop 0
+                   do ji = 1, jpi
+                      a(ji, jj) = a*a
+                    end do
+                end do
+                end program test'''
+    psyir = fortran_reader.psyir_from_source(source)
+    loops = psyir.children[0].children
+
+    dep_tools = DependencyTools()
+    result = dep_tools.can_loop_be_parallelised(loops[0])
+    assert result is False


### PR DESCRIPTION
While the original crash reported in #1840 is caused by reporting a read access for `x` in `size(X...`, which will be fixed in #1750 , there are still mixed expressions (arrays with and without index used: `a(i) = max(a)`) that would trigger a crash.
This small PR fixes the crash and will not allow parallelisation in this case.