### PR TITLE
1861 improve test coverage

### DIFF
--- a/src/psyclone/tests/conftest.py
+++ b/src/psyclone/tests/conftest.py
@@ -153,11 +153,13 @@ def infra_compile(tmpdir_factory, request):
 
     # Create a shared temporary directory to store the compiled files.
     shared_tmp_dir = Path(tmpdir_factory.getbasetemp())
+    num_processes = 1
     if os.environ.get('PYTEST_XDIST_TESTRUNUID') is not None:
         # We run in parallel, so we get a process-specific temporary
         # directory (e.g. pytest-58/popen-gw0). Use the parent directory
         # as base for any shared files/directories in this casse:
         shared_tmp_dir = shared_tmp_dir.parent
+        num_processes = int(os.environ.get('PYTEST_XDIST_WORKER_COUNT'))
 
     dynamo_shared_tmp_dir = shared_tmp_dir / "dynamo"
     dynamo_shared_lock = shared_tmp_dir / "dynamo.lock"
@@ -166,7 +168,7 @@ def infra_compile(tmpdir_factory, request):
             dynamo_shared_tmp_dir.mkdir()
             # This is the first instance created. This will trigger
             # compilation of the infrastructure files.
-            LFRicBuild(dynamo_shared_tmp_dir)
+            LFRicBuild(dynamo_shared_tmp_dir, num_processes=num_processes)
 
     gocean_shared_tmp_dir = shared_tmp_dir / "dl_esm_inf"
     gocean_shared_lock = shared_tmp_dir / "dl_esm_inf.lock"

--- a/src/psyclone/tests/gocean_build.py
+++ b/src/psyclone/tests/gocean_build.py
@@ -43,7 +43,7 @@ import os
 import subprocess
 import sys
 
-from psyclone.tests.utilities import Compile, CompileError
+from psyclone.tests.utilities import change_dir, Compile, CompileError
 
 
 class GOceanBuild(Compile):
@@ -93,47 +93,46 @@ class GOceanBuild(Compile):
         :raises CompileError: If the compilation of dl_esm_inf fails.
         '''
 
-        old_pwd = self._tmpdir.chdir()
-        # Store the temporary path so that the compiled infrastructure
-        # files can be used by all test compilations later.
-        GOceanBuild._compilation_path = str(self._tmpdir)
+        with change_dir(self._tmpdir):
+            # Store the temporary path so that the compiled infrastructure
+            # files can be used by all test compilations later.
+            GOceanBuild._compilation_path = str(self._tmpdir)
 
-        dl_esm_inf_path = \
-            os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         "../../../external/dl_esm_inf/finite_difference/src")
+            dl_esm_inf_path = \
+                os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "../../../external/dl_esm_inf/"
+                             "finite_difference/src")
 
-        fortcl_path = \
-            os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         "../../../external/FortCL/src")
+            fortcl_path = \
+                os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "../../../external/FortCL/src")
 
-        arg_list = [GOceanBuild._make_command, f"F90={self._f90}",
-                    f"F90FLAGS={self._f90flags}",
-                    "-f", f"{dl_esm_inf_path}/Makefile"]
+            arg_list = [GOceanBuild._make_command, f"F90={self._f90}",
+                        f"F90FLAGS={self._f90flags}",
+                        "-f", f"{dl_esm_inf_path}/Makefile"]
 
-        arg_list_fortcl = [GOceanBuild._make_command, f"F90={self._f90}",
-                           f"F90FLAGS={self._f90flags}",
-                           "-f", f"{fortcl_path}/Makefile"]
-        try:
-            with subprocess.Popen(arg_list,
-                                  stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT) as build:
-                # stderr is redirected to stdout, so ignore stderr
-                (output, _) = build.communicate()
-            if Compile.TEST_COMPILE_OPENCL:
-                with subprocess.Popen(arg_list_fortcl,
+            arg_list_fortcl = [GOceanBuild._make_command, f"F90={self._f90}",
+                               f"F90FLAGS={self._f90flags}",
+                               "-f", f"{fortcl_path}/Makefile"]
+            try:
+                with subprocess.Popen(arg_list,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.STDOUT) as build:
                     # stderr is redirected to stdout, so ignore stderr
                     (output, _) = build.communicate()
+                if Compile.TEST_COMPILE_OPENCL:
+                    with subprocess.Popen(arg_list_fortcl,
+                                          stdout=subprocess.PIPE,
+                                          stderr=subprocess.STDOUT) as build:
+                        # stderr is redirected to stdout, so ignore stderr
+                        (output, _) = build.communicate()
 
-        except OSError as err:
-            print(f"Failed to run: {' '.join(arg_list)}: ",
-                  file=sys.stderr)
-            print(f"Error was: {str(err)}", file=sys.stderr)
-            GOceanBuild._infrastructure_built = False
-            raise CompileError(str(err)) from err
-        finally:
-            old_pwd.chdir()
+            except OSError as err:
+                print(f"Failed to run: {' '.join(arg_list)}: ",
+                      file=sys.stderr)
+                print(f"Error was: {str(err)}", file=sys.stderr)
+                GOceanBuild._infrastructure_built = False
+                raise CompileError(str(err)) from err
 
         # Check the return code
         stat = build.returncode

--- a/src/psyclone/tests/lfric_build.py
+++ b/src/psyclone/tests/lfric_build.py
@@ -43,7 +43,7 @@ import subprocess
 import sys
 
 
-from psyclone.tests.utilities import CompileError, Compile
+from psyclone.tests.utilities import change_dir, CompileError, Compile
 
 
 class LFRicBuild(Compile):
@@ -106,22 +106,22 @@ class LFRicBuild(Compile):
         if not Compile.TEST_COMPILE:
             return
 
-        old_pwd = self._tmpdir.chdir()
-        # Store the temporary path so that the compiled infrastructure
-        # files can be used by all test compilations later.
-        LFRicBuild._compilation_path = str(self._tmpdir)
-        makefile = os.path.join(self._infrastructure_path, "Makefile")
-        arg_list = [LFRicBuild._make_command, "-f", makefile]
-        try:
-            with subprocess.Popen(arg_list, stdout=subprocess.PIPE,
-                                  stderr=subprocess.STDOUT) as build:
-                # stderr = stdout, so ignore stderr result:
-                (output, _) = build.communicate()
-        except OSError as err:
-            print(f"Failed to run: {' '.join(arg_list)}: ", file=sys.stderr)
-            raise CompileError(str(err)) from err
-        finally:
-            old_pwd.chdir()
+        with change_dir(self._tmpdir):
+            # Store the temporary path so that the compiled infrastructure
+            # files can be used by all test compilations later.
+            LFRicBuild._compilation_path = str(self._tmpdir)
+            makefile = os.path.join(self._infrastructure_path, "Makefile")
+            arg_list = [LFRicBuild._make_command, "-f", makefile]
+            try:
+                with subprocess.Popen(arg_list, stdout=subprocess.PIPE,
+                                      stderr=subprocess.STDOUT) as build:
+                    # stderr = stdout, so ignore stderr result:
+                    (output, _) = build.communicate()
+            except OSError as err:
+                print(f"Failed to run: {' '.join(arg_list)}: ",
+                      file=sys.stderr)
+                raise CompileError(str(err)) from err
+
         # Check the return code
         stat = build.returncode
         if stat != 0:

--- a/src/psyclone/tests/test_files/dynamo0p3/infrastructure/Makefile
+++ b/src/psyclone/tests/test_files/dynamo0p3/infrastructure/Makefile
@@ -108,10 +108,10 @@ include $(LFRIC_PATH)/dependency
 #     cd field; $(F90) $(F90FLAGS) -c $< -o $(notdir $@)
 
 define compile_rule_template =
-$(1)/%.o:	$$(LFRIC_PATH)/$(1)/%.f90
+$(1)/%.o:	$$(LFRIC_PATH)/$(1)/%.f90 dirs
 	cd $(1); $$(F90) $$(F90FLAGS) -c $$< -o $$(notdir $$@)
 
-$(1)/%.o:	$$(LFRIC_PATH)/$(1)/%.F90
+$(1)/%.o:	$$(LFRIC_PATH)/$(1)/%.F90 dirs
 	cd $(1); $$(F90) $$(F90FLAGS) -c $$< -o $$(notdir $$@)
 endef
 

--- a/src/psyclone/tests/utilities.py
+++ b/src/psyclone/tests/utilities.py
@@ -71,8 +71,20 @@ class CompileError(PSycloneError):
 
 # =============================================================================
 def line_number(root, string_name):
-    '''helper routine which returns the first index of the supplied
-    string or -1 if it is not found'''
+    '''Helper routine which returns the first index of the supplied
+    name in the root object, when it is converted into a string, or
+    -1 if it is not found.
+
+    :param root: the supplied object, which is converted into a list of \
+        strings using `str(root).splitlines()`
+    :type root: Any
+    :param str string_name: the string to search for.
+
+    :returns: first index in the converted list of strings, or -1 if it \
+        is not found
+    :rtype: int
+
+    '''
     lines = str(root).splitlines()
     for idx, line in enumerate(lines):
         if string_name in line:
@@ -82,8 +94,21 @@ def line_number(root, string_name):
 
 # =============================================================================
 def count_lines(root, string_name):
-    '''helper routine which returns the number of lines that contain the
-    supplied string'''
+    '''Helper routine which returns the number of lines that contain the
+    supplied string.
+    Helper routine which returns the first index of the supplied
+    name in the root object, when it is converted into a string, or
+    -1 if it is not found.
+
+    :param root: the supplied object, which is converted into a list of \
+        strings using `str(root).splitlines()`
+    :type root: Any
+    :param str string_name: the string to search for.
+
+    :returns: the number of lines that contain the specified string.
+    :rtype: int
+
+    '''
     count = 0
     lines = str(root).splitlines()
     for line in lines:
@@ -444,22 +469,20 @@ class Compile():
 
         # Change to the temporary directory passed in to us from
         # pytest. (This is a LocalPath object.)
-        old_pwd = self._tmpdir.chdir()
-        # Add a object-specific hash-code to the file name so that all files
-        # created in the same test have different names and can easily be
-        # inspected in case of errors.
-        filename = f"generated-{hash(self)}.f90"
-        with open(filename, 'w', encoding="utf-8") as test_file:
-            test_file.write(code)
+        with change_dir(self._tmpdir):
+            # Add a object-specific hash-code to the file name so that all
+            # files created in the same test have different names and can
+            # easily be inspected in case of errors.
+            filename = f"generated-{hash(self)}.f90"
+            with open(filename, 'w', encoding="utf-8") as test_file:
+                test_file.write(code)
 
-        success = True
-        try:
-            self.compile_file(filename)
-        except CompileError:
-            # Failed to compile the file
-            success = False
-        finally:
-            old_pwd.chdir()
+            success = True
+            try:
+                self.compile_file(filename)
+            except CompileError:
+                # Failed to compile the file
+                success = False
 
         return success
 

--- a/src/psyclone/tests/utilities.py
+++ b/src/psyclone/tests/utilities.py
@@ -289,7 +289,8 @@ class Compile():
                 with subprocess.Popen(arg_list,
                                       stdout=subprocess.PIPE,
                                       stderr=subprocess.STDOUT) as build:
-                    (output, error) = build.communicate()
+                    # stderr = stdout, so ignore empty stderr in result:
+                    (output, _) = build.communicate()
             except OSError as err:
                 print(f"Failed to run: {' '.join(arg_list)}: ",
                       file=sys.stderr)
@@ -300,9 +301,6 @@ class Compile():
         if stat != 0:
             print(f"Compiling: {' '.join(arg_list)}", file=sys.stderr)
             print(output.decode("utf-8"), file=sys.stderr)
-            if error:
-                print("=========", file=sys.stderr)
-                print(error.decode("utf-8"), file=sys.stderr)
             raise CompileError(output)
 
     def _code_compiles(self, psy_ast, dependencies=None):

--- a/src/psyclone/tests/utilities.py
+++ b/src/psyclone/tests/utilities.py
@@ -39,6 +39,7 @@
 from __future__ import absolute_import, print_function
 
 import difflib
+from contextlib import contextmanager
 import os
 from pprint import pprint
 import subprocess
@@ -106,6 +107,25 @@ def print_diffs(expected, actual):
     diff = difflib.Differ()
     diff_list = list(diff.compare(expected_lines, actual_lines))
     pprint(diff_list)
+
+
+# =============================================================================
+@contextmanager
+def change_dir(new_dir):
+    '''This is a small context manager that changes the current working
+    directory, and will automatically switch back. Usage:
+
+    >>> with change_dir("/tmp"):
+    ...     print(f"CWD is {os.getcwd()}")
+    CWD is /tmp
+
+    '''
+    prev_dir = os.getcwd()
+    os.chdir(os.path.expanduser(new_dir))
+    try:
+        yield
+    finally:
+        os.chdir(prev_dir)
 
 
 # =============================================================================

--- a/src/psyclone/tests/utilities_test.py
+++ b/src/psyclone/tests/utilities_test.py
@@ -32,14 +32,18 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors: R. W. Ford and A. R. Porter, STFC Daresbury Lab
+# Modified by J. Henrichs, Bureau of Meteorology
 
 ''' This module contains tests for the the various utility functions in
 psyclone_test_utils.'''
 
-from __future__ import absolute_import
+import os
+
 import pytest
+
 from psyclone.parse.utils import ParseError
-from psyclone.tests.utilities import CompileError, get_invoke, Compile
+from psyclone.tests.utilities import (change_dir, CompileError, get_invoke,
+                                      Compile)
 
 
 HELLO_CODE = '''
@@ -183,3 +187,16 @@ def test_get_invoke():
     with pytest.raises(ParseError) as excinfo:
         get_invoke("does_not_exist", "nemo", idx=0)
     assert "No such file or directory" in str(excinfo.value)
+
+
+# -----------------------------------------------------------------------------
+def test_change_directory():
+    '''Tests the change_directory context manager.'''
+
+    old_dir = os.getcwd()
+
+    with change_dir("/tmp"):
+        tmp_dir = os.getcwd()
+        assert tmp_dir == "/tmp"
+
+    assert os.getcwd() == old_dir

--- a/src/psyclone/tests/utilities_test.py
+++ b/src/psyclone/tests/utilities_test.py
@@ -41,9 +41,12 @@ import os
 
 import pytest
 
+from psyclone.parse.algorithm import parse
 from psyclone.parse.utils import ParseError
-from psyclone.tests.utilities import (change_dir, CompileError, get_invoke,
-                                      Compile)
+from psyclone.psyGen import PSyFactory
+from psyclone.tests.utilities import (change_dir, count_lines, Compile,
+                                      CompileError, get_invoke, line_number,
+                                      print_diffs)
 
 
 HELLO_CODE = '''
@@ -53,62 +56,117 @@ end program hello
 '''
 
 
-def test_compiler_works(tmpdir):
-    ''' Check that the specified compiler works for a hello-world
-    example '''
+def test_enable_disable_compilation(monkeypatch):
+    '''Test the behaviour when disabling compilation ... even if
+    compilation is enabled.
+    '''
+    monkeypatch.setattr(Compile, "TEST_COMPILE", False)
+    # Test that compile_file will do nothing if compilation is disabled:
+    _compile = Compile()
+    _compile.compile_file("nothing-to-compile")
+    _compile.code_compiles(None)
+    _compile.string_compiles("")
     Compile.skip_if_compilation_disabled()
 
-    old_pwd = tmpdir.chdir()
-    try:
+
+# -----------------------------------------------------------------------------
+def test_enable_disable_opencl_compilation(monkeypatch):
+    '''Test the behaviour when disabling opencl compilation ... even if
+    compilation is enabled.
+    '''
+    monkeypatch.setattr(Compile, "TEST_COMPILE_OPENCL", False)
+    Compile.skip_if_opencl_compilation_disabled()
+
+
+# -----------------------------------------------------------------------------
+def test_compiler_works(tmpdir, monkeypatch):
+    ''' Check that the specified compiler works for a hello-world
+    example.'''
+
+    _compile = Compile()
+    assert _compile.base_path is None
+    _compile.base_path = "/tmp"
+    assert _compile.base_path == "/tmp"
+
+    if not Compile.TEST_COMPILE:
+
+        # If compilation is disable, use '/usr/bin/true' as 'compile'
+        # to cover more lines:
+        monkeypatch.setattr(Compile, "TEST_COMPILE", True)
+        monkeypatch.setattr(Compile, "F90", "true")
+
+    with change_dir(tmpdir):
+        _compile = Compile(tmpdir)
+        # Check compile_file:
         with open("hello_world.f90", "w", encoding="utf-8") as ffile:
             ffile.write(HELLO_CODE)
-        Compile(tmpdir).compile_file("hello_world.f90", link=True)
-    finally:
-        old_pwd.chdir()
+        _compile.compile_file("hello_world.f90", link=True)
+        # Check string_compiles functions
+        _compile.string_compiles(HELLO_CODE)
+
+        monkeypatch.setattr(_compile, "_f90", "does-not-exist")
+        with pytest.raises(CompileError) as err:
+            _compile.compile_file("hello_world.f90")
+        assert _compile.string_compiles(HELLO_CODE) is False
+        # The actual error message might vary, e.g.:
+        # No such file or directory: 'does-not-exist
+        # But it should contain the invalid command in any case
+        assert "does-not-exist" in str(err.value)
 
 
-def test_compiler_with_flags(tmpdir):
+# -----------------------------------------------------------------------------
+def test_compiler_with_flags(tmpdir, monkeypatch):
     ''' Check that we can pass through flags to the Fortran compiler.
     Since correct flags are compiler-dependent and hard to test,
     we pass something that is definitely not a flag and check that
     the compiler complains. This test is skipped if no compilation
     tests have been requested (--compile flag to py.test). '''
-    Compile.skip_if_compilation_disabled()
-    old_pwd = tmpdir.chdir()
-    try:
+    if not Compile.TEST_COMPILE:
+        # If compilation is disable, use '/usr/bin/true' as 'compile'
+        # to cover more lines:
+        monkeypatch.setattr(Compile, "TEST_COMPILE", True)
+        monkeypatch.setattr(Compile, "F90", "false")
+
+    with change_dir(tmpdir):
         with open("hello_world.f90", "w", encoding="utf-8") as ffile:
             ffile.write(HELLO_CODE)
         _compile = Compile(tmpdir)
         _compile._f90flags = "not-a-flag"
         with pytest.raises(CompileError) as excinfo:
             _compile.compile_file("hello_world.f90")
-        assert "not-a-flag" in str(excinfo.value)
+
+        if Compile.F90 != "false":
+            # We don't get an error message like this from
+            assert "not-a-flag" in str(excinfo.value)
+        else:
+            # If we are not compiling, use 'true' as compiler in
+            # the next step that is supposed to be successful:
+            _compile._f90 = "true"
+
         # For completeness we also try with a valid flag although we
         # can't actually check its effect.
         _compile._f90flags = "-g"
         _compile.compile_file("hello_world.f90", link=True)
-    finally:
-        old_pwd.chdir()
 
 
+# -----------------------------------------------------------------------------
 def test_build_invalid_fortran(tmpdir):
     ''' Check that we raise the expected error when attempting
     to compile some invalid Fortran. Skips test if --compile not
     supplied to py.test on command-line. '''
     Compile.skip_if_compilation_disabled()
     invalid_code = HELLO_CODE.replace("write", "wite", 1)
-    old_pwd = tmpdir.chdir()
-    try:
+    with change_dir(tmpdir):
         with open("hello_world.f90", "w", encoding="utf-8") as ffile:
             ffile.write(invalid_code)
         _compile = Compile(tmpdir)
         with pytest.raises(CompileError) as excinfo:
             _compile.compile_file("hello_world.f90")
-    finally:
-        old_pwd.chdir()
+
     assert "Compile error" in str(excinfo.value)
 
 
+# -----------------------------------------------------------------------------
 def test_find_fortran_file(tmpdir):
     ''' Check that our find_fortran_file routine raises the expected
     error if it can't find a matching file. Also check that it returns
@@ -129,6 +187,7 @@ def test_find_fortran_file(tmpdir):
         old_pwd.chdir()
 
 
+# -----------------------------------------------------------------------------
 def test_compile_str(monkeypatch, tmpdir):
     ''' Checks for the routine that compiles Fortran supplied as a string '''
     # Check that we always return True if compilation testing is disabled
@@ -144,6 +203,68 @@ def test_compile_str(monkeypatch, tmpdir):
     # Repeat for some broken code
     invalid_code = HELLO_CODE.replace("write", "wite", 1)
     assert not _compile.string_compiles(invalid_code)
+
+
+# -----------------------------------------------------------------------------
+def test_code_compile(tmpdir, monkeypatch):
+    '''A dummy test of the underlying code_compiles function, which takes
+    an AST. Note that the derived classes (GOceanBuild and LFRicBUILD)
+    will test this properly, so here we just use 'true' as 'compiler'.
+    '''
+    _, invoke_info = parse(os.path.join(os.path.
+                                        dirname(os.path.
+                                                abspath(__file__)),
+                                        "test_files", "gocean1p0",
+                                        "single_invoke.f90"),
+                           api="gocean1.0")
+    psy = PSyFactory("gocean1.0", distributed_memory=False).create(invoke_info)
+    if not Compile.TEST_COMPILE:
+        # If compilation is disabled, temporarily enable it and use
+        # 'true' as compiler:
+        monkeypatch.setattr(Compile, "TEST_COMPILE", True)
+        monkeypatch.setattr(Compile, "F90", "true")
+    _compile = Compile(tmpdir)
+    _compile.base_path = "/tmp"
+    with change_dir(tmpdir):
+        with open("hello_world.f90", "w", encoding="utf-8") as ffile:
+            ffile.write(HELLO_CODE)
+        assert _compile.code_compiles(psy, dependencies=["something.cl",
+                                                         "hello_world.f90"])
+        # Now check compilation failure, which we simulate by
+        # using 'false' as compiler:
+        monkeypatch.setattr(_compile, "_f90", "false")
+        assert _compile.code_compiles(psy, dependencies=["something.cl",
+                                                         "hello_world.f90"]) \
+            is False
+
+
+# -----------------------------------------------------------------------------
+def test_line_number():
+    '''Tests the line number function.
+    '''
+    assert line_number("a\nb\nc", "a") == 0
+    assert line_number("a\nb\nc", "c") == 2
+    assert line_number("a\nb\nc", "x") == -1
+
+
+# -----------------------------------------------------------------------------
+def test_count_lines():
+    '''Tests the line number function.
+    '''
+    assert count_lines("a\nbab\ncaaa", "a") == 3
+    assert count_lines("a\nbab\ncaaa", "b") == 1
+    assert count_lines("a\nbab\ncaaa", "c") == 1
+
+
+# -----------------------------------------------------------------------------
+def test_print_diff(capsys):
+    '''Tests the print-diff function.'''
+    string_list1 = "aa\nbb\ncc"
+    string_list2 = "aa\ncc\ndd"
+    print_diffs(string_list1, string_list2)
+    out, err = capsys.readouterr()
+    assert out == "['  aa', '- bb', '  cc', '+ dd']\n"
+    assert err == ""
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Improve test coverage of tests/utilities.py, even if no compilation is enabled. This uses 'true' and 'false' as compiler to trigger the expected behaviour.
Note that this branch is based on #1849, so this PR must be done fir.st