### PR TITLE
(Closes #1874) rm pytest-pep257 from setup.py

### DIFF
--- a/changelog
+++ b/changelog
@@ -115,6 +115,8 @@
 
 	42) PR #1871 for #1870. Fixes typo in link in User Guide.
 
+	43) PR #1875 for #1874. Remove pytest-pep257 dependency from setup.py
+
 release 2.3.1 17th of June 2022
 
         1) PR #1747 for #1720. Adds support for If blocks to PSyAD.

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,7 @@ if __name__ == '__main__':
                     "sphinx_rtd_theme", "autoapi"],
             'psydata': ["Jinja2"],
             'test': ["pep8", "pylint", "pytest-cov", "pytest-pep8",
-                     "pytest-pylint", "pytest-flakes", "pytest-pep257"],
+                     "pytest-pylint", "pytest-flakes"],
         },
         include_package_data=True,
         scripts=['bin/psyclone', 'bin/psyclone-kern', 'bin/psyad'],


### PR DESCRIPTION
Removes pytest-pep257 from the `test` extra_dependencies.