### PR TITLE
(Closes #1893) allow for Symbol in is_upper/lower_bound

### DIFF
--- a/changelog
+++ b/changelog
@@ -145,6 +145,9 @@
 	52) PR #1853 for #1829. Add OMP teams distribute parallel do directive
 	and refactor OMPLoopTrans.
 
+	53) PR #1900 for #1893. Fix bug in is_upper/lower_bound for non-typed
+	Symbols.
+
 release 2.3.1 17th of June 2022
 
 	1) PR #1747 for #1720. Adds support for If blocks to PSyAD.

--- a/src/psyclone/psyir/nodes/array_mixin.py
+++ b/src/psyclone/psyir/nodes/array_mixin.py
@@ -49,7 +49,7 @@ from psyclone.psyir.nodes.member import Member
 from psyclone.psyir.nodes.operation import Operation, BinaryOperation
 from psyclone.psyir.nodes.ranges import Range
 from psyclone.psyir.nodes.reference import Reference
-from psyclone.psyir.symbols import SymbolError
+from psyclone.psyir.symbols import SymbolError, DataSymbol
 from psyclone.psyir.symbols.datatypes import (ScalarType, ArrayType,
                                               INTEGER_TYPE)
 
@@ -151,6 +151,10 @@ class ArrayMixin(metaclass=abc.ABCMeta):
         if isinstance(lower, Literal):
             try:
                 symbol = self.scope.symbol_table.lookup(self.name)
+                if not isinstance(symbol, DataSymbol):
+                    # We don't have any type information on this symbol
+                    # (probably because it originates from a wildcard import).
+                    return False
                 datatype = symbol.datatype
                 # Check that the symbol is of ArrayType. (It may be of
                 # UnknownFortranType if the symbol is of e.g. character type.)
@@ -215,6 +219,10 @@ class ArrayMixin(metaclass=abc.ABCMeta):
         if isinstance(upper, Literal):
             try:
                 symbol = self.scope.symbol_table.lookup(self.name)
+                if not isinstance(symbol, DataSymbol):
+                    # We don't have any type information on this symbol
+                    # (probably because it originates from a wildcard import).
+                    return False
                 datatype = symbol.datatype
                 # Check that the symbol is of ArrayType. (It may be of
                 # UnknownFortranType if the symbol is of e.g. character type.)

--- a/src/psyclone/tests/psyir/nodes/array_mixin_test.py
+++ b/src/psyclone/tests/psyir/nodes/array_mixin_test.py
@@ -117,9 +117,9 @@ def test_is_upper_lower_bound(fortran_reader):
     assert not array_ref.is_lower_bound(0)
     assert not array_ref.is_upper_bound(0)
 
-    # Return False if the symbol has not associated type information.
+    # Return False if the symbol has no associated type information.
     array_ref = assigns[2].lhs
-    assert type(array_ref.symbol) is not DataSymbol
+    assert not isinstance(array_ref.symbol, DataSymbol)
     assert not array_ref.is_lower_bound(0)
     assert not array_ref.is_upper_bound(0)
 

--- a/src/psyclone/tests/psyir/nodes/array_mixin_test.py
+++ b/src/psyclone/tests/psyir/nodes/array_mixin_test.py
@@ -80,10 +80,12 @@ def test_is_upper_lower_bound(fortran_reader):
     '''
     code = (
         "subroutine test()\n"
+        "use some_mod\n"
         "real a(10)\n"
         "character(10) my_str\n"
         "a(1:10) = 0.0\n"
         "my_str(2:2) = 'b'\n"
+        "var1(3:4) = 0\n"
         "end subroutine\n")
 
     # Return True as the literal values or the declaration and array
@@ -112,6 +114,12 @@ def test_is_upper_lower_bound(fortran_reader):
 
     # Return False if the symbol being referenced is of UnknownFortranType.
     array_ref = assigns[1].lhs
+    assert not array_ref.is_lower_bound(0)
+    assert not array_ref.is_upper_bound(0)
+
+    # Return False if the symbol has not associated type information.
+    array_ref = assigns[2].lhs
+    assert type(array_ref.symbol) is not DataSymbol
     assert not array_ref.is_lower_bound(0)
     assert not array_ref.is_upper_bound(0)
 


### PR DESCRIPTION
A second small bug fix to allow for the case where we have no type information at all.