### PR TITLE
(Closes #1896) Fix bug for parameter arrays in HoistLocalArraysTrans

### DIFF
--- a/changelog
+++ b/changelog
@@ -154,6 +154,9 @@
 	55) PR #1807 towards #1806. Adds PSyIR support for LFRic kernel
 	metadata.
 
+	56) PR #1906 for #1896. Update HoistLocalArrayTrans to avoid hoisting
+	parameter arrays and, unless explicitly requested, device parallel routines.
+
 release 2.3.1 17th of June 2022
 
 	1) PR #1747 for #1720. Adds support for If blocks to PSyAD.

--- a/src/psyclone/psyir/transformations/hoist_local_arrays_trans.py
+++ b/src/psyclone/psyir/transformations/hoist_local_arrays_trans.py
@@ -288,7 +288,7 @@ class HoistLocalArraysTrans(Transformation):
                 f"Container but the enclosing container is a "
                 f"FileContainer (named '{container.name}').")
 
-        if not (options and options.get("allow-accroutine-directive")):
+        if not (options and options.get("allow_accroutine")):
             if node.walk(ACCRoutineDirective):
                 raise TransformationError(
                     f"The supplied routine '{node.name}' contains an ACC "

--- a/src/psyclone/tests/psyir/transformations/hoist_local_arrays_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/hoist_local_arrays_trans_test.py
@@ -456,7 +456,7 @@ def test_validate_acc_routine_directive(fortran_reader):
     assert ("supplied routine 'test' contains an ACC Routine directive "
             "which implies" in str(err.value))
     # This check can be disabled.
-    hoist_trans.validate(routine, options={"allow-accroutine-directive": True})
+    hoist_trans.validate(routine, options={"allow_accroutine": True})
 
 
 def test_validate_tagged_symbol_clash(fortran_reader):


### PR DESCRIPTION
This PR also extends the validation to check for any ACCRoutine directives as these *usually* imply that the routine will be run in parallel. An option is implemented to permit this check to be disabled.