### PR TITLE
Improve CLI --version interface

### DIFF
--- a/src/psyclone/generator.py
+++ b/src/psyclone/generator.py
@@ -387,13 +387,11 @@ def main(args):
     parser.add_argument("--config", help="Config file with "
                         "PSyclone specific options.")
     parser.add_argument(
-        '-v', '--version', dest='version', action="store_true",
+        '--version', '-v', action='version',
+        version=f'PSyclone version: {__VERSION__}',
         help=f'Display version information ({__VERSION__})')
 
     args = parser.parse_args(args)
-
-    if args.version:
-        print(f"PSyclone version: {__VERSION__}")
 
     if args.profile:
         Profiler.set_options(args.profile)

--- a/src/psyclone/kernel_tools.py
+++ b/src/psyclone/kernel_tools.py
@@ -118,13 +118,11 @@ def run(args):
     parser.add_argument("--config", help="config file with "
                         "PSyclone specific options.")
     parser.add_argument(
-        '-v', '--version', dest='version', action="store_true",
-        help=f"display version information ({__VERSION__})")
+        '--version', '-v', action='version',
+        version=f'psyclone-kern version: {__VERSION__}',
+        help=f'display version information ({__VERSION__})')
 
     args = parser.parse_args(args)
-
-    if args.version:
-        print(f"psyclone-kern version: {__VERSION__}", file=sys.stdout)
 
     # If no config file name is specified, args.config is none
     # and config will load the default config file.

--- a/src/psyclone/tests/generator_test.py
+++ b/src/psyclone/tests/generator_test.py
@@ -582,18 +582,17 @@ def test_main_version(capsys):
     '''Tests that the version info is printed correctly.'''
 
     # First test if -h includes the right version info:
-    with pytest.raises(SystemExit):
-        main(["-h"])
-    output, _ = capsys.readouterr()
-    assert f"Display version information ({__VERSION__})" in output
+    for arg in ["-h", "--help"]:
+        with pytest.raises(SystemExit):
+            main([arg])
+        output, _ = capsys.readouterr()
+        assert f"Display version information ({__VERSION__})" in output
 
-    # Now test -v, but it needs a filename for argparse to work. Just use
-    # some invalid parameters - "-v" prints its output before that.
-    with pytest.raises(SystemExit) as _:
-        main(["-v", "does-not-exist"])
-    output, _ = capsys.readouterr()
-
-    assert f"PSyclone version: {__VERSION__}" in output
+    for arg in ["-v", "--version"]:
+        with pytest.raises(SystemExit) as _:
+            main([arg])
+        output, _ = capsys.readouterr()
+        assert f"PSyclone version: {__VERSION__}" in output
 
 
 def test_main_profile(capsys):

--- a/src/psyclone/tests/kernel_tools_test.py
+++ b/src/psyclone/tests/kernel_tools_test.py
@@ -82,10 +82,11 @@ def test_run(capsys, tmpdir):
 
 def test_run_version(capsys):
     ''' Test that the flag requesting version information works correctly. '''
-    with pytest.raises(SystemExit):
-        kernel_tools.run(["-v", "not-a-file.f90"])
-    result, _ = capsys.readouterr()
-    assert f"psyclone-kern version: {__VERSION__}" in result
+    for arg in ["-v", "--version"]:
+        with pytest.raises(SystemExit):
+            kernel_tools.run([arg])
+        result, _ = capsys.readouterr()
+        assert f"psyclone-kern version: {__VERSION__}" in result
 
 
 def test_run_invalid_api(capsys):


### PR DESCRIPTION
Modify `psyclone --version` and `psyclone-kern --version` to behave like common commands, i.e. print version and exit, instead of continuing. (E.g., `git --version` would behave in this way.)

Before:
* `psyclone --version` does not work.
* `psyclone --version /fake/file` works but returns 1.
* `psyclone --version /path/to/real/filename` prints version and continue to process `/path/to/real/filename`.

After:
* `psyclone --version` works as expected.
* `psyclone --version /path/to/anyfile` prints version and exits, ignoring other opts/args.  <-- **Is this change OK?**

(I stumbled upon this problem while installing PSyclone in my local environment, and decided to have a stab at fixing it. I have since found two related issues after making this change #175 and #888. Please feel free to close down this PR if this is not the correct fix.)