### PR TITLE
Create PSyIR kernel arguments from new metadata classes (closes #2078)

### DIFF
--- a/src/psyclone/domain/lfric/formal_kernel_args_from_metadata.py
+++ b/src/psyclone/domain/lfric/formal_kernel_args_from_metadata.py
@@ -1,0 +1,952 @@
+''' xxx '''
+
+from psyclone.domain.lfric import LFRicTypes, KernelArgOrder
+from psyclone.psyir.symbols import ArgumentInterface
+from psyclone.psyir.symbols import SymbolTable
+from psyclone.psyir.symbols import ArrayType, DataSymbol
+from psyclone.psyir.nodes import Reference
+
+# TODO: many symbols here are not declared in LFRicTypes
+
+class FormalKernelArgsFromMetadata(KernelArgOrder):
+    ''' xxx '''
+
+    _access_lookup = {
+        "gh_read": ArgumentInterface.Access.READ,
+        "gh_write": ArgumentInterface.Access.WRITE,
+        "gh_readwrite": ArgumentInterface.Access.READWRITE,
+        "gh_inc": ArgumentInterface.Access.READWRITE,
+        "gh_sum": ArgumentInterface.Access.READWRITE}
+
+    @classmethod
+    def _initialise(self, symbol_table):
+        ''' xxx '''
+        if symbol_table is None:
+            symbol_table = SymbolTable()
+        elif not isinstance(symbol_table, SymbolTable):
+            raise TypeError(
+                f"Expecting the optional info argument to be a symbol table "
+                f"but found {type(symbol_table).__name__}.")
+        super()._initialise(symbol_table)
+    
+    @classmethod
+    def _cell_position(self):
+        '''A cell position argument. This is an integer of type i_def and has
+        intent in. Its default name is 'cell'.
+
+        '''
+        self._add_arg("CellPositionDataSymbol", "cell")
+
+    @classmethod
+    def _mesh_height(self):
+        '''A mesh height argument. This is an integer of type i_def and has
+        intent in. Its default name is 'nlayers'.
+
+        '''
+        self._add_arg("MeshHeightDataSymbol", "nlayers")
+
+    @classmethod
+    def _mesh_ncell2d_no_halos(self):
+        '''Argument providing the number of columns in the mesh ignoring
+        halos. This is an integer of type i_def and has intent in.
+
+        '''
+        self._add_arg("LFRicIntegerScalarDataSymbol", "ncell_2d_no_halos")
+
+    @classmethod
+    def _mesh_ncell2d(self):
+        '''Argument providing the number of columns in the mesh including
+        halos. This is an integer of type i_def and has intent in. Its
+        default name is 'ncell_2d'.
+
+        '''
+        # This symbol might be used to dimension an array in another
+        # method and therefore could have already been declared.
+        symbol = self._get_or_create_symbol("LFRicIntegerScalarDataSymbol", "ncell_2d")
+        self._add_symbol(symbol)
+
+    @classmethod
+    def _cell_map(self):
+        '''Four arguments providing a mapping from coarse to fine mesh for the
+        current column. The first is 'cell_map', an integer array of
+        rank two, kind i_def and intent in. This is followed by its
+        extents, 'ncell_f_per_c_x' and 'ncell_f_per_c_y' the numbers
+        of fine cells per coarse cell in the x and y directions,
+        respectively. These are integers of kind i_def and have intent
+        in. Lastly is 'ncell_f', the number of cells (columns) in the
+        fine mesh. This is an integer of kind i_def and has intent in.
+
+        '''
+        x_symbol = self._create_datasymbol(
+            "LFRicIntegerScalarDataSymbol", "ncell_f_per_c_x")
+        y_symbol = self._create_datasymbol(
+            "LFRicIntegerScalarDataSymbol", "ncell_f_per_c_y")
+        scalar_type = self._create_datatype("LFRicIntegerScalarDataType")
+        array_type = ArrayType(
+            scalar_type, [Reference(x_symbol), Reference(y_symbol)])
+        interface = ArgumentInterface(ArgumentInterface.Access.READ)
+        cell_map_symbol = DataSymbol("cell_map", array_type, interface=interface)
+        self._add_symbol(cell_map_symbol)
+        self._add_symbol(x_symbol)
+        self._add_symbol(y_symbol)
+        self._add_arg("LFRicIntegerScalarDataSymbol", "ncell_f")
+
+    @classmethod
+    def _scalar(self, meta_arg):
+        '''Argument providing an LFRic scalar value.
+
+        :param meta_arg: the metadata associated with this scalar argument.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.ScalarArgMetadata`
+
+        '''
+        datatype = meta_arg.datatype[3:]
+        datatype_char = meta_arg.datatype[3:4]
+        meta_arg_index = self._metadata.meta_args.index(meta_arg)
+        self._add_arg(
+            f"LFRic{datatype.capitalize()}ScalarDataSymbol",
+            f"{datatype_char}scalar_{meta_arg_index+1}",
+            access=self._access_lookup[meta_arg.access])
+
+    @classmethod
+    def _field(self, meta_arg):
+        '''Argument providing an LFRic field.
+
+        :param meta_arg: the metadata associated with this field argument.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        undf_name = self._undf_name(meta_arg.function_space)
+        undf_symbol = self._get_or_create_symbol(
+            "NumberOfUniqueDofsDataSymbol", undf_name)
+
+        name = self._field_name(meta_arg)
+        datatype = meta_arg.datatype[3:]
+        self._add_arg(
+            f"{datatype.capitalize()}FieldDataSymbol", name, dims=[Reference(undf_symbol)],
+            access=self._access_lookup[meta_arg.access])
+
+    @classmethod
+    def _field_vector(self, meta_arg):
+        '''Arguments providing an LFRic field vector.
+
+        :param meta_arg: the metadata associated with this field \
+            vector argument.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldVectorArgMetadata`
+
+        '''
+        undf_name = self._undf_name(meta_arg.function_space)
+        undf_symbol = self._get_or_create_symbol(
+            "NumberOfUniqueDofsDataSymbol", undf_name)
+
+        field_name = self._field_name(meta_arg)
+        datatype = meta_arg.datatype[3:]
+        access = self._access_lookup[meta_arg.access]
+        for idx in range(int(meta_arg.vector_length)):
+            name = f"{field_name}_v{idx+1}"
+            self._add_arg(
+                f"{datatype.capitalize()}VectorFieldDataSymbol", name,
+                dims=[Reference(undf_symbol)], access=access)
+
+    @classmethod
+    def _operator(self, meta_arg):
+        '''Arguments providing an LMA operator. First include an integer
+        extent of kind i_def with intent in. The default name of this
+        extent is <operator_name>'_ncell_3d'. Next include the
+        operator. This is a rank-3, real array. Its precision (kind)
+        depends on how it is defined in the algorithm layer and its
+        intent depends on its metadata. Its default name is
+        'op_'<argument_position>. The extents of the first two
+        dimensions are the local degrees of freedom for the to and
+        from function spaces, respectively, and that of the third is
+        <operator_name>'_ncell_3d'.
+
+        :param meta_arg: the metadata associated with the operator \
+            arguments.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.OperatorArgMetadata`
+
+        '''
+        meta_arg_index = self._metadata.meta_args.index(meta_arg)
+        name = f"op_{meta_arg_index+1}_ncell_3d"
+        op_ncell_3d_symbol = self._create_datasymbol(
+            "LFRicIntegerScalarDataSymbol", name)
+        self._add_symbol(op_ncell_3d_symbol)
+
+        ndf_name_to = self._ndf_name(meta_arg.function_space_to)
+        ndf_to_symbol = self._get_or_create_symbol(
+            "NumberOfDofsDataSymbol", ndf_name_to)
+
+        ndf_name_from = self._ndf_name(meta_arg.function_space_from)
+        ndf_from_symbol = self._get_or_create_symbol(
+            "NumberOfDofsDataSymbol", ndf_name_from)
+
+        # TODO: Precision depends on how it is defined in the algorithm layer!!!!
+        operator_name = self._operator_name(meta_arg)
+        access = self._access_lookup[meta_arg.access]
+        self._add_arg(
+            "OperatorDataSymbol", operator_name,
+            dims=[Reference(ndf_to_symbol), Reference(ndf_from_symbol),
+                  Reference(op_ncell_3d_symbol)],
+            access=access)
+
+    @classmethod
+    def _cma_operator(self, meta_arg):
+        '''Arguments providing a columnwise operator. First include a real,
+        3-dimensional array of kind r_solver with its intent depending
+        on its metadata. Its default name is
+        'cma_op_'<argument_position>, hereon specified as
+        '<operator_name>' and the default names of its dimensions are
+        'bandwidth_'<operator_name>, 'nrow_'<operator_name>, and
+        'ncell_2d'. Next the number of rows in the banded matrix is
+        provided. This is an integer of kind i_def with intent in with
+        default name 'nrow_'<operator_name>. If the from-space of the
+        operator is not the same as the to-space then the number of
+        columns in the banded matrix is provided next. This is an
+        integer of kind i_def with intent in and has default name
+        'ncol_'<operator_name>. Next the bandwidth of the banded
+        matrix is added. This is an integer of kind i_def with intent
+        in and has default name 'bandwidth_'<operator_name>. Next
+        banded-matrix parameter alpha is added. This is an integer of
+        kind i_def with intent in and has default name
+        'alpha_'<operator_name>. Next banded-matrix parameter beta is
+        added. This is an integer of kind i_def with intent in and has
+        default name 'beta_<operator_name>. Next banded-matrix
+        parameter gamma_m is added. This is an integer of kind i_def
+        with intent in and has default name 'gamma_m_'<operator_name>.
+        Finally banded-matrix parameter gamma_p is added. This is an
+        integer of kind i_def with intent in and has default name
+        'gamma_p_'<operator_name>.
+
+        :param meta_arg: the metadata associated with the CMA operator \
+            arguments.
+        :type meta_arg: :py:class:`psyclone.domain.lfric.kernel.\
+            ColumnwiseOperatorArgMetadata`
+
+        '''
+
+        operator_name = self._cma_operator_name(meta_arg)
+
+        bandwidth = self._create_datasymbol(
+            "LFRicIntegerScalarDataSymbol", f"bandwidth_{operator_name}")
+        nrow = self._create_datasymbol(
+            "LFRicIntegerScalarDataSymbol", f"nrow_{operator_name}")
+        # ncell_2d is added to the symbol table in another method so
+        # may already be declared.
+        ncell_2d = self._get_or_create_symbol("LFRicIntegerScalarDataSymbol", "ncell_2d")
+
+        access = self._access_lookup[meta_arg.access]
+        # TODO: should be r_solver precision
+        self._add_arg("OperatorDataSymbol", operator_name,
+                      dims=[Reference(bandwidth), Reference(nrow), Reference(ncell_2d)], access=access)
+        self._add_symbol(nrow)
+        if meta_arg.function_space_from != meta_arg.function_space_to:
+            self._add_arg("LFRicIntegerScalarDataSymbol", f"ncol_{operator_name}")
+        self._add_symbol(bandwidth)
+        self._add_arg("LFRicIntegerScalarDataSymbol", f"alpha_{operator_name}")
+        self._add_arg("LFRicIntegerScalarDataSymbol", f"beta_{operator_name}")
+        self._add_arg("LFRicIntegerScalarDataSymbol", f"gamma_m_{operator_name}")
+        self._add_arg("LFRicIntegerScalarDataSymbol", f"gamma_p_{operator_name}")
+
+    @classmethod
+    def _ref_element_properties(self, meta_ref_element):
+        '''Arguments required if there are reference element properties
+        specified in the metadata.
+
+        If either the normals_to_horizontal_faces or
+        outward_normals_to_horizontal_faces properties of the
+        reference element are required then pass the number of
+        horizontal faces of the reference element, with default name
+        nfaces_re_h. Similarly, if either the
+        normals_to_vertical_faces or outward_normals_to_vertical_faces
+        are required then pass the number of vertical faces, with
+        default name 'nfaces_re_v'. This also holds for the
+        normals_to_faces and outward_normals_to_faces where the number
+        of all faces of the reference element (with default name
+        nfaces_re) is passed to the kernel. All of these quantities
+        are integers of kind i_def with intent in.
+
+        Then, in the order specified in the meta_reference_element
+        metadata: For the
+        [outward_]normals_to_horizontal/[outward_]vertical_faces, pass
+        a rank-2 integer array of kind i_def with dimensions (3,
+        nfaces_re_h/v) and intent in.  For normals_to_faces or
+        outward_normals_to_faces pass a rank-2 integer array of kind
+        i_def with dimensions (3, nfaces_re) and intent in. In each
+        case the default name is the same name as the reference
+        element property.
+
+        :param meta_ref_element: the metadata capturing the reference \
+            element properties required by the kernel.
+        :type meta_ref_element: List[:py:class:`psyclone.domain.lfric.\
+            kernel.MetaRefElementArgMetadata`]
+
+        '''
+        if [entry for entry in meta_ref_element if entry.reference_element in
+                ["normals_to_horizontal_faces",
+                 "outward_normals_to_horizontal_faces"]]:
+            self._add_arg("NumberOfQrPointsInXy", "nfaces_re_h")
+        if [entry for entry in meta_ref_element if entry.reference_element in
+                ["normals_to_vertical_faces",
+                 "outward_normals_to_vertical_faces"]]:
+            self._add_arg("NumberOfQrPointsInZ", "nfaces_re_v")
+        if [entry for entry in meta_ref_element if entry.reference_element in
+                ["normals_to_faces",
+                 "outward_normals_to_faces"]]:
+            self._add_arg("NumberOfQrPointsInFaces", "nfaces_re")
+        for ref_element_property in meta_ref_element:
+            self._add_arg(
+                "LFRicIntegerScalar", ref_element_property.reference_element)
+
+    @classmethod
+    def _mesh_properties(self, meta_mesh):
+        '''All arguments required for mesh properties specified in the kernel
+        metadata.
+
+        If the adjacent_face mesh property is required then, if the
+        number of horizontal cell faces obtained from the reference
+        element (nfaces_re_h) is not already being passed to the
+        kernel via the reference element then supply it here. This is
+        an integer of kind i_def with intent in and has default name
+        'nfaces_re_h'.
+
+        Also pass a rank-1, integer array with intent in of kind i_def
+        and extent nfaces_re_h, with default name being the name of
+        the property (adjacent_face in this case).
+
+        :param meta_mesh: the metadata capturing the mesh properties \
+            required by the kernel.
+        :type meta_mesh: List[\
+            :py:class:`psyclone.domain.lfric.kernel.MetaMeshArgMetadata`]
+
+        raises InternalError: if the mesh property is not 'adjacent_face'.
+
+        '''
+        for mesh_property in meta_mesh:
+            if mesh_property.mesh == "adjacent_face":
+                if not self._metadata.meta_ref_element or not \
+                   [entry for entry in self._metadata.meta_ref_element
+                    if entry.reference_element in [
+                            "normals_to_horizontal_faces",
+                            "outward_normals_to_horizontal_faces"]]:
+                    # nfaces_re_h has not already been passed via reference
+                    # element logic so add it here.
+                    self._add_arg("NumberOfQrPointsInXy", "nfaces_re_h")
+                    self._add_arg("LFRicIntegerScalar", mesh_property.mesh)
+            else:
+                raise InternalError(
+                    f"Unexpected mesh property '{mesh_property.mesh}' found. "
+                    f"Expected 'adjacent_face'.")
+
+    @classmethod
+    def _fs_common(self, function_space):
+        '''Arguments associated with a function space that are common to
+        fields and operators. Add the number of degrees of freedom for
+        this function space. This is an integer of kind i_def with
+        intent in and default name 'ndf_'<function_space>.
+
+        :param str function_space: the current function space.
+
+        '''
+        function_space_name = self._function_space_name(function_space)
+        self._add_arg("NumberOfDofs", f"ndf_{function_space_name}")
+
+    @classmethod
+    def fs_compulsory_field(self, function_space):
+        '''Compulsory arguments for this function space. First include the
+        unique number of degrees of freedom for this function
+        space. This is a scalar integer of kind i_def with intent in
+        and it's default name is 'undf'_<function_space>. Second
+        include the dof map for this function space. This is a 1D
+        integer array with dimension 'ndf_<function_space>' of kind
+        i_def with intent in and its' default name is
+        'map_<function_space>.
+
+        :param str function_space: the current function space.
+
+        '''
+        function_space_name = self._function_space_name(function_space)
+        undf_name = self._undf_name(function_space)
+        self._add_arg("NumberOfUniqueDofs", undf_name)
+        self._add_arg("DofMap", f"map_{function_space_name}")
+
+    @classmethod
+    def fs_intergrid(self, meta_arg):
+        '''Function-space related arguments for an intergrid kernel.
+
+        For this field include the required dofmap information.
+
+        If the dofmap is associated with an argument on the fine mesh,
+        include the number of DoFs per cell for the FS of the field on
+        the fine mesh. This is an integer with intent in and precision
+        i_def. Its default name is 'ndf_'<function_space>. Next,
+        include the number of unique DoFs per cell for the FS of the
+        field on the fine mesh. This is an integer with intent in and
+        precision i_def. Its default name is
+        'undf_'<function_space>. Lastly include the whole dofmap for
+        the fine mesh. This is an integer array of rank two and kind
+        i_def with intent in. The extent of the first dimension is
+        ndf_<function_space> and that of the second is ncell_f. Its
+        default name is 'full_map_'<function_space>.
+
+        If the dofmap is associated with an argument on the coarse
+        mesh then include undf_coarse, the number of unique DoFs for
+        the coarse field. This is an integer of kind i_def with intent
+        in. Its default name is 'undf_'<function_space>. Lastly,
+        include the dofmap for the current cell (column) in the coarse
+        mesh. This is an integer array of rank one, kind i_def``and
+        has intent ``in. Its default name is 'map_'<function_space>.
+
+        :param meta_arg: the metadata capturing the InterGrid argument \
+            required by the kernel.
+        :type meta_arg: \
+        :py:class:`psyclone.domain.lfric.kernel.InterGridArgMetadata`]
+
+        '''
+        function_space = meta_arg.function_space
+        function_space_name = self._function_space_name(function_space)
+        if meta_arg.mesh_arg == "gh_fine":
+            # ndf
+            self._fs_common(function_space)
+            # undf
+            undf_name = self._undf_name(function_space)
+            self._add_arg("NumberOfUniqueDofs", undf_name)
+            # full dofmap
+            self._add_arg("LFRicIntegerScalar", f"full_map_{function_space_name}")
+        else:  # "gh_coarse"
+            # undf + dofmap
+            self._fs_compulsory_field(function_space)
+
+    @classmethod
+    def _basis_or_diff_basis(self, name, function_space):
+        '''Utility function for the basis and diff_basis methods.
+
+        For each operation on the function space (name = ["basis",
+        "diff_basis"]), in the order specified in the metadata, pass
+        real arrays of kind r_def with intent in. For each shape
+        specified in the gh_shape metadata entry:
+
+        If shape is gh_quadrature_* then the arrays are of rank four
+        and have default name
+        "<name>_"<function_space>_<quadrature_arg_name>.
+
+        If shape is gh_quadrature_xyoz then the arrays have extent
+        (dimension, number_of_dofs, np_xy, np_z).
+
+        If shape is gh_quadrature_face or gh_quadrature_edge then the
+        arrays have extent (dimension, number_of_dofs, np_xyz, nfaces
+        or nedges).
+
+        If shape is gh_evaluator then pass one array for each target
+        function space (i.e. as specified by
+        gh_evaluator_targets). Each of these arrays are of rank three
+        with extent (dimension, number_of_dofs,
+        ndf_<target_function_space>). The default name of the argument
+        is <name>"_"<function_space>"_on_"<target_function_space>.
+
+        Here <quadrature_arg_name> is the name of the corresponding
+        quadrature object being passed to the Invoke. dimension is 1
+        or 3 and depends upon the function space and whether or not
+        it is a basis or a differential basis function (see the table
+        below). number_of_dofs is the number of degrees of freedom
+        (DoFs) associated with the function space and np_* are the
+        number of points to be evaluated: i) *_xyz in all directions
+        (3D); ii) *_xy in the horizontal plane (2D); iii) *_x, *_y in
+        the horizontal (1D); and iv) *_z in the vertical (1D). nfaces
+        and nedges are the number of horizontal faces/edges obtained
+        from the appropriate quadrature object supplied to the Invoke.
+
+        Function Type    Dimension    Function Space Name
+
+        Basis               1         W0, W2trace, W2Htrace, W2Vtrace, W3,
+                                      Wtheta, Wchi
+                            3         W1, W2, W2H, W2V, W2broken, ANY_W2
+
+        Differential Basis  1         W2, W2H, W2V, W2broken, ANY_W2
+
+                            3         W0, W1, W2trace, W2Htrace, W2Vtrace,
+                                      W3, Wtheta, Wchi
+
+        :param str name: 'basis' or 'diff_basis'.
+        :param str function_space: the current function space.
+
+        raises InternalError: if unexpected shape metadata is found.
+
+        '''
+        function_space_name = self._function_space_name(function_space)
+        const = LFRicConstants()
+        if not self._metadata.shapes:
+            return
+        for shape in self._metadata.shapes:
+            if shape in const.VALID_QUADRATURE_SHAPES:
+                self._add_arg(
+                    "LFRicIntegerScalar"
+                    f"{name}_{function_space_name}_qr_{shape.split('_')[-1]}")
+            elif shape in const.VALID_EVALUATOR_SHAPES:
+                if self._metadata.evaluator_targets:
+                    target_function_spaces = self._metadata.evaluator_targets
+                else:
+                    # Targets are the function spaces of all modified fields.
+                    fields = [field for field in self._metadata.meta_args
+                              if type(field) in [
+                                      FieldArgMetadata, FieldVectorArgMetadata,
+                                      InterGridArgMetadata,
+                                      InterGridVectorArgMetadata]
+                              and field.access != "gh_read"]
+                    target_function_spaces = []
+                    for field in fields:
+                        if field.function_space not in target_function_spaces:
+                            target_function_spaces.append(field.function_space)
+                for target_function_space in target_function_spaces:
+                    self._add_arg("LFRicIntegerScalar",
+                        f"{name}_{function_space_name}_to_"
+                        f"{target_function_space}")
+            else:
+                raise InternalError(
+                    f"Unexpected shape metadata. Found '{shape}' but expected "
+                    f"one of {const.VALID_EVALUATOR_SHAPES}.")
+
+    @classmethod
+    def _basis(self, function_space):
+        '''Arguments associated with basis functions on the supplied function
+        space.
+
+        :param str function_space: the current function space.
+
+        '''
+        self._basis_or_diff_basis("basis", function_space)
+
+    @classmethod
+    def _diff_basis(self, function_space):
+        '''Arguments associated with differential basis functions on the
+        supplied function space.
+
+        :param str function_space: the current function space.
+
+        '''
+        self._basis_or_diff_basis("diff_basis", function_space)
+
+    @classmethod
+    def _quad_rule(self, shapes):
+        '''Quadrature information is required (gh_shape =
+        gh_quadrature_*). For each shape in the order specified in the
+        gh_shape metadata:
+
+        Include integer, scalar arguments of kind i_def with intent in
+        that specify the extent of the basis/diff-basis arrays:
+
+        If gh_shape is gh_quadrature_XYoZ then pass
+        np_xy_<quadrature_arg_name> and np_z_<quadrature_arg_name>.
+
+        If gh_shape is gh_quadrature_face/_edge then pass
+        nfaces/nedges_<quadrature_arg_name> and
+        np_xyz_<quadrature_arg_name>.
+
+        Include weights which are real arrays of kind r_def:
+
+        If gh_quadrature_XYoZ pass in weights_xz_<quadrature_arg_name>
+        (rank one, extent np_xy_<quadrature_arg_name>) and
+        weights_z_<quadrature_arg_name> (rank one, extent
+        np_z_<quadrature_arg_name>).
+
+        If gh_quadrature_face/_edge pass in
+        weights_xyz_<quadrature_arg_name> (rank two with extents
+        [np_xyz_<quadrature_arg_name>,
+        nfaces/nedges_<quadrature_arg_name>]).
+
+        :param shapes: the metadata capturing the quadrature shapes \
+            required by the kernel.
+        :type shapes: List[str]
+
+        raises InternalError: if unexpected (quadrature) shape \
+            metadata is found.
+
+        '''
+        const = LFRicConstants()
+        for quad in shapes:
+            quad_name = quad.split('_')[-1]
+            if quad == "gh_quadrature_xyoz":
+                self.arg_info.extend([
+                    f"npxy_{quad_name}", f"np_z_{quad_name}",
+                    f"weights_xz_{quad_name}", f"weights_z_{quad_name}"])
+                self._arg_index += 4
+            elif quad == "gh_quadrature_face":
+                self.arg_info.extend([
+                    f"nfaces_{quad_name}", f"np_xyz_{quad_name}",
+                    f"weights_xyz_{quad_name}"])
+                self._arg_index += 3
+            elif quad == "gh_quadrature_edge":
+                self.arg_info.extend([
+                    f"nedges_{quad_name}", f"np_xyz_{quad_name}",
+                    f"weights_xyz_{quad_name}"])
+                self._arg_index += 3
+            else:
+                raise InternalError(
+                    f"Unexpected shape metadata. Found '{quad}' but expected "
+                    f"one of {const.VALID_QUADRATURE_SHAPES}.")
+
+    # pylint: disable=unidiomatic-typecheck
+    @classmethod
+    def _field_bcs_kernel(self):
+        '''Fix for the field boundary condition kernel. Adds a boundary dofs
+        2D integer array with intent in and kind i_def. The size of
+        the dimensions are ndf_<function_space>, 2. Its default name
+        is "boundary_dofs_"<field_name>, where <field_name> is the
+        default name of the field on the current function space.
+
+        :raises InternalError: if the enforce_bc_kernel does not have \
+            a single field argument on the any_space_1 function space.
+
+        '''
+        # Check that this kernel has a single field argument that is
+        # on the any_space_1 function space.
+        if len(self._metadata.meta_args) != 1:
+            raise InternalError(
+                f"An enforce_bc_code kernel should have a single "
+                f"argument but found '{len(self._metadata.meta_args)}'.")
+        meta_arg = self._metadata.meta_args[0]
+        if not type(meta_arg) == FieldArgMetadata:
+            raise InternalError(
+                f"An enforce_bc_code kernel should have a single field "
+                f"argument but found '{type(meta_arg).__name__}'.")
+        if not meta_arg.function_space == "any_space_1":
+            raise InternalError(
+                f"An enforce_bc_code kernel should have a single field "
+                f"argument on the 'any_space_1' function space, but found "
+                f"'{meta_arg.function_space}'.")
+
+        field_name = self._field_name(meta_arg)
+        # 2d integer array
+        print("TO BE ADDED")
+        exit(1)
+        # self._add_arg("xxx", f"boundary_dofs_{field_name}")
+
+    @classmethod
+    def _operator_bcs_kernel(self):
+        '''Fix for the operator boundary condition kernel. Adds a boundary
+        dofs 2D integer array with intent in and kind i_def. The size
+        of the dimensions are ndf_<function_space>, 2. Its default
+        name is "boundary_dofs_"<field_name>, where <field_name> is
+        the default name of the field on the current function space.
+
+        :raises InternalError: if the enforce_operator_bc_kernel does \
+            not have a single lma operator argument.
+
+        '''
+        # Check that this kernel has a single LMA argument.
+        if len(self._metadata.meta_args) != 1:
+            raise InternalError(
+                f"An enforce_operator_bc_code kernel should have a single "
+                f"argument but found '{len(self._metadata.meta_args)}'.")
+        meta_arg = self._metadata.meta_args[0]
+        if not type(meta_arg) == OperatorArgMetadata:
+            raise InternalError(
+                f"An enforce_operator_bc_code kernel should have a single "
+                f"lma operator argument but found "
+                f"'{type(meta_arg).__name__}'.")
+
+        lma_operator_name = self._operator_name(meta_arg)
+        print("TO BE ADDED")
+        exit(1)
+        # self._add_arg("", f"boundary_dofs_{lma_operator_name}")
+
+    @classmethod
+    def _stencil_2d_unknown_extent(self, meta_arg):
+        '''The field entry has a stencil access of type cross2d so add a 1D
+        integer array of extent 4 and kind i_def stencil-size argument
+        with intent in. The default name is
+        <field_name>"_stencil_size", where <field_name> is the default
+        name of the field with this stencil. This will supply the
+        number of cells in each branch of the stencil.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a cross2d stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        # Array
+        print("TO BE DONE")
+        exit(1)
+        # self._add_arg(f"{field_name}_stencil_size")
+
+    @classmethod
+    def _stencil_2d_max_extent(self, meta_arg):
+        '''The field entry has a stencil access of type cross2d so add an
+        integer of kind i_def and intent in for the max branch
+        length. The default name is <field_name>"_max_branch_length",
+        where <field_name> is the default name of the field with this
+        stencil. This is used in defining the dimensions of the
+        stencil dofmap array and is required due to the varying length
+        of the branches of the stencil when used on planar meshes.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a cross2d stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        self._add_arg("LFRicIntegerScalar", f"{field_name}_max_branch_length")
+
+    @classmethod
+    def _stencil_unknown_extent(self, meta_arg):
+        '''The field entry has a stencil access so add an integer stencil-size
+        argument with intent in and kind i_def. The default name is
+        <field_name>"_stencil_size", where <field_name> is the default
+        name of the field with this stencil. This argument will
+        contain the number of cells in the stencil.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        self._add_arg("LFRicIntegerScalar", f"{field_name}_stencil_size")
+
+    @classmethod
+    def _stencil_unknown_direction(self, meta_arg):
+        '''The field entry stencil access is of type XORY1D so add an
+        additional integer direction argument of kind i_def and with
+        intent in, with default name <field_name>"_direction", where
+        <field_name> is the default name of the field with this
+        stencil.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a xory1d stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        self._add_arg("LFRicIntegerScalar", f"{field_name}_direction")
+
+    @classmethod
+    def _stencil_2d(self, meta_arg):
+        '''Stencil information that is passed from the Algorithm layer if the
+        stencil is 'cross2d'. Add a 3D stencil dofmap array of type
+        integer, kind i_def and intent in. The dimensions are
+        (number-of-dofs-in-cell, max-branch-length, 4). The default
+        name is <field_name>"_stencil_dofmap", where <field_name> is
+        the default name of the field with this stencil.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        self._add_arg("LFRicIntegerScalar", f"{field_name}_stencil_dofmap")
+
+    @classmethod
+    def _stencil(self, meta_arg):
+        '''Stencil information that is passed from the Algorithm layer if the
+        stencil is not 'cross2d'. Add a 2D stencil dofmap array of
+        type integer, kind i_def and intent in. The dimensions are
+        (number-of-dofs-in-cell, stencil-size). The default name is
+        <field_name>"_stencil_dofmap, where <field_name> is the
+        default name of the field with this stencil.
+
+        :param meta_arg: the metadata associated with a field argument \
+            with a stencil access.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        '''
+        field_name = self._field_name(meta_arg)
+        print("TO BE DONE")
+        exit(1)
+        # self._add_arg(f"{field_name}_stencil_dofmap")
+
+    @classmethod
+    def _banded_dofmap(self, function_space, cma_operator):
+        '''Adds a banded dofmap for the provided function space and cma
+        operator when there is an assembly cma kernel.
+
+        Include the column-banded dofmap, the list of offsets for the
+        to/from-space. This is an integer array of rank 2 and kind
+        i_def with intent in. The first dimension is
+        "ndf_"<arg_function_space> and the second is nlayers. Its
+        default name is 'cbanded_map_'<function_space>'_'<op_name>
+
+        :param str function_space: the function space for this banded \
+            dofmap.
+        :param cma_operator: the cma operator metadata associated with \
+            this banded dofmap.
+        :type cma_operator: :py:class:`psyclone.domain.lfric.kernel.\
+            ColumnwiseOperatorArgMetadata`
+
+        '''
+        function_space_name = self._function_space_name(function_space)
+        name = self._cma_operator_name(cma_operator)
+        print("TO BE DONE")
+        exit(1)
+        # self._add_arg(f"cbanded_map_{function_space_name}_{name}")
+
+    @classmethod
+    def _indirection_dofmap(self, function_space, cma_operator):
+        '''Adds an indirection dofmap for the provided function space and cma
+        operator when there is an apply cma kernel.
+
+        Include the indirection map for the 'to' function space of the
+        supplied CMA operator. This is a rank-1 integer array of kind
+        i_def and intent in with extent nrow. Its default name is
+        'cma_indirection_map_'<function_space>'_'<operator_name>.
+
+        If the from-space of the operator is not the same as the
+        to-space then include the indirection map for the 'from'
+        function space of the CMA operator. This is a rank-1 integer
+        array of kind i_def and intent in with extent ncol. Its
+        default name is
+        'cma_indirection_map_'<function_space>'_'<operator_name>.
+
+        Note, this method will not be called for the from space if the
+        to and from function spaces are the same so there is no need
+        to explicitly check.
+
+        :param str function_space: the function space for this \
+            indirection dofmap.
+        :param cma_operator: the cma operator metadata associated with \
+            this indirection dofmap.
+        :type cma_operator: :py:class:`psyclone.domain.lfric.kernel.\
+            ColumnwiseOperatorArgMetadata`
+
+        '''
+        function_space_name = self._function_space_name(function_space)
+        name = self._cma_operator_name(cma_operator)
+        
+        print("TO BE DONE")
+        exit(1)        
+        #self._add_arg("",
+        #    f"cma_indirection_map_{function_space_name}_{name}")
+
+    @classmethod
+    def _create_datatype(self, class_name):
+        ''' xxx '''
+        required_class = LFRicTypes(class_name)
+        symbol = required_class()
+        return symbol
+
+    @classmethod
+    def _create_datasymbol(self, class_name, symbol_name, dims=None, access=ArgumentInterface.Access.READ):
+        ''' xxx '''
+        required_class = LFRicTypes(class_name)
+        if dims:
+            symbol = required_class(symbol_name, dims)
+        else:
+            symbol = required_class(symbol_name)
+        symbol.interface = ArgumentInterface(access)
+        return symbol
+
+    @classmethod
+    def _add_symbol(self, symbol):
+        ''' xxx '''
+        self._info.add(symbol)
+        self._info._argument_list.append(symbol)
+        #TODO???
+        #symbol_table.specify_argument_list([arg1])
+
+    @classmethod
+    def _get_or_create_symbol(self, class_name, symbol_name, access=ArgumentInterface.Access.READ):
+        ''' xxx '''
+        try:
+            return self._info.lookup(tag=symbol_name)
+        except:
+            return self._create_datasymbol(class_name, symbol_name, access=access)
+        
+    @classmethod
+    def _add_arg(self, class_name, symbol_name, dims=None, access=ArgumentInterface.Access.READ):
+        '''Utility function to create an LFRic-PSyIR symbol of type class_name
+        and name symbol_name and add it to the symbol table.
+
+        :param str class_name: the name of the class to be created.
+        :param str symbol_name: the name of the symbol to be created.
+
+        '''
+        symbol = self._create_datasymbol(class_name, symbol_name, dims=dims, access=access)
+        self._add_symbol(symbol)
+
+    @classmethod
+    def _field_name(self, meta_arg):
+        '''Utility function providing the default field name from its meta_arg
+        metadata.
+
+        :param meta_arg: metadata describing a field argument.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.FieldArgMetadata`
+
+        :returns: the default name for this meta_arg field.
+        :rtype: str
+
+        '''
+        datatype = meta_arg.datatype[3:4]
+        meta_arg_index = self._metadata.meta_args.index(meta_arg)
+        return f"{datatype}field_{meta_arg_index+1}"
+
+    @classmethod
+    def _operator_name(self, meta_arg):
+        '''Utility function providing the default field name from its meta_arg
+        metadata.
+
+        :param meta_arg: metadata describing an lma operator argument.
+        :type meta_arg: \
+            :py:class:`psyclone.domain.lfric.kernel.OperatorArgMetadata`
+
+        :returns: the default name for this meta_arg field.
+        :rtype: str
+
+        '''
+        meta_arg_index = self._metadata.meta_args.index(meta_arg)
+        return f"op_{meta_arg_index+1}"
+
+    @classmethod
+    def _cma_operator_name(self, meta_arg):
+        '''Utility function providing the default cma operator name from its
+        meta_arg metadata.
+
+        :param meta_arg: metadata describing a cma operator argument.
+        :type meta_arg: :py:class:`psyclone.domain.lfric.kernel.\
+            ColumnwiseOperatorArgMetadata`
+
+        :returns: the default name for this meta_arg cma operator.
+        :rtype: str
+
+        '''
+        meta_arg_index = self._metadata.meta_args.index(meta_arg)
+        return f"cma_op_{meta_arg_index+1}"
+
+    @classmethod
+    def _function_space_name(self, function_space):
+        '''Shortens the function space name if it is any_space_* or
+        any_discontinuous_space_*.
+
+        :param str function_space: the function space name.
+
+        :returns: a shortened function space name.
+        :rtype: str
+
+        '''
+        if "any_space_" in function_space:
+            return f"as_{function_space[10:]}"
+        if "any_discontinuous_space_" in function_space:
+            return f"ads_{function_space[24:]}"
+        return function_space
+
+    @classmethod
+    def _undf_name(self, function_space):
+        ''' xxx '''
+        function_space_name = self._function_space_name(function_space)
+        return f"undf_{function_space_name}"
+
+    @classmethod
+    def _ndf_name(self, function_space):
+        ''' xxx '''
+        function_space_name = self._function_space_name(function_space)
+        return f"ndf_{function_space_name}"
+

--- a/src/psyclone/tests/domain/lfric/formal_kernel_args_from_metadata_test.py
+++ b/src/psyclone/tests/domain/lfric/formal_kernel_args_from_metadata_test.py
@@ -1,0 +1,136 @@
+''' xxx '''
+import pytest
+
+from psyclone.domain.lfric import LFRicTypes
+from psyclone.domain.lfric.formal_kernel_args_from_metadata import (
+    FormalKernelArgsFromMetadata)
+from psyclone.domain.lfric.kernel import (
+    ScalarArgMetadata, FieldArgMetadata, LFRicKernelMetadata,
+    FieldVectorArgMetadata, OperatorArgMetadata, ColumnwiseOperatorArgMetadata)
+
+from psyclone.psyir.symbols import SymbolTable, DataSymbol
+
+
+def call_method(method_name, *args, metadata=None):
+    ''' xxx '''
+    cls = FormalKernelArgsFromMetadata
+    cls._info = SymbolTable()
+    cls._metadata = metadata
+    getattr(cls, method_name)(*args)
+    return cls
+
+def check_single_symbol(method_name, datasymbol_name, symbol_name, *args, metadata=None):
+    ''' xxx '''
+    cls = call_method(method_name, *args, metadata=metadata)
+    lfric_class = LFRicTypes(datasymbol_name)
+    assert isinstance(cls._info.lookup(symbol_name), lfric_class)
+    assert len(cls._info.argument_list) == 1
+
+
+def test_cell_position():
+    ''' Test _cell_position method. '''
+    check_single_symbol("_cell_position", "CellPositionDataSymbol", "cell")
+
+
+def test_mesh_height():
+    ''' Test _mesh_height method. '''
+    check_single_symbol("_mesh_height", "MeshHeightDataSymbol", "nlayers")
+
+
+def test_mesh_ncell2d_no_halos():
+    ''' Test _mesh_ncell2d_no_halos method. '''
+    check_single_symbol("_mesh_ncell2d_no_halos", "LFRicIntegerScalarDataSymbol", "ncell_2d_no_halos")
+
+
+def test_mesh_ncell2d():
+    ''' Test _mesh_ncell2d method. '''
+    check_single_symbol("_mesh_ncell2d", "LFRicIntegerScalarDataSymbol", "ncell_2d")
+
+
+def test_cell_map():
+    ''' Test _cell_map method. '''
+    cls = call_method("_cell_map")
+    lfric_class = LFRicTypes("LFRicIntegerScalarDataSymbol")
+    assert isinstance(cls._info.lookup("cell_map"), DataSymbol)
+    assert isinstance(cls._info.lookup("ncell_f_per_c_x"), lfric_class)
+    assert isinstance(cls._info.lookup("ncell_f_per_c_y"), lfric_class)
+    assert isinstance(cls._info.lookup("ncell_f"), lfric_class)
+    assert len(cls._info.argument_list) == 4
+
+
+def test_scalar():
+    ''' Test _scalar method. '''
+    # At least one field arg is required for the metadata to be valid
+    # even though we only want to test the scalar metadata.
+    field_meta_arg = FieldArgMetadata("GH_REAL", "GH_WRITE", "W3")
+    scalar_meta_arg = ScalarArgMetadata("GH_REAL", "GH_READ")
+    metadata = LFRicKernelMetadata(operates_on="cell_column", meta_args=[field_meta_arg, scalar_meta_arg])
+    metadata.validate()
+    check_single_symbol("_scalar", "LFRicRealScalarDataSymbol", "rscalar_2", scalar_meta_arg, metadata=metadata)
+
+
+def test_field():
+    ''' Test _field method. '''
+    field_meta_arg = FieldArgMetadata("GH_REAL", "GH_WRITE", "W3")
+    metadata = LFRicKernelMetadata(operates_on="cell_column", meta_args=[field_meta_arg])
+    metadata.validate()
+    check_single_symbol("_field", "RealFieldDataSymbol", "rfield_1", field_meta_arg, metadata=metadata)
+
+
+def test_field_vector():
+    ''' Test _field_vector method. '''
+    field_meta_arg = FieldVectorArgMetadata("GH_REAL", "GH_WRITE", "W3", "3")
+    metadata = LFRicKernelMetadata(operates_on="cell_column", meta_args=[field_meta_arg])
+    metadata.validate()
+    cls = call_method("_field_vector", field_meta_arg, metadata=metadata)
+    lfric_class = LFRicTypes("RealFieldDataSymbol")
+    assert isinstance(cls._info.lookup("rfield_1_v1"), lfric_class)
+    assert isinstance(cls._info.lookup("rfield_1_v2"), lfric_class)
+    assert isinstance(cls._info.lookup("rfield_1_v3"), lfric_class)
+    assert len(cls._info.argument_list) == 3
+
+
+def test_operator():
+    ''' Test _operator method. '''
+    operator_meta_arg = OperatorArgMetadata("GH_REAL", "GH_WRITE", "W3", "W2")
+    metadata = LFRicKernelMetadata(operates_on="cell_column", meta_args=[operator_meta_arg])
+    metadata.validate()
+    cls = call_method("_operator", operator_meta_arg, metadata=metadata)
+    lfric_class = LFRicTypes("LFRicIntegerScalarDataSymbol")
+    assert isinstance(cls._info.lookup("op_1_ncell_3d"), lfric_class)
+    lfric_class = LFRicTypes("OperatorDataSymbol")
+    assert isinstance(cls._info.lookup("op_1"), lfric_class)
+    assert len(cls._info.argument_list) == 2
+
+
+def check_common_cma_symbols(fs1, fs2):
+    ''' xxx '''
+    operator_meta_arg = ColumnwiseOperatorArgMetadata("GH_REAL", "GH_WRITE", fs1, fs2)
+    metadata = LFRicKernelMetadata(operates_on="cell_column", meta_args=[operator_meta_arg])
+    metadata.validate()
+    cls = call_method("_cma_operator", operator_meta_arg, metadata=metadata)
+    lfric_class = LFRicTypes("OperatorDataSymbol")
+    assert isinstance(cls._info.lookup("cma_op_1"), lfric_class)
+    lfric_class = LFRicTypes("LFRicIntegerScalarDataSymbol")
+    assert isinstance(cls._info.lookup("nrow_cma_op_1"), lfric_class)
+    assert isinstance(cls._info.lookup("bandwidth_cma_op_1"), lfric_class)
+    assert isinstance(cls._info.lookup("alpha_cma_op_1"), lfric_class)
+    assert isinstance(cls._info.lookup("beta_cma_op_1"), lfric_class)
+    assert isinstance(cls._info.lookup("gamma_m_cma_op_1"), lfric_class)
+    assert isinstance(cls._info.lookup("gamma_p_cma_op_1"), lfric_class)
+    return cls
+
+
+def test_cma_operator():
+    ''' Test _cma_operator method. '''
+    # to/from function spaces differ
+    cls = check_common_cma_symbols("W3", "W2")
+    lfric_class = LFRicTypes("LFRicIntegerScalarDataSymbol")
+    assert isinstance(cls._info.lookup("ncol_cma_op_1"), lfric_class)
+    assert len(cls._info.argument_list) == 8
+
+    # to/from function spaces are the same
+    cls = check_common_cma_symbols("W3", "W3")
+    with pytest.raises(KeyError):
+        cls._info.lookup("ncol_cma_op_1")
+    assert len(cls._info.argument_list) == 7


### PR DESCRIPTION
This PR creates a subclass of the new `metadata_to_argument_rules.py` base class being implemented in PR #2048. This new subclass will create LFRic PSyIR kernel arguments. This is similar to the existing partial implementation in `kernel_interface.py` but uses the new metadata and will be complete, so will replace this code. It will also replace the existing `kern_stub_arg_list.py` which uses the old style string arguments and the old style metadata and is used when generating kernel stub code. Once complete this new class can then be used to generate kernel stub code by replacing the existing implementation in  `gen_kernel_stub.py`.