### PR TITLE
WIP #2091: splitting off and renaming DynKernCallFactory

### DIFF
--- a/src/psyclone/domain/lfric/__init__.py
+++ b/src/psyclone/domain/lfric/__init__.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Author J. Henrichs, Bureau of Meteorology
-# Modified: I. Kavcic, Met Office
+# Modified: I. Kavcic and L. Turner, Met Office
 #           R. W. Ford and A. R. Porter, STFC Daresbury Lab
 
 '''Module for the LFRic domain.
@@ -56,6 +56,7 @@ from psyclone.domain.lfric.lfric_extract_driver_creator import \
 from psyclone.domain.lfric.lfric_symbol_table import LFRicSymbolTable
 from psyclone.domain.lfric.lfric_types import LFRicTypes
 from psyclone.domain.lfric.kern_stub_arg_list import KernStubArgList
+from psyclone.domain.lfric.lfric_kern_call_factory import LFRicKernCallFactory
 
 __all__ = [
     'ArgOrdering',

--- a/src/psyclone/domain/lfric/lfric_kern_call_factory.py
+++ b/src/psyclone/domain/lfric/lfric_kern_call_factory.py
@@ -1,0 +1,99 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2017-2023, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
+# Modified I. Kavcic, A. Coughtrie and L. Turner, Met Office
+# Modified J. Henrichs, Bureau of Meteorology
+# Modified A. B. G. Chalk and N. Nobre, STFC Daresbury Lab
+
+''' This module implements the PSyclone Dynamo 0.3 API by 1)
+    specialising the required base classes in parser.py (KernelType) and
+    adding a new class (DynFuncDescriptor03) to capture function descriptor
+    metadata and 2) specialising the required base classes in psyGen.py
+    (PSy, Invokes, Invoke, InvokeSchedule, Loop, Kern, Inf, Arguments and
+    Argument). '''
+
+# Imports
+
+class LFRicKernCallFactory():
+    ''' Create the necessary framework for a Dynamo kernel call.
+    This consists of a Loop over cells containing a call to the
+    user-supplied kernel routine.
+
+    '''
+    # pylint: disable=too-few-public-methods
+    @staticmethod
+    def create(call, parent=None):
+        '''
+        Create the objects needed for a call to the kernel
+        described in the call object.
+
+        :param call: information on the kernel call as obtained from the \
+                     Algorithm layer.
+        :type call: :py:class:`psyclone.parse.algorithm.KernelCall`
+        :param parent: the parent of this kernel call in the PSyIR.
+        :type parent: :py:class:`psyclone.psyir.nodes.Schedule`
+
+        '''
+        if call.ktype.iterates_over == "domain":
+            # Kernel operates on whole domain so there is no loop.
+            # We still need a loop object though as that is where the logic
+            # for handling halo exchanges is currently implemented.
+            loop_type = "null"
+        else:
+            # Loop over cells, indicated by an empty string.
+            loop_type = ""
+        # Import here to avoid circular dependency
+        # pylint: disable=import-outside-toplevel
+        from psyclone.dynamo0p3 import DynLoop
+        cloop = DynLoop(parent=parent, loop_type=loop_type)
+
+        # The kernel itself
+        # Import here to avoid circular dependency
+        # pylint: disable=import-outside-toplevel
+        from psyclone.dynamo0p3 import DynKern
+        kern = DynKern()
+        kern.load(call, cloop.loop_body)
+
+        # Add the kernel as a child of the loop
+        cloop.loop_body.addchild(kern)
+
+        # Set-up the loop now we have the kernel object
+        cloop.load(kern)
+        return cloop
+
+
+# ---------- Documentation utils -------------------------------------------- #
+# The list of module members that we wish AutoAPI to generate
+# documentation for. (See https://psyclone-ref.readthedocs.io)
+__all__ = ['LFRicKernCallFactory']

--- a/src/psyclone/dynamo0p3.py
+++ b/src/psyclone/dynamo0p3.py
@@ -32,7 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
-# Modified I. Kavcic and A. Coughtrie, Met Office
+# Modified I. Kavcic, A. Coughtrie and L. Turner, Met Office
 # Modified J. Henrichs, Bureau of Meteorology
 # Modified A. B. G. Chalk and N. Nobre, STFC Daresbury Lab
 
@@ -60,7 +60,8 @@ from psyclone.domain.common.psylayer import PSyLoop
 from psyclone.domain.lfric import (FunctionSpace, KernCallAccArgList,
                                    KernCallArgList, KernStubArgList,
                                    LFRicArgDescriptor, KernelInterface,
-                                   LFRicConstants, LFRicSymbolTable)
+                                   LFRicConstants, LFRicSymbolTable,
+                                   LFRicKernCallFactory)
 from psyclone.errors import GenerationError, InternalError, FieldNotFoundError
 from psyclone.f2pygen import (AllocateGen, AssignGen, CallGen, CommentGen,
                               DeallocateGen, DeclGen, DoGen, IfThenGen,
@@ -5836,7 +5837,7 @@ class DynInvokeSchedule(InvokeSchedule):
     '''
 
     def __init__(self, name, arg, reserved_names=None, parent=None):
-        super().__init__(name, DynKernCallFactory,
+        super().__init__(name, LFRicKernCallFactory,
                          LFRicBuiltInCallFactory, arg, reserved_names,
                          parent=parent, symbol_table=LFRicSymbolTable())
 
@@ -10130,48 +10131,6 @@ class DynKernelArgument(KernelArgument):
             f"'{str(self)}' is not a scalar, field or operator argument")
 
 
-class DynKernCallFactory():
-    ''' Create the necessary framework for a Dynamo kernel call.
-    This consists of a Loop over cells containing a call to the
-    user-supplied kernel routine.
-
-    '''
-    # pylint: disable=too-few-public-methods
-    @staticmethod
-    def create(call, parent=None):
-        '''
-        Create the objects needed for a call to the kernel
-        described in the call object.
-
-        :param call: information on the kernel call as obtained from the \
-                     Algorithm layer.
-        :type call: :py:class:`psyclone.parse.algorithm.KernelCall`
-        :param parent: the parent of this kernel call in the PSyIR.
-        :type parent: :py:class:`psyclone.psyir.nodes.Schedule`
-
-        '''
-        if call.ktype.iterates_over == "domain":
-            # Kernel operates on whole domain so there is no loop.
-            # We still need a loop object though as that is where the logic
-            # for handling halo exchanges is currently implemented.
-            loop_type = "null"
-        else:
-            # Loop over cells, indicated by an empty string.
-            loop_type = ""
-        cloop = DynLoop(parent=parent, loop_type=loop_type)
-
-        # The kernel itself
-        kern = DynKern()
-        kern.load(call, cloop.loop_body)
-
-        # Add the kernel as a child of the loop
-        cloop.loop_body.addchild(kern)
-
-        # Set-up the loop now we have the kernel object
-        cloop.load(kern)
-        return cloop
-
-
 class DynACCEnterDataDirective(ACCEnterDataDirective):
     '''
     Sub-classes ACCEnterDataDirective to provide an API-specific implementation
@@ -10225,5 +10184,4 @@ __all__ = [
     'DynStencil',
     'DynKernelArguments',
     'DynKernelArgument',
-    'DynKernCallFactory',
     'DynACCEnterDataDirective']

--- a/src/psyclone/psyGen.py
+++ b/src/psyclone/psyGen.py
@@ -674,7 +674,7 @@ class InvokeSchedule(Routine):
 
     :param str name: name of the Invoke.
     :param type KernFactory: class instance of the factory to use when \
-     creating Kernels. e.g. :py:class:`psyclone.dynamo0p3.DynKernCallFactory`.
+     creating Kernels. e.g. :py:class:`psyclone.domain.lfric.LFRicKernCallFactory`.
     :param type BuiltInFactory: class instance of the factory to use when \
      creating built-ins. e.g. \
      :py:class:`psyclone.domain.lfric.lfric_builtins.LFRicBuiltInCallFactory`.


### PR DESCRIPTION
Chased the circular dependencies a couple of levels down to find a relatively short section I could try separating out and importing so as to avoid any circular dependencies 