### PR TITLE
Support renamed imported symbols in the PSyIR (towards #1618)

### DIFF
--- a/src/psyclone/psyir/backend/fortran.py
+++ b/src/psyclone/psyir/backend/fortran.py
@@ -518,8 +518,12 @@ class FortranWriter(LanguageWriter):
                 f"SymbolTable.")
 
         # Construct the list of symbol names for the ONLY clause
-        only_list = [dsym.name for dsym in
-                     symbol_table.symbols_imported_from(symbol)]
+        only_list = []
+        for dsym in symbol_table.symbols_imported_from(symbol):
+            if dsym.interface.orig_name:
+                only_list.append(f"{dsym.name}=>{dsym.interface.orig_name}")
+            else:
+                only_list.append(dsym.name)
 
         # Finally construct the use statements for this Container (module)
         if not only_list and not symbol.wildcard_import:

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -1562,7 +1562,12 @@ class Fparser2Reader():
                     # will replace a previous import with an empty only-list.
                     pass
                 for name in decl.items[4].items:
-                    sym_name = str(name).lower()
+                    if isinstance(name, Fortran2003.Rename):
+                        sym_name = str(name.children[1]).lower()
+                        orig_name = str(name.children[2]).lower()
+                    else:
+                        sym_name = str(name).lower()
+                        orig_name = None
                     sym_visibility = visibility_map.get(
                         sym_name,  parent.symbol_table.default_visibility)
                     if sym_name not in parent.symbol_table:
@@ -1573,7 +1578,8 @@ class Fparser2Reader():
                         # the type of this symbol we create a generic Symbol.
                         parent.symbol_table.add(
                             Symbol(sym_name, visibility=sym_visibility,
-                                   interface=ImportInterface(container)))
+                                   interface=ImportInterface(
+                                       container, orig_name=orig_name)))
                     else:
                         # There's already a symbol with this name
                         existing_symbol = parent.symbol_table.lookup(

--- a/src/psyclone/psyir/symbols/interfaces.py
+++ b/src/psyclone/psyir/symbols/interfaces.py
@@ -113,10 +113,23 @@ class ImportInterface(SymbolInterface):
 
 
     '''
-    def __init__(self, container_symbol):
+    def __init__(self, container_symbol, orig_name=None):
         super().__init__()
+        if not isinstance(orig_name, (str, type(None))):
+            raise TypeError(
+                f"ImportInterface orig_name parameter must be of type "
+                f"str or None, but found '{type(orig_name).__name__}'.")
+        self._orig_name = orig_name
         # Use error-checking setter
         self.container_symbol = container_symbol
+
+    @property
+    def orig_name(self):
+        '''
+        :returns: the symbol's original name if it has been renamed.
+        :rtype: Optional[str]
+        '''
+        return self._orig_name
 
     @property
     def container_symbol(self):
@@ -148,14 +161,18 @@ class ImportInterface(SymbolInterface):
         self._container_symbol = value
 
     def __str__(self):
-        return f"Import(container='{self.container_symbol.name}')"
+        orig_name_str = ""
+        if self.orig_name:
+            orig_name_str = f", orig_name='{self.orig_name}'"
+        return (f"Import(container='{self.container_symbol.name}"
+                f"'{orig_name_str})")
 
     def copy(self):
         '''
         :returns: a copy of this object.
         :rtype: :py:class:`psyclone.psyir.symbol.SymbolInterface`
         '''
-        return self.__class__(self.container_symbol)
+        return self.__class__(self.container_symbol, orig_name=self.orig_name)
 
 
 class ArgumentInterface(SymbolInterface):


### PR DESCRIPTION
Adds support for renamed imported symbols in the PSyIR. For example `use my_mod, only : new_name=>name`