### PR TITLE
(Closes #2224) configure linkcheck to ignore problematic anchor

### DIFF
--- a/changelog
+++ b/changelog
@@ -512,6 +512,9 @@
 	173) PR #2221 for #2214. Fix names of invokes containing a single
 	kernel in the PSyIR of the LFRic Alg layer.
 
+	174) PR #2225 for #2224. Fix erroneous CI link check error by
+	omitting test for the particular link.
+
 release 2.3.1 17th of June 2022
 
 	1) PR #1747 for #1720. Adds support for If blocks to PSyAD.

--- a/doc/user_guide/conf.py
+++ b/doc/user_guide/conf.py
@@ -365,6 +365,10 @@ epub_copyright = copyright
 # -- Options for linkcheck -------------------------------------------------
 
 linkcheck_anchors = True
+# We need to ignore this anchor (used a couple of times in examples.rst)
+# because it seems that GitHub's JavaScript-generated page defeats the
+# link checker.
+linkcheck_anchors_ignore = ['user-content-netcdf-library-lfric-examples']
 
 # MyBinder fails on a very regular basis so we skip those links.
 # The puma site no longer exists but the GOcean documentation needs to be


### PR DESCRIPTION
'Fixes' the recent linkcheck problem by ignoring the specific anchor.