### PR TITLE
Tweak PSyclone's OpenACC example script for NEMO

### DIFF
--- a/changelog
+++ b/changelog
@@ -538,6 +538,9 @@
 	consider that UnresolvedInterface symbols can come from the body of
 	a Fortran Interface.
 
+	182) PR #2240 for #2234. Fix WhileLoop issue in the NEMO OpenACC kernels
+	script.
+
 release 2.3.1 17th of June 2022
 
 	1) PR #1747 for #1720. Adds support for If blocks to PSyAD.

--- a/examples/nemo/scripts/kernels_trans.py
+++ b/examples/nemo/scripts/kernels_trans.py
@@ -54,7 +54,7 @@ region is found to contain such a node (by the ``valid_acc_kernel``
 routine) then the script moves a level down the tree and then repeats
 the process of attempting to create the largest possible Kernel region.
 
-Tested with the NVIDIA HPC SDK version 22.5.
+Tested with the NVIDIA HPC SDK version 23.7.
 '''
 
 import logging
@@ -63,7 +63,7 @@ from psyclone.errors import InternalError
 from psyclone.nemo import NemoInvokeSchedule, NemoKern, NemoLoop
 from psyclone.psyGen import TransInfo
 from psyclone.psyir.nodes import IfBlock, CodeBlock, Schedule, \
-    ArrayReference, Assignment, BinaryOperation, Loop, \
+    ArrayReference, Assignment, BinaryOperation, Loop, WhileLoop, \
     Literal, Return, Call, ACCLoopDirective
 from psyclone.psyir.transformations import TransformationError, ProfileTrans, \
                                            ACCUpdateTrans
@@ -184,11 +184,11 @@ def valid_acc_kernel(node):
 
     # Rather than walk the tree multiple times, look for both excluded node
     # types and possibly problematic operations
-    excluded_node_types = (CodeBlock, Return, Call, IfBlock, NemoLoop)
-    excluded_nodes = node.walk(excluded_node_types)
+    excluded_types = (CodeBlock, Return, Call, IfBlock, NemoLoop, WhileLoop)
+    excluded_nodes = node.walk(excluded_types)
 
     for enode in excluded_nodes:
-        if isinstance(enode, (CodeBlock, Return, Call)):
+        if isinstance(enode, (CodeBlock, Return, Call, WhileLoop)):
             log_msg(routine_name,
                     f"region contains {type(enode).__name__}", enode)
             return False


### PR DESCRIPTION
Hey,

Since implementing `do while` loops in PSyclone, I don't think I ever tested the example script on the MetOffice's code - bad Nuno 👎 - and we were now hitting a new compiler error which this patch avoids.

Cheers,
Nuno