### PR TITLE
2297 option for original name in variables access

### DIFF
--- a/doc/developer_guide/dependency.rst
+++ b/doc/developer_guide/dependency.rst
@@ -338,6 +338,15 @@ constructor can be used: add the key
 In this case all arrays specified as first parameter to one of the
 PSyIR operators above will be reported as read access.
 
+Fortran also allows to rename a symbol locally when it is being imported,
+(`use some_mod, only: renamed => original_name`). Depending on use case,
+it might be useful to get the non-local, original name. By default,
+`VariablesAccessInfo` will report the local name (i.e. the renamed name),
+but if you add the key `USE-ORIGINAL-NAMES` and set it to True::
+
+    vai = VariablesAccessInfo(options={'USE-ORIGINAL-NAMES': True})
+
+the original name will be returned in the `VariablesAccessInfo` object.
 
 SingleVariableAccessInfo
 ------------------------

--- a/src/psyclone/core/variables_access_info.py
+++ b/src/psyclone/core/variables_access_info.py
@@ -64,9 +64,13 @@ class VariablesAccessInfo(dict):
         to a True value, arrays used as first parameter to the PSyIR query \
         operators lbound, ubound, or size will be reported as 'read'.
         Otherwise, these accesses will be ignored.
+    :param Any options["USE-ORIGINAL-NAMES"]: if this option is set to a \
+        True value, an imported symbol that is renamed (``use mod, a=>b``)
+        will be reported using the original name (``b`` in the example).
+        Otherwise these symbols will be reported using the renamed name
+        (``a``).
 
     '''
-
     # List of valid options and their default values. Note that only the
     # options method checks this, since it is convenient to pass in options
     # from the DependencyTools that might contain options for these tools.

--- a/src/psyclone/core/variables_access_info.py
+++ b/src/psyclone/core/variables_access_info.py
@@ -67,25 +67,31 @@ class VariablesAccessInfo(dict):
 
     '''
 
-    # List of valid options. Note that only the options method checks this,
-    # since it is convenient to pass in options from the DependencyTools
-    # that might contain options for these tools.
-    _VALID_OPTIONS = ["COLLECT-ARRAY-SHAPE-READS"]
+    # List of valid options and their default values. Note that only the
+    # options method checks this, since it is convenient to pass in options
+    # from the DependencyTools that might contain options for these tools.
+    # COLLECT-ARRAY-SHAPE-READS: controls if access to the shape of an array
+    #     (e.g. ``ubound(a)`` are reported as read or not at all. Defaults
+    #     to True.
+    # USE-ORIGINAL-NAMES: if set this will report the original names of any
+    #     symbol that is being renamed (``use mod, renamed_a=>a``). Defaults
+    #     to False.
+    _DEFAULT_OPTIONS = {"COLLECT-ARRAY-SHAPE-READS": False,
+                        "USE-ORIGINAL-NAMES": False}
 
     def __init__(self, nodes=None, options=None):
         # This dictionary stores the mapping of signatures to the
         # corresponding SingleVariableAccessInfo instance.
         dict.__init__(self)
 
+        self._options = VariablesAccessInfo._DEFAULT_OPTIONS.copy()
         if options:
             if not isinstance(options, dict):
                 raise InternalError(f"The options argument for "
                                     f"VariablesAccessInfo must be a "
                                     f"dictionary or None, but got "
                                     f"'{type(options).__name__}'.")
-            self._options = options.copy()
-        else:
-            self._options = {}
+            self._options.update(options)
 
         # Stores the current location information
         self._location = 0
@@ -161,11 +167,11 @@ class VariablesAccessInfo(dict):
 
         '''
         if key:
-            if key not in VariablesAccessInfo._VALID_OPTIONS:
+            if key not in VariablesAccessInfo._DEFAULT_OPTIONS:
+                valids = list(VariablesAccessInfo._DEFAULT_OPTIONS.keys())
+                valids.sort()
                 raise InternalError(f"Option key '{key}' is invalid, it "
-                                    f"must be one of "
-                                    f"{VariablesAccessInfo._VALID_OPTIONS}"
-                                    f".")
+                                    f"must be one of {valids}.")
             return self._options.get(key, None)
         return self._options
 

--- a/src/psyclone/psyir/nodes/reference.py
+++ b/src/psyclone/psyir/nodes/reference.py
@@ -42,7 +42,7 @@
 from psyclone.core import AccessType, Signature
 # We cannot import from 'nodes' directly due to circular import
 from psyclone.psyir.nodes.datanode import DataNode
-from psyclone.psyir.symbols import Symbol
+from psyclone.psyir.symbols import ImportInterface, Symbol
 from psyclone.psyir.symbols.datatypes import DeferredType
 
 
@@ -172,6 +172,10 @@ class Reference(DataNode):
 
         '''
         sig, all_indices = self.get_signature_and_indices()
+        if isinstance(self.symbol.interface, ImportInterface) and \
+                var_accesses.options("USE-ORIGINAL-NAMES") and \
+                self.symbol.interface.orig_name:
+            sig = Signature(self.symbol.interface.orig_name, sig[1:])
         for indices in all_indices:
             for index in indices:
                 index.reference_accesses(var_accesses)

--- a/src/psyclone/tests/core/variables_access_info_test.py
+++ b/src/psyclone/tests/core/variables_access_info_test.py
@@ -387,14 +387,27 @@ def test_symbol_array_detection(fortran_reader):
 def test_variables_access_info_options():
     '''Test handling of options for VariablesAccessInfo.
     '''
-    vai = VariablesAccessInfo(options={'COLLECT-ARRAY-SHAPE-READS': True})
+    vai = VariablesAccessInfo()
+    assert vai.options("COLLECT-ARRAY-SHAPE-READS") is False
+    assert vai.options("USE-ORIGINAL-NAMES") is False
 
+    vai = VariablesAccessInfo(options={'COLLECT-ARRAY-SHAPE-READS': True})
     assert vai.options("COLLECT-ARRAY-SHAPE-READS") is True
-    assert vai.options() == {'COLLECT-ARRAY-SHAPE-READS': True}
+    assert vai.options("USE-ORIGINAL-NAMES") is False
+    assert vai.options() == {"COLLECT-ARRAY-SHAPE-READS": True,
+                             "USE-ORIGINAL-NAMES": False}
+
+    vai = VariablesAccessInfo(options={'USE-ORIGINAL-NAMES': True})
+    assert vai.options("COLLECT-ARRAY-SHAPE-READS") is False
+    assert vai.options("USE-ORIGINAL-NAMES") is True
+    assert vai.options() == {"COLLECT-ARRAY-SHAPE-READS": False,
+                             "USE-ORIGINAL-NAMES": True}
+
     with pytest.raises(InternalError) as err:
         vai.options("invalid")
     assert ("Option key 'invalid' is invalid, it must be one of "
-            "['COLLECT-ARRAY-SHAPE-READS']." in str(err.value))
+            "['COLLECT-ARRAY-SHAPE-READS', 'USE-ORIGINAL-NAMES']."
+            in str(err.value))
 
 
 # -----------------------------------------------------------------------------

--- a/src/psyclone/tests/psyir/nodes/reference_test.py
+++ b/src/psyclone/tests/psyir/nodes/reference_test.py
@@ -45,7 +45,8 @@ from psyclone.core import VariablesAccessInfo
 from psyclone.psyGen import GenerationError
 from psyclone.psyir.nodes import (ArrayReference, Assignment, colored,
                                   KernelSchedule, Literal, Reference)
-from psyclone.psyir.symbols import (ArrayType, DataSymbol, DeferredType,
+from psyclone.psyir.symbols import (ArrayType, ContainerSymbol, DataSymbol,
+                                    DeferredType, ImportInterface,
                                     INTEGER_SINGLE_TYPE, REAL_SINGLE_TYPE,
                                     REAL_TYPE, ScalarType, Symbol,
                                     UnresolvedInterface)
@@ -181,6 +182,20 @@ def test_reference_accesses():
     var_access_info = VariablesAccessInfo()
     array.reference_accesses(var_access_info)
     assert str(var_access_info) == "i: READ, temp: READ"
+
+    # Test that renaming an imported reference is handled
+    # correctly by the access info code:
+    symbol = Symbol('renamed_name')
+    symbol.interface = ImportInterface(ContainerSymbol("my_mod"),
+                                       orig_name="orig_name")
+    reference.symbol = symbol
+    var_access_info = VariablesAccessInfo()
+    reference.reference_accesses(var_access_info)
+    assert "renamed_name: READ" in str(var_access_info)
+
+    var_access_info = VariablesAccessInfo(options={"USE-ORIGINAL-NAMES": True})
+    reference.reference_accesses(var_access_info)
+    assert "orig_name: READ" in str(var_access_info)
 
 
 def test_reference_can_be_copied():


### PR DESCRIPTION
A small PR that is part of #1990 (kernel extraction with non-local variables). It introduces an option to VariableAccessInfo to return the original name of a renamed (`use some_mod, a=>b`) variable name. 
It is not actually used, though should already be fully covered in the tests.