### PR TITLE
(Closes #1558) support out-of-order parameter statements

### DIFF
--- a/changelog
+++ b/changelog
@@ -592,6 +592,8 @@
 
 	199) PR #2293 for #2301. Add 'is_independent' property/query to Loop.
 
+	200) PR #2309 for #1558. Add support for out-of-order parameter statements.
+
 release 2.3.1 17th of June 2022
 
 	1) PR #1747 for #1720. Adds support for If blocks to PSyAD.


### PR DESCRIPTION
This PR simply moves the existing functionality for processing PARAMETER statements into a separate routine which can then be called once all the variable declarations have been processed.