### PR TITLE
Add `Node.siblings` property

### DIFF
--- a/src/psyclone/psyir/nodes/node.py
+++ b/src/psyclone/psyir/nodes/node.py
@@ -35,6 +35,7 @@
 #         I. Kavcic, Met Office
 #         J. Henrichs, Bureau of Meteorology
 # Modified A. B. G. Chalk, STFC Daresbury Lab
+# Modified J. G. Wallwork, Met Office
 # -----------------------------------------------------------------------------
 
 '''
@@ -955,6 +956,14 @@ class Node():
         :rtype: :py:class:`psyclone.psyir.nodes.Node` or NoneType
         '''
         return self._parent
+
+    @property
+    def siblings(self):
+        '''
+        :returns: list of sibling nodes, including self.
+        :rtype: List[:py:class:`psyclone.psyir.nodes.Node`]
+        '''
+        return self.parent.children
 
     @property
     def has_constructor_parent(self):


### PR DESCRIPTION
Closes #2369.

A simple addition to determine a node's siblings, i.e., parent's children. I implemented it as a property, for consistency with `children` and `parent`. However, it does mean that the siblings include the node itself. Maybe this is fine.