### PR TITLE
Add a transformation that uses LLM (OpenAI) to modify the code

### DIFF
--- a/src/psyclone/psyir/transformations/__init__.py
+++ b/src/psyclone/psyir/transformations/__init__.py
@@ -76,6 +76,7 @@ from psyclone.psyir.transformations.intrinsics.sign2code_trans import \
     Sign2CodeTrans
 from psyclone.psyir.transformations.intrinsics.sum2loop_trans import \
     Sum2LoopTrans
+from psyclone.psyir.transformations.llm_trans import LLMTrans
 from psyclone.psyir.transformations.loop_fuse_trans import LoopFuseTrans
 from psyclone.psyir.transformations.loop_swap_trans import LoopSwapTrans
 from psyclone.psyir.transformations.loop_tiling_2d_trans \
@@ -118,6 +119,7 @@ __all__ = ['ACCUpdateTrans',
            'Min2CodeTrans',
            'Sign2CodeTrans',
            'Sum2LoopTrans',
+           'LLMTrans',
            'LoopFuseTrans',
            'LoopSwapTrans',
            'LoopTiling2DTrans',

--- a/src/psyclone/psyir/transformations/llm_trans.py
+++ b/src/psyclone/psyir/transformations/llm_trans.py
@@ -1,0 +1,90 @@
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2023, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors: S. Siso, STFC Daresbury Lab
+
+'''This module contains the LLMTrans '''
+
+import os
+from openai import OpenAI
+from psyclone.psyGen import Transformation
+from psyclone.psyir.transformations.transformation_error \
+    import TransformationError
+from psyclone.psyir.frontend.fortran import FortranReader
+from psyclone.psyir.nodes import ScopingNode
+
+
+class LLMTrans(Transformation):
+    ''' Requests a transformation to ChatGPT '''
+
+    def apply(self, node, options=None):
+        '''Apply the LLMTrans transformation.
+
+        :param node: node to which to apply the transformation.
+        :type node: :py:class:`psyclone.psyir.nodes.Node`
+        :param options: a dictionary with the transformations options.
+        :type options: Optional[Dict[str, Any]]
+        :param bool options["prompt"]: the prompt to provide to the LLM.
+
+        '''
+        if not options:
+            options = {}
+        if 'prompt' not in options:
+            raise TransformationError("Needs a prompt")
+        prompt = options['prompt']
+
+        client = OpenAI()
+        suggestion = client.chat.completions.create(
+            messages=[
+                {
+                    "role": "user",
+                    "content": f"""
+                    ```fortran
+                       {node.debug_string()}
+                    ```
+                    Given the Fortran code above, rewrite it into a valid Fortran
+                    code but {prompt}:
+                    """,
+                }
+            ],
+            model="gpt-3.5-turbo",
+        )
+        print("Output", suggestion)
+        output = node.debug_string()
+        print("Output", output)
+        reader = FortranReader()
+        psyir = reader.psyir_from_statement(output, node.ancestor(ScopingNode).symbol_table)
+        node.replace_with(psyir)
+
+# For Sphinx AutoAPI documentation generation
+__all__ = ["LLMTrans"]

--- a/src/psyclone/tests/psyir/transformations/llm_trans.py
+++ b/src/psyclone/tests/psyir/transformations/llm_trans.py
@@ -1,0 +1,47 @@
+
+# -----------------------------------------------------------------------------
+# BSD 3-Clause License
+#
+# Copyright (c) 2024, Science and Technology Facilities Council.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of the copyright holder nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+# -----------------------------------------------------------------------------
+# Authors: S. Siso, STFC Daresbury Lab
+
+'''This module contains the tests for LLMTrans '''
+ 
+import pytest
+
+from psyclone.psyir.transformations import LLMTrans
+
+def test_validate_not_installed():
+    '''
+    TODO
+
+    '''


### PR DESCRIPTION
The transformation is quite simple, it essentially:
1. outputs the provided node in Fortran
2. sends it to OpenAI with a text prompt (currently to the paid model -needs a Key- as the free tier does not provide very good results)
3. uses the reader to convert the suggested code to psyir
4. If everything succeeded replaces the old node with the new one

For some experiments I did, using `r = matmul(a, b)` as starting code.

When I do:
`llm.apply(statement, options={"prompt": "inline the Fortran intrinsics"})`
I get:
```fortran
do i = 1, SIZE(a, DIM=1), 1
  do j = 1, SIZE(b, DIM=2), 1
	r(i,j) = SUM(a(i,:) * b(:,j))
  enddo
enddo
```

If then I do:
`llm.apply(statement, options={"prompt": "add loop tiling"})`
I get:
```fortran
do ii = 1, SIZE(a, 1), blocksize
  do jj = 1, SIZE(b, 2), blocksize

    ib = min(blocksize, SIZE(a, 1)-ii+1)
    jb = min(blocksize, SIZE(b, 2)-jj+1)

    do i = ii, ii+ib-1 , 1
      do j = jj, jj+jb-1 , 1
        r(i,j) = SUM(a(i,:) * b(:,j))
      enddo
    enddo

  enddo
enddo
```
(which can not be directly inserted because of the undeclared symbols, but I can independently request for the declarations needed)

If instead I do:
`llm.apply(statement, options={"prompt": "parallelise the loop with OpenMP"})`
I get:
```fortran
!$OMP PARALLEL DO PRIVATE(i,j)
  do j = 1, SIZE(b, DIM=2), 1
    do i = 1, SIZE(a, DIM=1), 1
      r(i,j) = SUM(a(i,:) * b(:,j))
    end do
  end do
!$OMP END PARALLEL DO
```
(which unfortunately the reader then discards the pragmas)

Not all is good, if I do:
`llm.apply(statement, options={"prompt": "offload the loop to the GPU with OpenMP"})` 
I get:
```fortran
!$omp target map(to:a(:,:),b(:,:)) map(from:r(:,:))
do j = 1, SIZE(b, DIM=2), 1
  do i = 1, SIZE(a, DIM=1), 1
    !$omp parallel do
    r(i,j) = SUM(a(i,:) * b(:,j))
  enddo
enddo
!$omp end target
```
(but if I modify the transformation to get a second prompt, I can ask for a corrected version and then it gets the right answer)

In conclusion, this works surprisingly well in an interactive shell as I can fix small issues with the responses, but is very fragile to automatically apply in large sets of code. However I think it has lots of potential to mix it with psyclone and we should continue exploring it.
