### PR TITLE
(Closes #2492) nemoouterarrayrange bug

### DIFF
--- a/changelog
+++ b/changelog
@@ -147,6 +147,8 @@
 	53) PR #2439 for #2105. Use maxval2loop and atomics to parallelise
 	NEMO stpctl.f90.
 
+	54) PR #2493 for #2492. Fix bug in NemoOuterArrayRange2LoopTrans
+
 release 2.4.0 29th of September 2023
 
 	1) PR #1758 for #1741. Splits the PSyData read functionality into a

--- a/examples/nemo/scripts/utils.py
+++ b/examples/nemo/scripts/utils.py
@@ -120,7 +120,9 @@ def enhance_tree_information(schedule):
                         ArrayType.Extent.ATTRIBUTE]))
         elif reference.symbol.name == "sbc_dcy":
             # The parser gets this wrong, it is a Call not an Array access
-            reference.symbol.specialise(RoutineSymbol)
+            if not isinstance(reference.symbol, RoutineSymbol):
+                # We haven't already specialised this Symbol.
+                reference.symbol.specialise(RoutineSymbol)
             call = Call(reference.symbol)
             for child in reference.children:
                 call.addchild(child.detach())

--- a/src/psyclone/domain/nemo/transformations/nemo_outerarrayrange2loop_trans.py
+++ b/src/psyclone/domain/nemo/transformations/nemo_outerarrayrange2loop_trans.py
@@ -115,7 +115,6 @@ class NemoOuterArrayRange2LoopTrans(ArrayRange2LoopTrans):
         # Get deepest array in LHS (excluding inside Ranges)
         deepest_range = node.lhs.walk(Range, stop_type=Range)[-1]
         lhs_array_ref = deepest_range.parent
-        #lhs_array_ref = node.lhs.walk(ArrayMixin, stop_type=Range)[-1]
         index = lhs_array_ref.get_outer_range_index()
         nemo_arrayrange2loop = NemoArrayRange2LoopTrans()
         nemo_arrayrange2loop.apply(lhs_array_ref.children[index])

--- a/src/psyclone/domain/nemo/transformations/nemo_outerarrayrange2loop_trans.py
+++ b/src/psyclone/domain/nemo/transformations/nemo_outerarrayrange2loop_trans.py
@@ -113,7 +113,9 @@ class NemoOuterArrayRange2LoopTrans(ArrayRange2LoopTrans):
         self.validate(node)
 
         # Get deepest array in LHS (excluding inside Ranges)
-        lhs_array_ref = node.lhs.walk(ArrayMixin, stop_type=Range)[-1]
+        deepest_range = node.lhs.walk(Range, stop_type=Range)[-1]
+        lhs_array_ref = deepest_range.parent
+        #lhs_array_ref = node.lhs.walk(ArrayMixin, stop_type=Range)[-1]
         index = lhs_array_ref.get_outer_range_index()
         nemo_arrayrange2loop = NemoArrayRange2LoopTrans()
         nemo_arrayrange2loop.apply(lhs_array_ref.children[index])


### PR DESCRIPTION
Bug fix for the named transformation (required when an array reference itself uses an array reference in an index expression) and also a minor fix to the `utils.py` file in `examples/nemo/scripts` that prevents us attempting to specialise the same Symbol more than once. (Found while processing latest NEMO source.)
