### PR TITLE
Fix OpenMPI while testing HPC-X

### DIFF
--- a/examples/nemo/scripts/Makefile
+++ b/examples/nemo/scripts/Makefile
@@ -27,7 +27,7 @@ TEST_CASE ?= SPITZ12
 # Example Config for MetOffice - eORCA1_GO8 - nvidia
 NEMO_DIR ?= ${WORKSPACE}/NEMO
 ROOT_SRC ?= ${NEMO_DIR}/cfgs/SPITZ12_serial/BLD/ppsrc/nemo/
-MPI_INC_DIR ?= ${NVHPC_ROOT}/comm_libs/mpi/include
+MPI_INC_DIR ?= ${NVHPC_ROOT}/comm_libs/openmpi/openmpi-3.1.5/include
 COMPILER_ARCH ?= linux_nvidia_omp_gpu
 ADD_KEYS ?= "IEEE_IS_NAN=ieee_is_nan key_nosignedzero"
 DEL_KEYS ?= "key_iomput key_mpp_mpi key_si3"


### PR DESCRIPTION
This needs to be merged asap to prevent CI tests from failing.