### PR TITLE
(Closes #2619) Add an `OMPParallelDoDirective.create` static method.

### DIFF
--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -2198,6 +2198,22 @@ class OMPParallelDoDirective(OMPParallelDirective, OMPDoDirective):
         OMPDoDirective.__init__(self, **kwargs)
         self.addchild(OMPDefaultClause(
             clause_type=OMPDefaultClause.DefaultClauseTypes.SHARED))
+        
+    @staticmethod
+    def create(children=None, **kwargs):
+        '''
+        Create an OMPParallelDoDirective.
+
+        :param children: The child nodes of the new directive.
+        :type children: List of :py:class:`psyclone.psyir.nodes.Node`
+        :param kwargs: additional keyword arguments provided to the PSyIR node.
+        :type kwargs: unwrapped dict.
+
+        :returns: A new OMPParallelDoDirective.
+        :rtype: :py:class:`psyclone.psyir.nodes.OMPParallelDoDirective`
+        '''
+
+        return OMPParallelDoDirective(children=children, **kwargs)
 
     @staticmethod
     def _validate_child(position, child):

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -2198,7 +2198,7 @@ class OMPParallelDoDirective(OMPParallelDirective, OMPDoDirective):
         OMPDoDirective.__init__(self, **kwargs)
         self.addchild(OMPDefaultClause(
             clause_type=OMPDefaultClause.DefaultClauseTypes.SHARED))
-        
+
     @staticmethod
     def create(children=None, **kwargs):
         '''

--- a/src/psyclone/tests/psyir/nodes/omp_directives_test.py
+++ b/src/psyclone/tests/psyir/nodes/omp_directives_test.py
@@ -525,6 +525,23 @@ def test_omp_do_directive_validate_global_constraints(fortran_reader,
             in str(err.value))
 
 
+def test_omp_parallel_do_create():
+    ''' Test the OMPParallelDoDirective create method. '''
+    loop = Loop.create(DataSymbol("i", INTEGER_SINGLE_TYPE),
+                       Literal("1", INTEGER_SINGLE_TYPE),
+                       Literal("10", INTEGER_SINGLE_TYPE),
+                       Literal("1", INTEGER_SINGLE_TYPE),
+                       [])
+    children = [loop]
+    directive = OMPParallelDoDirective.create(children=children, collapse=2)
+    assert directive.collapse == 2
+    assert directive.omp_schedule == "none"
+    assert str(directive) == "OMPParallelDoDirective[collapse=2]"
+    assert directive.dir_body.children[0] is loop
+    assert (directive.default_clause.clause_type
+            == OMPDefaultClause.DefaultClauseTypes.SHARED)
+
+
 def test_omp_pdo_validate_child():
     ''' Test the _validate_child method for OMPParallelDoDirective'''
     sched = Schedule()


### PR DESCRIPTION
`OMPParallelDoDirective` currently inherits its parent (`OMPParallelDirective`) `create` static method, which leads to the creation of an instance of it.
After further inspection, making `OMPParallelDirective.create` a class method would not cover all attributes (inherited from `OMPDoDirective`) so this reimplements `create` in the derived class instead.