### PR TITLE
Add `is_literal_assignment` method for `Assignment` node

### DIFF
--- a/changelog
+++ b/changelog
@@ -250,6 +250,8 @@
 	
 	86) PR #2707 for #257. Fixes bugs in the loop-fusion transformation.
 
+	87) PR #2752 towards #2717. Adds Assignment.is_literal_assignment property.
+
 release 2.5.0 14th of February 2024
 
 	1) PR #2199 for #2189. Fix bugs with missing maps in enter data

--- a/src/psyclone/psyir/nodes/assignment.py
+++ b/src/psyclone/psyir/nodes/assignment.py
@@ -34,6 +34,7 @@
 # Authors R. W. Ford, A. R. Porter, S. Siso and N. Nobre, STFC Daresbury Lab
 #         I. Kavcic, Met Office
 #         J. Henrichs, Bureau of Meteorology
+#         J. G. Wallwork, University of Cambridge
 # -----------------------------------------------------------------------------
 
 ''' This module contains the Assignment node implementation.'''
@@ -41,6 +42,7 @@
 from psyclone.core import VariablesAccessInfo
 from psyclone.errors import InternalError
 from psyclone.f2pygen import PSyIRGen
+from psyclone.psyir.nodes.literal import Literal
 from psyclone.psyir.nodes.array_reference import ArrayReference
 from psyclone.psyir.nodes.datanode import DataNode
 from psyclone.psyir.nodes.intrinsic_call import (
@@ -243,6 +245,16 @@ class Assignment(Statement):
                     # array range on the LHS
                     return True
         return False
+
+    @property
+    def is_literal_assignment(self):
+        '''
+        returns: True if the rhs of the assignment is a literal value and False
+            otherwise.
+        rtype: bool
+
+        '''
+        return isinstance(self.rhs, Literal)
 
     def gen_code(self, parent):
         '''F2pygen code generation of an Assignment.

--- a/src/psyclone/tests/psyir/nodes/assignment_test.py
+++ b/src/psyclone/tests/psyir/nodes/assignment_test.py
@@ -34,6 +34,7 @@
 # Authors R. W. Ford, A. R. Porter and S. Siso, STFC Daresbury Lab
 #         I. Kavcic, Met Office
 #         J. Henrichs, Bureau of Meteorology
+#         J. G. Wallwork, University of Cambridge
 # -----------------------------------------------------------------------------
 
 ''' Performs py.test tests on the Assignment PSyIR node. '''
@@ -100,6 +101,7 @@ def test_assignment_create():
     lhs = Reference(DataSymbol("tmp", REAL_SINGLE_TYPE))
     rhs = Literal("0.0", REAL_SINGLE_TYPE)
     assignment = Assignment.create(lhs, rhs)
+    assert assignment.is_literal_assignment
     check_links(assignment, [lhs, rhs])
     result = FortranWriter().assignment_node(assignment)
     assert result == "tmp = 0.0\n"
@@ -150,6 +152,7 @@ def test_is_array_assignment():
     array_ref = ArrayReference.create(symbol, [x_range, int_one.copy()])
     assignment = Assignment.create(array_ref, one.copy())
     assert assignment.is_array_assignment is True
+    assert assignment.is_literal_assignment
 
     # Check when lhs consists of various forms of structure access
     grid_type = StructureType.create([
@@ -349,8 +352,11 @@ def test_pointer_assignment():
     assignment1 = Assignment(is_pointer=True)
     assignment1.addchild(lhs.copy())
     assignment1.addchild(rhs.copy())
+    assert not assignment1.is_literal_assignment
     assignment2 = Assignment.create(lhs, rhs, is_pointer=True)
+    assert not assignment2.is_literal_assignment
     not_pointer = Assignment.create(lhs.copy(), rhs.copy())
+    assert not not_pointer.is_literal_assignment
 
     # Getters, equality and copy
     assert assignment1.is_pointer


### PR DESCRIPTION
Partially addresses #2717.

This PR merges the `assignment` module of [PSyACC](https://github.com/MetOffice/psyacc) into PSyclone.