### PR TITLE
(Closes #2774) Refactor matmul2code to allow for more permutations of full ranges

### DIFF
--- a/src/psyclone/psyir/transformations/intrinsics/matmul2code_trans.py
+++ b/src/psyclone/psyir/transformations/intrinsics/matmul2code_trans.py
@@ -67,9 +67,12 @@ def _create_matrix_ref(matrix_symbol, loop_idx_symbols, other_dims,
                        not being looped over. (If there are none then this \
                        must be an empty list.)
     :type other_dims: List[:py:class:`psyclone.psyir.nodes.ExpressionNode`]
-    :param order:      list of indices in the original matrix where the
-                       other_dims are.
-    :type order:      List[int]
+    :param loop_idx_order: list of indices in the original matrix where the
+                           loop_idx_symbols are.
+    :type loop_idx_order: List[int]
+    :param other_dims_order: list of indices in the original matrix where the
+                             other_dims are.
+    :type other_dims_order: List[int]
 
     :returns: the new reference to a matrix element.
     :rtype: :py:class:`psyclone.psyir.nodes.ArrayReference`
@@ -154,9 +157,10 @@ def _get_full_range_split(array):
 
     :param array: the reference that we are interested in.
     :type array: :py:class:`psyir.nodes.Reference`
-    :returns: tuple with number of full ranges and
-              the list of non full range indices for this array.
-    :rtype: (int, List[psyclone.psyir.nodes.DataNode])
+    :returns: tuple with list of full range indices,
+              the list of non full range indices, and
+              list of non full range nodes for this array.
+    :rtype: (List[int], List[int], List[psyclone.psyir.nodes.DataNode])
 
    :raises TransformationError: if any Range nodes are not full, or
         if there are more than two full range nodes.
@@ -180,7 +184,8 @@ def _get_full_range_split(array):
             non_full_range_order.append(it)
 
     # Error raising if we go above 2 full ranges
-    if len(full_range_order) > 2:
+    n_full_ranges = len(full_range_order)
+    if n_full_ranges > 2:
         from psyclone.psyir.transformations import TransformationError
         raise TransformationError(
             f"To use matmul2code_trans on matmul, no more than "

--- a/src/psyclone/psyir/transformations/intrinsics/matmul2code_trans.py
+++ b/src/psyclone/psyir/transformations/intrinsics/matmul2code_trans.py
@@ -82,11 +82,11 @@ def _create_matrix_ref(matrix_symbol, loop_idx_symbols, other_dims,
     else:
         n_indices = len(loop_idx_symbols) + len(other_dims)
         indices = [-1]*n_indices
-        for it, order_idx in enumerate(other_dims_order):
-            indices[order_idx] = other_dims[it].copy()
-        # Fill the remaining indices with loop index symbols
         for it, order_idx in enumerate(loop_idx_order):
             indices[order_idx] = Reference(loop_idx_symbols[it])
+        # Fill the remaining indices with the other dims
+        for it, order_idx in enumerate(other_dims_order):
+            indices[order_idx] = other_dims[it].copy()
     return ArrayReference.create(matrix_symbol, indices)
 
 
@@ -178,13 +178,14 @@ def _get_full_range_split(array):
         else:
             non_full_ranges.append(idx)
             non_full_range_order.append(it)
-        # Early error raising if we go above 2 full ranges
-        if len(full_range_order) > 2:
-            from psyclone.psyir.transformations import TransformationError
-            raise TransformationError(
-                f"To use matmul2code_trans on matmul, no more than "
-                f"two indices of the argument '{array.name}' "
-                f"must be full ranges but found {n_full_ranges}.")
+
+    # Error raising if we go above 2 full ranges
+    if len(full_range_order) > 2:
+        from psyclone.psyir.transformations import TransformationError
+        raise TransformationError(
+            f"To use matmul2code_trans on matmul, no more than "
+            f"two indices of the argument '{array.name}' "
+            f"must be full ranges but found {n_full_ranges}.")
     return (full_range_order, non_full_range_order, non_full_ranges)
 
 

--- a/src/psyclone/tests/psyir/transformations/intrinsics/matmul2code_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/intrinsics/matmul2code_trans_test.py
@@ -109,7 +109,7 @@ def test_create_matrix_ref_1d():
     array_type = ArrayType(REAL_TYPE, [10])
     array_symbol = DataSymbol("x", array_type)
     i_loop_sym = DataSymbol("i", INTEGER_TYPE)
-    ref1 = _create_matrix_ref(array_symbol, [i_loop_sym], [], [])
+    ref1 = _create_matrix_ref(array_symbol, [i_loop_sym], [], [0], [])
     assert isinstance(ref1, ArrayReference)
     assert ref1.symbol is array_symbol
     assert len(ref1.indices) == 1
@@ -126,7 +126,7 @@ def test_create_matrix_ref_trailing_indices():
     i_loop_sym = DataSymbol("i", INTEGER_TYPE)
     k_sym = DataSymbol("k", INTEGER_TYPE)
     k_ref = Reference(k_sym)
-    ref1 = _create_matrix_ref(array_symbol, [i_loop_sym], [k_ref], [1])
+    ref1 = _create_matrix_ref(array_symbol, [i_loop_sym], [k_ref], [0], [1])
     assert isinstance(ref1, ArrayReference)
     assert ref1.symbol is array_symbol
     assert len(ref1.indices) == 2
@@ -145,7 +145,11 @@ def test_create_matrix_ref_2d():
     array_symbol = DataSymbol("x", array_type)
     i_loop_sym = DataSymbol("i", INTEGER_TYPE)
     j_loop_sym = DataSymbol("j", INTEGER_TYPE)
-    ref2 = _create_matrix_ref(array_symbol, [i_loop_sym, j_loop_sym], [], [])
+    ref2 = _create_matrix_ref(array_symbol,
+                             [i_loop_sym, j_loop_sym],
+                             [],
+                             [0,1],
+                             [])
     assert isinstance(ref2, ArrayReference)
     assert ref2.symbol is array_symbol
     assert len(ref2.indices) == 2


### PR DESCRIPTION
Fixes #2774.

There was a hardcoded standard in PSyclone where for matrix multiplications, the first one or two indices must be full ranges (i.e.: the Fortran would be written as `matrix(:,:,...)` or `vector(:,...)`). However, Fortran can perform matrix multiplications with the full ranges in different orderings, as long as the shape conforms.

When recent LFRic changes re-ordered some of the operator index accesses, this shifted the full ranges into forbidden permutations.

This change addresses this issue by allowing more permutations that produce valid Fortran matmul code.

**Description of changes**
Added a new private method `_get_full_range_split` to matmul2code_trans.py, which splits information about full range and non full range nodes as well as performs some validation. For a given `array`, the method iterates over the children, and checks whether or not they are `Range` nodes. If the `Range` node is a full range, we append its position in the array to a list. If not, we throw an error. If it is not a `Range` node then its position and the node itself are appended to two different lists. 

After the children are iterated over, if we have more than two full ranges then this `array` is not a valid input for matmul, so we throw an error. Otherwise, return the two lists containing the positions of the full range and non full range nodes in the array, as well as the non full range node list.

Some further validation is performed to ensure that the first matrix involved in the matmul has exactly two full ranges, and that the second matrix has one or two (since it can be a vector or matrix).

The orderings and list of non full range nodes are fed to the modified `_create_matrix_ref` to make the matrix reference.

**Testing**
A new test `test_apply_matmat_reordered` has been added which tests the expected behaviour directly, by feeding the PSyIR some Fortran code with spatially conforming but re-ordered (with respect to the old standard) matrices. Other tests will be modified since a lot of them tested aspects of the old standard that no longer apply.