### PR TITLE
(Closes #2816) fix idx type in test harness construction

### DIFF
--- a/src/psyclone/psyad/domain/lfric/lfric_adjoint_harness.py
+++ b/src/psyclone/psyad/domain/lfric/lfric_adjoint_harness.py
@@ -266,7 +266,7 @@ def _init_fields_random(fields, input_symbols, table):
 
     '''
     idef_sym = table.add_lfric_precision_symbol("i_def")
-    idef_type = ScalarType(ScalarType.Intrinsic.REAL, idef_sym)
+    idef_type = ScalarType(ScalarType.Intrinsic.INTEGER, idef_sym)
     # We use the setval_random builtin to initialise all fields.
     kernel_list = []
     builtin_factory = LFRicBuiltinFunctorFactory.get()

--- a/src/psyclone/tests/psyad/domain/lfric/test_lfric_adjoint_harness.py
+++ b/src/psyclone/tests/psyad/domain/lfric/test_lfric_adjoint_harness.py
@@ -249,7 +249,7 @@ def test_init_fields_random_vector(type_map):
     '''
     table = LFRicSymbolTable()
     idef_sym = table.add_lfric_precision_symbol("i_def")
-    idef_type = ScalarType(ScalarType.Intrinsic.REAL, idef_sym)
+    idef_type = ScalarType(ScalarType.Intrinsic.INTEGER, idef_sym)
 
     fld_type = DataTypeSymbol(type_map["field"]["type"],
                               datatype=UnresolvedType())


### PR DESCRIPTION
Fixes a small bug in the LFRic psyad test-harness generation. This was thrown up by the recent change to the fortran backend to allow for types of literals.
Please could @TeranIvy and @DrTVockerodtMO confirm that this fixes the issue?