### PR TITLE
#2724 Updated version number to be 3.0.1-dev.

### DIFF
--- a/src/psyclone/version.py
+++ b/src/psyclone/version.py
@@ -33,6 +33,7 @@
 # -----------------------------------------------------------------------------
 # Author: A. R. Porter, STFC Daresbury Laboratory
 # Modified by R. W. Ford and N. Nobre, STFC Daresbury Lab
+# Modified by J. Henrichs, Bureau of Meteorology
 
 ''' Single location for the current version number of PSyclone. This is
     used in setup.py and
@@ -42,5 +43,5 @@ __MAJOR__ = 3
 __MINOR__ = 0
 __MICRO__ = 0
 
-__SHORT_VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}"
-__VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}.{__MICRO__:d}"
+__SHORT_VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}-dev"
+__VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}.{__MICRO__:d}-dev"

--- a/src/psyclone/version.py
+++ b/src/psyclone/version.py
@@ -41,7 +41,7 @@
 
 __MAJOR__ = 3
 __MINOR__ = 0
-__MICRO__ = 0
+__MICRO__ = 1
 
 __SHORT_VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}-dev"
 __VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}.{__MICRO__:d}-dev"


### PR DESCRIPTION
This doesn't fully fix 2724. MY understanding is that we first use `-dev`, then wait for feedback from Iva if we can switch to the automated way using setuptools_scm (which caused problems on some UK systems I Believe).

So, this only adds `-dev` for now