### PR TITLE
Update Zenodo reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img width="460" src="doc/logo/psyclone_v1.0.png">
 </p>
 
-[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11190458.svg)](https://doi.org/10.5281/zenodo.11190458)
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.11190457.svg)](https://doi.org/10.5281/zenodo.11190457)
 ![Build Status](https://github.com/stfc/PSyclone/workflows/PSyclone%20tests%20and%20examples/badge.svg)
 [![codecov](https://codecov.io/gh/stfc/PSyclone/branch/master/graph/badge.svg)](https://codecov.io/gh/stfc/PSyclone)
 

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+	1) PR #2827. Update Zenodo with release 3.0.0 and update link in
+	README.md.
+
 release 3.0.0 6th of December 2024
 
 	1) PR #2477 for #2463. Add support for Fortran Namelist statements.


### PR DESCRIPTION
I made a version artifact for PSyclone 3.0 in our Zenodo DOI (https://zenodo.org/records/14500240), but it has given it a new number/reference.

There is also a DOI that cite all versions of PSyclone and will always resolve to the latest one, so I updated the README to it.

@arporter This is a small one, I didn't create a related issue, let me know if you prefer it. This is ready for review.