### PR TITLE
(Towards #2909) forbid redundant computation setval/op_random and rename Dynamo0p3RedundantComputationTrans

### DIFF
--- a/doc/developer_guide/APIs.rst
+++ b/doc/developer_guide/APIs.rst
@@ -929,7 +929,7 @@ Modifying the Schedule
 ----------------------
 
 Transformations modify the schedule. At the moment only one of these
-transformations - the ``Dynamo0p3RedundantComputationTrans`` class in
+transformations - the ``LFRicRedundantComputationTrans`` class in
 ``transformations.py`` - affects halo exchanges. This transformation can
 mean there is a requirement for new halo exchanges, it can mean
 existing halo exchanges are no longer required and it can mean that
@@ -938,7 +938,7 @@ the properties of a halo exchange (e.g. depth) can change.
 The redundant computation transformation is applied to a loop in a
 schedule. When this is done the ``update_halo_exchanges()`` method for
 that loop is called - see the ``apply()`` method in
-``Dynamo0p3RedundantComputationTrans``.
+``LFRicRedundantComputationTrans``.
 
 The first thing that the ``update_halo_exchanges()`` method does is call
 the ``create_halo_exchanges()`` method to add in any new halo exchanges

--- a/doc/user_guide/dynamo0p3.rst
+++ b/doc/user_guide/dynamo0p3.rst
@@ -3924,7 +3924,7 @@ Transformations
 ---------------
 
 This section describes the LFRic API-specific transformations. In
-cases, excepting **Dynamo0p3RedundantComputationTrans**,
+cases, excepting **LFRicRedundantComputationTrans**,
 **Dynamo0p3AsyncHaloExchangeTrans** and **Dynamo0p3KernelConstTrans**,
 these transformations are specialisations of generic transformations
 described in the :ref:`transformations` section. The difference
@@ -3953,7 +3953,7 @@ are the same. The exception are loops over discontinuous spaces (see
 for which loop fusion is allowed (unless the loop bounds become different
 due to a prior transformation).
 
-The **Dynamo0p3RedundantComputationTrans** and
+The **LFRicRedundantComputationTrans** and
 **Dynamo0p3AsyncHaloExchange** transformations are only valid for the
 LFRic API. This is because this API is currently the only one
 that supports distributed memory.  An example of redundant computation
@@ -4011,6 +4011,6 @@ transformations have not yet been migrated to this directory.
     :members:
     :noindex:
 
-.. autoclass:: psyclone.transformations.Dynamo0p3RedundantComputationTrans
+.. autoclass:: psyclone.transformations.LFRicRedundantComputationTrans
     :members:
     :noindex:

--- a/examples/lfric/eg11/async_script.py
+++ b/examples/lfric/eg11/async_script.py
@@ -51,7 +51,7 @@ def trans(psyir):
 
     '''
     from psyclone.transformations import \
-        Dynamo0p3RedundantComputationTrans, \
+        LFRicRedundantComputationTrans, \
         Dynamo0p3AsyncHaloExchangeTrans, \
         MoveTrans
 
@@ -63,7 +63,7 @@ def trans(psyir):
     # the grad_p field. This transformation is unnecessary if
     # annexed_dofs is set to True in the config file (although the
     # transformation still works).
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[0], {"depth": 1})
     print(schedule.view())
 

--- a/examples/lfric/eg8/redundant_script.py
+++ b/examples/lfric/eg8/redundant_script.py
@@ -55,9 +55,9 @@ def trans(psyir):
     :type psyir: :py:class:`psyclone.psyir.nodes.FileContainer`
 
     '''
-    from psyclone.transformations import Dynamo0p3RedundantComputationTrans, \
+    from psyclone.transformations import LFRicRedundantComputationTrans, \
         MoveTrans
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     m_trans = MoveTrans()
 
     # Get first invoke subroutine

--- a/examples/lfric/scripts/everything_everywhere_all_at_once.py
+++ b/examples/lfric/scripts/everything_everywhere_all_at_once.py
@@ -49,7 +49,7 @@ from psyclone.psyGen import InvokeSchedule
 from psyclone.transformations import Dynamo0p3ColourTrans, \
                                      Dynamo0p3OMPLoopTrans, \
                                      OMPParallelTrans, \
-                                     Dynamo0p3RedundantComputationTrans, \
+                                     LFRicRedundantComputationTrans, \
                                      Dynamo0p3AsyncHaloExchangeTrans, \
                                      MoveTrans, \
                                      TransformationError
@@ -69,7 +69,7 @@ def trans(psyir):
     :type psyir: :py:class:`psyclone.psyir.nodes.FileContainer`
 
     '''
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     ctrans = Dynamo0p3ColourTrans()
     otrans = Dynamo0p3OMPLoopTrans()
     oregtrans = OMPParallelTrans()

--- a/examples/lfric/scripts/gpu_offloading.py
+++ b/examples/lfric/scripts/gpu_offloading.py
@@ -49,7 +49,7 @@ from psyclone.psyir.transformations import (
     ACCKernelsTrans, TransformationError, OMPTargetTrans)
 from psyclone.transformations import (
     Dynamo0p3ColourTrans, Dynamo0p3OMPLoopTrans,
-    Dynamo0p3RedundantComputationTrans, OMPParallelTrans,
+    LFRicRedundantComputationTrans, OMPParallelTrans,
     ACCParallelTrans, ACCLoopTrans, ACCRoutineTrans,
     OMPDeclareTargetTrans, OMPLoopTrans)
 
@@ -71,7 +71,7 @@ def trans(psyir):
     :type psyir: :py:class:`psyclone.psyir.nodes.FileContainer`
 
     '''
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     ctrans = Dynamo0p3ColourTrans()
     otrans = Dynamo0p3OMPLoopTrans()
     const = LFRicConstants()

--- a/examples/lfric/scripts/redundant_dofs.py
+++ b/examples/lfric/scripts/redundant_dofs.py
@@ -38,7 +38,7 @@ API to apply redundant computation to halo depth 1 for all loops that
 iterate over dofs and do not contain a reduction.
 
 '''
-from psyclone.transformations import Dynamo0p3RedundantComputationTrans
+from psyclone.transformations import LFRicRedundantComputationTrans
 
 ITERATION_SPACES = ["dofs"]
 DEPTH = 1
@@ -54,7 +54,7 @@ def trans(psyir):
     :type psyir: :py:class:`psyclone.psyir.nodes.FileContainer`
 
     '''
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
 
     transformed = 0
 

--- a/examples/lfric/scripts/redundant_setval_c.py
+++ b/examples/lfric/scripts/redundant_setval_c.py
@@ -38,7 +38,7 @@ API to apply redundant computation to halo depth 1 for all instances
 of loops that iterate over dofs and contain the setval_c builtin.
 
 '''
-from psyclone.transformations import Dynamo0p3RedundantComputationTrans
+from psyclone.transformations import LFRicRedundantComputationTrans
 
 ITERATION_SPACES = ["dofs"]
 KERNEL_NAMES = ["setval_c"]
@@ -58,7 +58,7 @@ def trans(psyir):
     :type psyir: :py:class:`psyclone.psyir.nodes.FileContainer`
 
     '''
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
 
     transformed = 0
 

--- a/src/psyclone/tests/domain/lfric/dofkern_test.py
+++ b/src/psyclone/tests/domain/lfric/dofkern_test.py
@@ -50,7 +50,7 @@ from psyclone.parse.algorithm import parse
 from psyclone.parse.utils import ParseError
 from psyclone.psyGen import PSyFactory
 from psyclone.tests.lfric_build import LFRicBuild
-from psyclone.transformations import Dynamo0p3RedundantComputationTrans
+from psyclone.transformations import LFRicRedundantComputationTrans
 
 
 @pytest.fixture(scope="module", autouse=True)
@@ -214,7 +214,7 @@ def test_redundant_comp_trans(tmpdir, monkeypatch):
 
     # Now transform the first loop to perform redundant computation out to
     # the level-3 halo
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     rtrans.apply(first_invoke.schedule[0], options={"depth": 3})
 
     # There should now be a halo exchange for f2

--- a/src/psyclone/tests/domain/lfric/lfric_loop_test.py
+++ b/src/psyclone/tests/domain/lfric/lfric_loop_test.py
@@ -59,7 +59,7 @@ from psyclone.tests.lfric_build import LFRicBuild
 from psyclone.tests.utilities import get_invoke
 from psyclone.transformations import (Dynamo0p3ColourTrans,
                                       DynamoOMPParallelLoopTrans,
-                                      Dynamo0p3RedundantComputationTrans)
+                                      LFRicRedundantComputationTrans)
 
 BASE_PATH = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(
@@ -373,7 +373,7 @@ def test_upper_bound_ncolour(dist_mem):
                 "last_halo_cell_all_colours(colour, 1)")
         # Apply redundant computation to increase the depth of the access
         # to the halo.
-        rtrans = Dynamo0p3RedundantComputationTrans()
+        rtrans = LFRicRedundantComputationTrans()
         rtrans.apply(loops[1])
         assert (loops[1]._upper_bound_fortran() ==
                 "last_halo_cell_all_colours(colour, max_halo_depth_mesh)")

--- a/src/psyclone/tests/domain/lfric/transformations/lfric_haloex_test.py
+++ b/src/psyclone/tests/domain/lfric/transformations/lfric_haloex_test.py
@@ -49,7 +49,7 @@ from psyclone.parse.algorithm import parse
 from psyclone.psyGen import PSyFactory, GenerationError
 from psyclone.tests.lfric_build import LFRicBuild
 from psyclone.tests.utilities import get_invoke
-from psyclone.transformations import (Dynamo0p3RedundantComputationTrans,
+from psyclone.transformations import (LFRicRedundantComputationTrans,
                                       Dynamo0p3AsyncHaloExchangeTrans)
 
 
@@ -113,7 +113,7 @@ def test_gh_inc_nohex_1(tmpdir, monkeypatch):
     assert LFRicBuild(tmpdir).code_compiles(psy)
 
     # make 1st loop iterate over dofs to the level 1 halo and check output
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[0], {"depth": 1})
     assert schedule.children[0].upper_bound_name == "dof_halo"
     assert schedule.children[0].upper_bound_halo_depth.value == "1"
@@ -168,7 +168,7 @@ def test_gh_inc_nohex_2(tmpdir, monkeypatch):
 
     # make 1st loop iterate over dofs to the level 1 halo and check
     # output. There should be no halo exchange for field "f1"
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[0], {"depth": 1})
     loop1 = schedule.children[0]
     haloex = schedule.children[1]
@@ -239,7 +239,7 @@ def test_gh_inc_nohex_3(tmpdir, monkeypatch):
     assert LFRicBuild(tmpdir).code_compiles(psy)
 
     # make 1st loop iterate over cells to the level 2 halo and check output
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[1], {"depth": 2})
 
     def check(schedule, f1depth, f2depth):
@@ -346,7 +346,7 @@ def test_gh_inc_nohex_4(tmpdir, monkeypatch):
     assert LFRicBuild(tmpdir).code_compiles(psy)
 
     # make 1st loop iterate over cells to the level 2 halo and check output
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[2], {"depth": 2})
     # we should now have a speculative halo exchange at the start of
     # the schedule for "f1" to depth 1 and "f2" to depth 2
@@ -379,7 +379,7 @@ def test_gh_inc_max(tmpdir, monkeypatch, annexed):
                     api=API)
     psy = PSyFactory(API, distributed_memory=True).create(info)
     schedule = psy.invokes.invoke_list[0].schedule
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
 
     def check(haloex, depth):
         '''check the halo exchange has the expected properties
@@ -471,7 +471,7 @@ def test_setval_x_then_user(tmpdir, monkeypatch):
     assert first_invoke.schedule[1].field.name == "f1"
     # Now transform the first loop to perform redundant computation out to
     # the level-1 halo
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     rtrans.apply(first_invoke.schedule[0], options={"depth": 1})
     # There should now be a halo exchange for f1 before the first
     # (builtin) kernel call
@@ -571,7 +571,7 @@ def test_add_halo_exchange_code_nreader(monkeypatch):
 
     schedule = psy.invokes.invoke_list[0].schedule
     loop = schedule[0]
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     rtrans.apply(loop, options={"depth": 1})
     f1_field = schedule[0].field
     del schedule.children[0]
@@ -654,7 +654,7 @@ def test_stencil_with_redundant_comp_trans(monkeypatch, tmpdir, annexed):
     sched = invoke.schedule
     loop = sched.walk(LFRicLoop)[0]
     # Transform the loop to perform redundant computation out to depth 2.
-    rtrans = Dynamo0p3RedundantComputationTrans()
+    rtrans = LFRicRedundantComputationTrans()
     rtrans.apply(loop, {"depth": 2})
     result = str(psy.gen).lower()
     # Updated argument is on w0 and has gh_inc access. If we are not

--- a/src/psyclone/tests/psyGen_test.py
+++ b/src/psyclone/tests/psyGen_test.py
@@ -74,7 +74,7 @@ from psyclone.tests.lfric_build import LFRicBuild
 from psyclone.tests.test_files import dummy_transformations
 from psyclone.tests.test_files.dummy_transformations import LocalTransformation
 from psyclone.tests.utilities import get_invoke
-from psyclone.transformations import (Dynamo0p3RedundantComputationTrans,
+from psyclone.transformations import (LFRicRedundantComputationTrans,
                                       Dynamo0p3KernelConstTrans,
                                       Dynamo0p3OMPLoopTrans,
                                       Dynamo0p3ColourTrans, OMPParallelTrans)
@@ -1985,7 +1985,7 @@ def test_find_w_args_multiple_deps_error(monkeypatch, annexed, tmpdir):
         index = 1
     else:
         index = 4
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[index], {"depth": 2})
     del schedule.children[index]
     loop = schedule.children[index+2]
@@ -2061,7 +2061,7 @@ def test_find_w_args_multiple_deps(monkeypatch, annexed):
         index = 1
     else:
         index = 4
-    rc_trans = Dynamo0p3RedundantComputationTrans()
+    rc_trans = LFRicRedundantComputationTrans()
     rc_trans.apply(schedule.children[index], {"depth": 2})
     loop = schedule.children[index+3]
     kernel = loop.loop_body[0]

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -1810,7 +1810,7 @@ class MoveTrans(Transformation):
             location.parent.children.insert(location_index+1, my_node)
 
 
-class Dynamo0p3RedundantComputationTrans(LoopTrans):
+class LFRicRedundantComputationTrans(LoopTrans):
     '''This transformation allows the user to modify a loop's bounds so
     that redundant computation will be performed. Redundant
     computation can result in halo exchanges being modified, new halo
@@ -1906,46 +1906,46 @@ class Dynamo0p3RedundantComputationTrans(LoopTrans):
         dir_node = node.ancestor(Directive)
         if dir_node:
             raise TransformationError(
-                f"In the Dynamo0p3RedundantComputation transformation apply "
+                f"In the LFRicRedundantComputation transformation apply "
                 f"method the supplied loop is sits beneath a directive of "
                 f"type {type(dir_node)}. Redundant computation must be applied"
                 f" before directives are added.")
         if not (isinstance(node.parent, LFRicInvokeSchedule) or
                 isinstance(node.parent.parent, Loop)):
             raise TransformationError(
-                f"In the Dynamo0p3RedundantComputation transformation "
+                f"In the LFRicRedundantComputation transformation "
                 f"apply method the parent of the supplied loop must be the "
                 f"LFRicInvokeSchedule, or a Loop, but found "
                 f"{type(node.parent)}")
         if isinstance(node.parent.parent, Loop):
             if node.loop_type != "colour":
                 raise TransformationError(
-                    f"In the Dynamo0p3RedundantComputation transformation "
+                    f"In the LFRicRedundantComputation transformation "
                     f"apply method, if the parent of the supplied Loop is "
                     f"also a Loop then the supplied Loop must iterate over "
                     f"'colour', but found '{node.loop_type}'")
             if node.parent.parent.loop_type != "colours":
                 raise TransformationError(
-                    f"In the Dynamo0p3RedundantComputation transformation "
+                    f"In the LFRicRedundantComputation transformation "
                     f"apply method, if the parent of the supplied Loop is "
                     f"also a Loop then the parent must iterate over "
                     f"'colours', but found '{node.parent.parent.loop_type}'")
             if not isinstance(node.parent.parent.parent, LFRicInvokeSchedule):
                 raise TransformationError(
-                    f"In the Dynamo0p3RedundantComputation transformation "
+                    f"In the LFRicRedundantComputation transformation "
                     f"apply method, if the parent of the supplied Loop is "
                     f"also a Loop then the parent's parent must be the "
                     f"LFRicInvokeSchedule, but found {type(node.parent)}")
         if not Config.get().distributed_memory:
             raise TransformationError(
-                "In the Dynamo0p3RedundantComputation transformation apply "
+                "In the LFRicRedundantComputation transformation apply "
                 "method distributed memory must be switched on")
 
         # loop must iterate over cell-column, dof or colour. Note, an
         # empty loop_type iterates over cell-columns.
         if node.loop_type not in ["", "dof", "colour"]:
             raise TransformationError(
-                f"In the Dynamo0p3RedundantComputation transformation apply "
+                f"In the LFRicRedundantComputation transformation apply "
                 f"method the loop type must be one of '' (cell-columns), 'dof'"
                 f" or 'colour', but found '{node.loop_type}'")
 
@@ -1976,14 +1976,14 @@ class Dynamo0p3RedundantComputationTrans(LoopTrans):
             if node.upper_bound_name in const.HALO_ACCESS_LOOP_BOUNDS:
                 if not node.upper_bound_halo_depth:
                     raise TransformationError(
-                        "In the Dynamo0p3RedundantComputation transformation "
+                        "In the LFRicRedundantComputation transformation "
                         "apply method the loop is already set to the maximum "
                         "halo depth so this transformation does nothing")
                 for call in node.kernels():
                     for arg in call.arguments.args:
                         if arg.stencil:
                             raise TransformationError(
-                                f"In the Dynamo0p3RedundantComputation "
+                                f"In the LFRicRedundantComputation "
                                 f"transformation apply method the loop "
                                 f"contains field '{arg.name}' with a stencil "
                                 f"access in kernel '{call.name}', so it is "
@@ -1992,12 +1992,12 @@ class Dynamo0p3RedundantComputationTrans(LoopTrans):
         else:
             if not isinstance(depth, int):
                 raise TransformationError(
-                    f"In the Dynamo0p3RedundantComputation transformation "
+                    f"In the LFRicRedundantComputation transformation "
                     f"apply method the supplied depth should be an integer but"
                     f" found type '{type(depth)}'")
             if depth < 1:
                 raise TransformationError(
-                    "In the Dynamo0p3RedundantComputation transformation "
+                    "In the LFRicRedundantComputation transformation "
                     "apply method the supplied depth is less than 1")
 
             if node.upper_bound_name in const.HALO_ACCESS_LOOP_BOUNDS:
@@ -2006,13 +2006,13 @@ class Dynamo0p3RedundantComputationTrans(LoopTrans):
                         upper_bound = int(node.upper_bound_halo_depth.value)
                         if upper_bound >= depth:
                             raise TransformationError(
-                                f"In the Dynamo0p3RedundantComputation "
+                                f"In the LFRicRedundantComputation "
                                 f"transformation apply method the supplied "
                                 f"depth ({depth}) must be greater than the "
                                 f"existing halo depth ({upper_bound})")
                 else:
                     raise TransformationError(
-                        "In the Dynamo0p3RedundantComputation transformation "
+                        "In the LFRicRedundantComputation transformation "
                         "apply method the loop is already set to the maximum "
                         "halo depth so can't be set to a fixed value")
 
@@ -2050,7 +2050,7 @@ class Dynamo0p3RedundantComputationTrans(LoopTrans):
         else:
             raise TransformationError(
                 f"Unsupported loop_type '{loop.loop_type}' found in "
-                f"Dynamo0p3Redundant ComputationTrans.apply()")
+                f"{self.name}.apply()")
         # Add/remove halo exchanges as required due to the redundant
         # computation
         loop.update_halo_exchanges()
@@ -3005,7 +3005,7 @@ __all__ = [
    "Dynamo0p3ColourTrans",
    "Dynamo0p3KernelConstTrans",
    "Dynamo0p3OMPLoopTrans",
-   "Dynamo0p3RedundantComputationTrans",
+   "LFRicRedundantComputationTrans",
    "DynamoOMPParallelLoopTrans",
    "GOceanOMPLoopTrans",
    "GOceanOMPParallelLoopTrans",


### PR DESCRIPTION
A  small PR that does precisely that. I've also renamed the associated transformation. However, for reviewing simplicity and to avoid clashes with other, big PRs, I've not done any moving of the implementation or the tests.