### PR TITLE
#2534 Try to trigger creation of the PDF version on readthedocs again.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,5 +1,8 @@
 version: 2
 
+formats:
+    - pdf
+
 python:
   version: "3.8"
   install:


### PR DESCRIPTION
@arporter , @sergisiso - I've created a PR for #2534, but I don't know if this can be tested without merging it to master. I don't think I have access to the readthedocs account (nor do I know what would be possible if I had :) ).

If we get the PDFs to work again, I would agree (as Sergi suggested) that pointing to the readthedocs version of the user guide would be better, esp. since it saves us the trouble of having to manually rebuild it all the time