### PR TITLE
(closes #2978) Ignore redundant return statements

### DIFF
--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -4650,18 +4650,18 @@ class Fparser2Reader():
         :raises NotImplementedError: if the parse tree contains an
             alternate return statement.
         '''
+        # Fortran Alternate Return statements are not supported
+        if node.children != (None, ):
+            raise NotImplementedError(
+                "Fortran alternate returns are not supported.")
         # Ignore redundant Returns at the end of Execution sections
         if isinstance(node.parent, Fortran2003.Execution_Part):
             if node is node.parent.children[-1]:
-                if node.children == (None, ):
-                    return None
-        if node.children == (None, ):
-            rtn = Return(parent=parent)
-            rtn.ast = node
-            return rtn
-        # Otherwise it is an "alternate return" which we don't support
-        raise NotImplementedError(
-            "Fortran alternate returns are not supported.")
+                return None
+        # Everything else is a valid PSyIR Return
+        rtn = Return(parent=parent)
+        rtn.ast = node
+        return rtn
 
     def _assignment_handler(self, node, parent):
         '''

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -4647,10 +4647,21 @@ class Fparser2Reader():
         :return: PSyIR representation of node.
         :rtype: :py:class:`psyclone.psyir.nodes.Return`
 
+        :raises NotImplementedError: if the parse tree contains an
+            alternate return statement.
         '''
-        rtn = Return(parent=parent)
-        rtn.ast = node
-        return rtn
+        # Ignore redundant Returns at the end of Execution sections
+        if isinstance(node.parent, Fortran2003.Execution_Part):
+            if node is node.parent.children[-1]:
+                if node.children == (None, ):
+                    return None
+        if node.children == (None, ):
+            rtn = Return(parent=parent)
+            rtn.ast = node
+            return rtn
+        # Otherwise it is an "alternate return" which we don't support
+        raise NotImplementedError(
+            "Fortran alternate returns are not supported.")
 
     def _assignment_handler(self, node, parent):
         '''

--- a/src/psyclone/psyir/transformations/inline_trans.py
+++ b/src/psyclone/psyir/transformations/inline_trans.py
@@ -240,11 +240,6 @@ class InlineTrans(Transformation):
         # TODO #924 - while doing this we should ensure that any References
         # to common/shared Symbols in the inlined code are updated to point
         # to the ones at the call site.
-        if isinstance(new_stmts[-1], Return):
-            # If the final statement of the routine is a return then
-            # remove it from the list.
-            del new_stmts[-1]
-
         if routine.return_symbol:
             # This is a function
             assignment = node.ancestor(Statement, excluding=Call)

--- a/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
+++ b/src/psyclone/tests/nemo/transformations/profiling/nemo_profile_test.py
@@ -442,7 +442,7 @@ def test_no_return_in_profiling(fortran_reader):
         "  real :: my_array(3,3)\n"
         "  my_array(:,:) = 0.0\n"
         "  my_test = 1\n"
-        "  return\n"
+        "  if (my_test .eq. 1) return\n"
         "end subroutine my_test\n")
     schedule = psyir.children[0]
     with pytest.raises(TransformationError) as err:

--- a/src/psyclone/tests/psyir/backend/fortran_test.py
+++ b/src/psyclone/tests/psyir/backend/fortran_test.py
@@ -1554,8 +1554,10 @@ def test_fw_return(fortran_reader, fortran_writer, tmpdir):
     code = (
         "module test\n"
         "contains\n"
-        "subroutine tmp()\n"
+        "subroutine tmp(a)\n"
+        "  integer, intent(inout) :: a\n"
         "  return\n"
+        "  a = 3\n"  # Stmt after return to avoid droping it
         "end subroutine tmp\n"
         "end module test")
     schedule = fortran_reader.psyir_from_source(code)

--- a/src/psyclone/tests/psyir/transformations/inline_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/inline_trans_test.py
@@ -105,32 +105,6 @@ def test_apply_empty_routine(fortran_reader, fortran_writer, tmpdir):
     assert Compile(tmpdir).string_compiles(output)
 
 
-def test_apply_single_return(fortran_reader, fortran_writer, tmpdir):
-    '''Check that a call to a routine containing only a return statement
-    is removed. '''
-    code = (
-        "module test_mod\n"
-        "contains\n"
-        "  subroutine run_it()\n"
-        "    integer :: i\n"
-        "    i = 10\n"
-        "    call sub(i)\n"
-        "  end subroutine run_it\n"
-        "  subroutine sub(idx)\n"
-        "    integer :: idx\n"
-        "    return\n"
-        "  end subroutine sub\n"
-        "end module test_mod\n")
-    psyir = fortran_reader.psyir_from_source(code)
-    routine = psyir.walk(Call)[0]
-    inline_trans = InlineTrans()
-    inline_trans.apply(routine)
-    output = fortran_writer(psyir)
-    assert ("    i = 10\n\n"
-            "  end subroutine run_it\n" in output)
-    assert Compile(tmpdir).string_compiles(output)
-
-
 def test_apply_return_then_cb(fortran_reader, fortran_writer, tmpdir):
     '''Check that a call to a routine containing a return statement followed
     by a CodeBlock is removed.'''


### PR DESCRIPTION
Also puts "Fortran alternate returns" into Codeblocks