### PR TITLE
#3019 Added deprecated classes for old-style Dynamo0p3 transformation names

### DIFF
--- a/src/psyclone/tests/domain/lfric/transformations/lfric_transformations_test.py
+++ b/src/psyclone/tests/domain/lfric/transformations/lfric_transformations_test.py
@@ -7991,3 +7991,29 @@ def test_colour_trans_tiled_continuous_writer_intergrid(dist_mem):
     # TODO #2623: To compile it needs an up-to-date lfric infrastructure with
     # the new tile-colouring methods
     # assert LFRicBuild(tmpdir).code_compiles(psy)
+
+
+def test_deprecated_names(capsys):
+    '''
+    Check that the old Dynamo0p3-based transformation names are still
+    accepted, but will print a deprecation message when they are
+    instantiated.
+    '''
+
+    # Since these names are deprecated, they are imported in this one test
+    # only, to make it easier to remove them later all at once
+    # pylint: disable=no-name-in-module, import-outside-toplevel
+    from psyclone.transformations import (
+        Dynamo0p3OMPParallelLoopTrans, Dynamo0p3OMPLoopTrans,
+        Dynamo0p3ColourTrans, Dynamo0p3RedundantComputationTrans,
+        Dynamo0p3AsyncHaloExchangeTrans)
+    for trans_cls in [Dynamo0p3OMPParallelLoopTrans, Dynamo0p3OMPLoopTrans,
+                      Dynamo0p3ColourTrans, Dynamo0p3RedundantComputationTrans,
+                      Dynamo0p3AsyncHaloExchangeTrans]:
+        old_name = trans_cls.__name__
+        new_name = old_name.replace("Dynamo0p3", "LFRic")
+        _ = trans_cls()
+        out, _ = capsys.readouterr()
+        assert (f"Deprecation warning: the script uses the legacy name "
+                f"'{old_name}', please use new name "
+                f"'{new_name}' instead.") in out

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -3129,6 +3129,28 @@ class KernelImportsToArguments(Transformation):
             node.modified = True
 
 
+# Create a compatibility layer for all existing Dynamo0p3 transformation
+# names. These are just derived classes from the new name which print
+# a deprecation message when creating an instance
+for name in ["OMPParallelLoopTrans",
+             "OMPLoopTrans",
+             "ColourTrans",
+             "RedundantComputationTrans",
+             "AsyncHaloExchangeTrans",
+             "KernelConstTrans"]:
+    class_string = f"""
+class Dynamo0p3{name}(LFRic{name}):
+
+    def __new__(cls):
+        print("Deprecation warning: the script uses the legacy name "
+              "'Dynamo0p3{name}', please use new name "
+              "'LFRic{name}' instead.")
+        return super().__new__(cls)
+        """
+    # pylint: disable=exec-used
+    exec(class_string)
+
+
 # For Sphinx AutoAPI documentation generation
 __all__ = [
    "ACCEnterDataTrans",


### PR DESCRIPTION
Fixes #3019.

Note that I uses `exec`. While the classes could be created using `type`, this would (as far as I can see) require to define a dedicated ``__new__`` function (with any name) to be assigned to the `__new__` attribute, which seems messy. Given the limited time that we need these classes, I stayed with `exec` (which is used elsewhere as well :) ).

For the tests, I do all the imports in the test function, so it's easy to remove this test later.