### PR TITLE
(towards #2551) Add DUC positions caching

### DIFF
--- a/src/psyclone/psyir/tools/definition_use_chains.py
+++ b/src/psyclone/psyir/tools/definition_use_chains.py
@@ -204,6 +204,11 @@ class DefinitionUseChain:
                   DefinitionUseChain
         :rtype: list[:py:class:`psyclone.psyir.nodes.Node`]
         """
+        # Compute the abs position caches as we'll use these a lot.
+        # The compute_cached_abs_position will only do this if needed
+        # so we don't need to check here.
+        self._reference.compute_cached_abs_positions()
+
         # Setup the start and stop positions
         save_start_position = self._start_point
         save_stop_position = self._stop_point
@@ -852,6 +857,11 @@ class DefinitionUseChain:
                   DefinitionUseChain
         :rtype: list[:py:class:`psyclone.psyir.nodes.Node`]
         """
+        # Compute the abs position caches as we'll use these a lot.
+        # The compute_cached_abs_position will only do this if needed
+        # so we don't need to check here.
+        self._reference.compute_cached_abs_positions()
+
         # Setup the start and stop positions
         save_start_position = self._start_point
         save_stop_position = self._stop_point


### PR DESCRIPTION
This is just a `git checkout origin/2551_omp_barrier_Removal  -- src/psyclone/psyir/tools/definition_use_chains.py`, from @LonelyCat124 branch that I already reviewed but that branch still have some integration test issues to fix. However his change in this file brings the processing time of some NEMO files significantly down. And will be very convenient to already merge.

The most extreme case is:
<img width="672" height="380" alt="image" src="https://github.com/user-attachments/assets/0faffebe-4115-4682-bb30-1f85b90af512" />
to:
<img width="673" height="388" alt="image" src="https://github.com/user-attachments/assets/70e7cf7d-31d5-4cb7-8a4d-98c4e89b45b7" />
The time without profiling is 8s.
PS: these flamecharts are now fully-connected because we got rid of the eval in #3045 :)