### PR TITLE
(Towards #3074) update dl_esm_inf to master

### DIFF
--- a/examples/lfric/scripts/Makefile
+++ b/examples/lfric/scripts/Makefile
@@ -40,6 +40,9 @@ include ../../common.mk
 # the compare_output.py script
 SCRIPTS = $(filter-out compare_ouput.py, $(wildcard *.py))
 
+# The kernel-extraction script generates driver source files.
+GENERATED_FILES += driver-*.F90
+
 transform: ${SCRIPTS}
 
 .PHONY: ${SCRIPTS}


### PR DESCRIPTION
Also improves the `allclean` target for examples to clean-up generated driver code.