### PR TITLE
Infer reduction clauses in parallel loop transformations

### DIFF
--- a/examples/nemo/scripts/omp_cpu_trans.py
+++ b/examples/nemo/scripts/omp_cpu_trans.py
@@ -82,7 +82,8 @@ def trans(psyir):
         return
 
     omp_parallel_trans = None
-    omp_loop_trans = OMPLoopTrans(omp_schedule="static")
+    omp_loop_trans = OMPLoopTrans(omp_schedule="static",
+                                  enable_reductions=True)
     omp_loop_trans.omp_directive = "paralleldo"
 
     for subroutine in psyir.walk(Routine):

--- a/src/psyclone/psyir/nodes/loop.py
+++ b/src/psyclone/psyir/nodes/loop.py
@@ -106,6 +106,10 @@ class Loop(Statement):
         # if this loop is run concurrently. Alternatively this could be
         # implemented by moving the symbols to the loop_body symbol table.
         self._explicitly_private_symbols = set()
+        # Hold the set of operator/variable pairs that can be used to create
+        # reduction clauses if the loop is run concurrently.
+        # TODO[mn416]: it's probably not necessary to store these here
+        self._inferred_reduction_vars = set()
 
     def __eq__(self, other):
         '''
@@ -134,6 +138,16 @@ class Loop(Statement):
         :rtype: Set[:py:class:`psyclone.psyir.symbols.DataSymbol`]
         '''
         return self._explicitly_private_symbols
+
+    @property
+    def inferred_reduction_vars(self):
+        '''
+        :returns: the set of operator/variable pairs that can be used to
+            create reduction clauses if the loop is run concurrently.
+        :rtype: Set[(str, str)]
+        '''
+        # TODO[mn416]: to use a richer datatype than strings.
+        return self._inferred_reduction_vars
 
     @property
     def loop_type(self):
@@ -465,6 +479,9 @@ class Loop(Statement):
                 except KeyError:
                     pass
         super().replace_symbols_using(table_or_symbol)
+
+        # TODO[mn416]: anything to do for self._inferred_reduction_vars
+        # here?
 
     def __str__(self):
         # Give Loop sub-classes a specialised name

--- a/src/psyclone/psyir/nodes/omp_directives.py
+++ b/src/psyclone/psyir/nodes/omp_directives.py
@@ -1785,6 +1785,11 @@ class OMPDoDirective(OMPRegionDirective, DataSharingAttributeMixin):
                 parts.append(f"reduction("
                              f"{OMP_OPERATOR_MAPPING[reduction_type]}:"
                              f"{reduction})")
+        # TODO[mn416]: use the OMPReductionClause class to insert reduction
+        # clauses into directives, rather than this low-level approach.
+        if isinstance(self.dir_body[0], Loop):
+            for (op, var) in self.dir_body[0].inferred_reduction_vars:
+                parts.append(f"reduction({op}:{var})")
         return ", ".join(parts)
 
     @property

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -577,7 +577,8 @@ def test_omploop_trans_new_options(sample_psyir):
     assert ("'OMPLoopTrans' received invalid options ['fakeoption1', "
             "'fakeoption2']. Valid options are '['node_type_check', "
             "'verbose', 'collapse', 'force', 'ignore_dependencies_for', "
-            "'privatise_arrays', 'sequential', 'nowait', 'reprod']."
+            "'privatise_arrays', 'sequential', 'nowait', 'enable_reductions', "
+            "'reprod']."
             in str(excinfo.value))
 
     # Check we get the relevant error message when submitting multiple


### PR DESCRIPTION
This is work in progress. The intention is to create a PR early so that CI can identify issues.

To infer reduction clauses, pass `enable_reductions=True` to the `apply()` method of `OMPLoopTrans`.

There are a number of TODOs in the code identifying things that would need to be polished before any potential merge.

The main limitations that I'm aware of are:

  * It only targets loops, not general parallel regions.
  * It only targets scalars, not arrays (array reduction variables have been supported since OpenMP 4.5).
  * No thought has been given to what happens when the same variable occurs both in a reduction clause and a data-sharing clause.
  * We'd like to add `OMPReductionClause`s to loop directives, instead of using the `_reduction_string()` method of `OMPDoDirective`.
  * We'd like an option along the lines of `force_reductions={'+': var_name}` to introduce reduction clauses that are not inferred.

All tests are passing locally, but so far there is only one test that exercises the new functionality.

There is also the question of whether the general approach I have taken is sensible or not. My hope is that this PR will be useful, even if the PSyclone team opts to implement the feature from scratch.