### PR TITLE
#3123 Updated lfric file forgotten in 2878.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   85) PR #3128 for #3123. Fixes Fortran file in lfric binary extraction
+   library so that it works with gfortran 15.
+
    84) PR #3116 for #2623. Remove old LFRic infrastructure and bring in
    new version.
 

--- a/lib/extract/binary/lfric/README.md
+++ b/lib/extract/binary/lfric/README.md
@@ -8,7 +8,7 @@ using the LFRic infrastructure library. A stand-alone driver can then be
 used to rerun this specific code region and verify the results (or
 compare performance).
 
-Note that the processed file ``read_kernel_data_mod.f90`` and
+Note that the processed files ``read_kernel_data_mod.f90`` and
 ``compare_variables_mod.F90`` are required for compilation tests.
 
 ## Dependencies

--- a/lib/extract/binary/lfric/README.md
+++ b/lib/extract/binary/lfric/README.md
@@ -8,8 +8,8 @@ using the LFRic infrastructure library. A stand-alone driver can then be
 used to rerun this specific code region and verify the results (or
 compare performance).
 
-Note that the processed file ``read_kernel_data_mod.f90`` is required for
-compilation tests.
+Note that the processed file ``read_kernel_data_mod.f90`` and
+``compare_variables_mod.F90`` are required for compilation tests.
 
 ## Dependencies
 

--- a/lib/extract/binary/lfric/compare_variables_mod.F90
+++ b/lib/extract/binary/lfric/compare_variables_mod.F90
@@ -134,7 +134,7 @@ contains
             "#rel<1E-9", "#rel<1E-6", "#rel<1E-3", "#rel>=1E-3", &
             "max_abs", "max_rel", "l2_diff", "l2_cos"
 
-        out_format = trim(out_format)//"' ',6(I12, ' '),4(E12.7,' '))"
+        out_format = trim(out_format)//",' ',6(I12, ' '),4(E12.7,' '))"
 
         ! Then write out the results for each variable:
         do i=1, current_index


### PR DESCRIPTION
A tiny fix for gfortran-15 compilation. The main issue was fixed in #2878, but I forgot to update the pre-processed file in lfric/binary (which is required for compilation tests).