### PR TITLE
(Closes #3159, #3140) bug fixes for parameter declaration handling

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+   97) PR #3160 for #3159 and #3140. Fix declarations with self-references.a
+
    96) PR #3153 for #3151. Fix some case-related naming comparison issues.
 
    95) PR #3108 for #2446. Adds the ability to automatically add reduction

--- a/src/psyclone/psyir/backend/fortran.py
+++ b/src/psyclone/psyir/backend/fortran.py
@@ -40,7 +40,6 @@
 from a PSyIR tree. '''
 
 # pylint: disable=too-many-lines
-from psyclone.core import Signature
 from psyclone.errors import InternalError
 from psyclone.psyir.backend.language_writer import LanguageWriter
 from psyclone.psyir.backend.visitor import VisitorError

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -1949,7 +1949,7 @@ class Fparser2Reader():
                 sym = symbol_table.lookup(sym_name, scope_limit=scope)
                 # pylint: disable=unidiomatic-typecheck
                 if type(sym) is Symbol:
-                    # This was a generic symbol. We now know what it is
+                    # This was a generic symbol. We now know what it is.
                     sym.specialise(DataSymbol, datatype=datatype,
                                    visibility=visibility,
                                    interface=this_interface,
@@ -1961,6 +1961,16 @@ class Fparser2Reader():
                             f"Symbol '{sym_name}' already present in "
                             f"SymbolTable with a defined interface "
                             f"({sym.interface}).")
+                    # We already had a DataSymbol but we need to update all of
+                    # its properties now we've found a declaration.
+                    tmp_sym = DataSymbol(
+                        sym_name,
+                        datatype=datatype,
+                        visibility=visibility,
+                        interface=this_interface,
+                        is_constant=has_constant_value,
+                        initial_value=init_expr)
+                    sym.copy_properties(tmp_sym)
             except KeyError:
                 try:
                     sym = DataSymbol(sym_name, datatype,


### PR DESCRIPTION
There were two bugs in the logic that determined the correct order in which to declare parameters:
 1. it was case sensitive;
 2. a parameter that depended on itself resulted in us raising an exception.
 
(For clarity, 2. is a possibility because of declarations like:
```fortran
real, parameter, dimension(4) :: var = [1, 1, 1, HUGE(var)]
```
)
In addition, while testing, I hit #3140 so have fixed that too - while processing a declaration, if we encountered a kind parameter symbol that we hadn't seen before we would create a DataSymbol. However, we did not update the properties of it when we subsequently found the actual declaration of that symbol because it was already a `DataSymbol` rather than just a `Symbol`.