### PR TITLE
(Closes #3406) Fix subroutine handler to find the subroutine stmt if it exists instead of assuming its the first child.

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   9) PR #3406 for # 3406. Fix issue with comment before a subroutine that
+   turns into a CodeBlock.
+ 
    8) PR #3371 towards #3012. Add workaround to bypass psyclonefc fixed-from
    issues.
 

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         classifiers=CLASSIFIERS,
         packages=PACKAGES,
         package_dir={"": "src"},
-        install_requires=['pyparsing', 'fparser==0.2.2', 'configparser',
+        install_requires=['pyparsing', 'fparser>=0.2.2', 'configparser',
                           'sympy', "Jinja2", 'termcolor', 'graphviz'],
         # Have to pin Sphinx to a pre-9.0 version because of
         # https://github.com/sphinx-doc/sphinx/issues/14223

--- a/setup.py
+++ b/setup.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         classifiers=CLASSIFIERS,
         packages=PACKAGES,
         package_dir={"": "src"},
-        install_requires=['pyparsing', 'fparser>=0.2.2', 'configparser',
+        install_requires=['pyparsing', 'fparser==0.2.2', 'configparser',
                           'sympy', "Jinja2", 'termcolor', 'graphviz'],
         # Have to pin Sphinx to a pre-9.0 version because of
         # https://github.com/sphinx-doc/sphinx/issues/14223

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -5717,7 +5717,16 @@ class Fparser2Reader():
         try:
             x = _first_type_match(node.children,
                                   Fortran2003.Internal_Subprogram_Part)
-            name = str(x.parent.children[0].children[1])
+            subroutine_stmt = None
+            for child in x.parent.children:
+                if isinstance(child, Fortran2003.Subroutine_Stmt):
+                    subroutine_stmt = child
+                    break
+            # Backup branch to maintain old functionality for edge cases
+            # and test suite.
+            if not subroutine_stmt:
+                subroutine_stmt = x.parent.children[0]
+            name = str(subroutine_stmt.children[1])
             # If we will make a CodeBlock to represent this subroutine then
             # we still need to ensure the symbol is in the parent's symbol
             # table. For this case the best we can do is place the symbol

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -5717,15 +5717,12 @@ class Fparser2Reader():
         try:
             x = _first_type_match(node.children,
                                   Fortran2003.Internal_Subprogram_Part)
-            subroutine_stmt = None
-            for child in x.parent.children:
-                if isinstance(child, Fortran2003.Subroutine_Stmt):
-                    subroutine_stmt = child
-                    break
-            # Backup branch to maintain old functionality for edge cases
-            # and test suite.
-            if not subroutine_stmt:
-                subroutine_stmt = x.parent.children[0]
+            # Find the Subroutine_Stmt or Function_Stmt to find the Name
+            # from.
+            subroutine_stmt = _first_type_match(
+                x.parent.children,
+                (Fortran2003.Subroutine_Stmt, Fortran2003.Function_Stmt)
+            )
             name = str(subroutine_stmt.children[1])
             # If we will make a CodeBlock to represent this subroutine then
             # we still need to ensure the symbol is in the parent's symbol

--- a/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
@@ -631,24 +631,54 @@ def test_module_contains_comment_before_subroutine(
     '''Test to check that subroutines contained in a module are
     correctly handled when there are comments before the subroutine
     statement after the contains.'''
-    code = """MODULE tsltde
+    code = """MODULE test_mod
 CONTAINS
 ! Here is a comment
-   SUBROUTINE tsl_tde_osc()
-   END SUBROUTINE tsl_tde_osc
-END MODULE tsltde"""
+   SUBROUTINE test()
+     contains
+     Subroutine subsub()
+     end subroutine
+   END SUBROUTINE test
+END MODULE test_mod"""
     fortran_reader = FortranReader(ignore_comments=False)
     psyir = fortran_reader.psyir_from_source(code)
     out = fortran_writer(psyir)
-    assert """module tsltde
-  implicit none
-  public
-
-  contains
+    assert """  contains
+  ! PSyclone CodeBlock (unsupported code) reason:
+  !  - PSyclone doesn't yet support 'Contains' inside a Subroutine or Function
   ! Here is a comment
-  subroutine tsl_tde_osc()
+    SUBROUTINE test
+    CONTAINS
+    SUBROUTINE subsub
+    END SUBROUTINE
+  END SUBROUTINE test""" in out
 
 
-  end subroutine tsl_tde_osc
+def test_module_contains_comment_before_function(
+    fortran_writer
+):
+    '''Test to check that functions contained in a module are
+    correctly handled when there are comments before the function
+    statement after the contains.'''
+    code = """MODULE test_mod
+CONTAINS
+! Here is a comment
+   FUNCTION test()
+     contains
+     function subsub()
+     end function
+   END FUNCTION test
+END MODULE test_mod"""
 
-end module tsltde""" in out
+    fortran_reader = FortranReader(ignore_comments=False)
+    psyir = fortran_reader.psyir_from_source(code)
+    out = fortran_writer(psyir)
+    assert """  contains
+  ! PSyclone CodeBlock (unsupported code) reason:
+  !  - PSyclone doesn't yet support 'Contains' inside a Subroutine or Function
+  ! Here is a comment
+    FUNCTION test()
+    CONTAINS
+    FUNCTION subsub()
+    END FUNCTION
+  END FUNCTION test""" in out

--- a/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
@@ -642,6 +642,8 @@ CONTAINS
 END MODULE test_mod"""
     fortran_reader = FortranReader(ignore_comments=False)
     psyir = fortran_reader.psyir_from_source(code)
+    assert "test" in psyir.children[0].symbol_table
+    assert "subsub" not in psyir.children[0].symbol_table
     out = fortran_writer(psyir)
     assert """  contains
   ! PSyclone CodeBlock (unsupported code) reason:
@@ -672,6 +674,8 @@ END MODULE test_mod"""
 
     fortran_reader = FortranReader(ignore_comments=False)
     psyir = fortran_reader.psyir_from_source(code)
+    assert "test" in psyir.children[0].symbol_table
+    assert "subsub" not in psyir.children[0].symbol_table
     out = fortran_writer(psyir)
     assert """  contains
   ! PSyclone CodeBlock (unsupported code) reason:

--- a/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_subroutine_handler_test.py
@@ -46,6 +46,7 @@ from fparser.common.readfortran import FortranStringReader
 from psyclone.errors import InternalError
 from psyclone.psyir.frontend.fparser2 import (
     Fparser2Reader, TYPE_MAP_FROM_FORTRAN)
+from psyclone.psyir.frontend.fortran import FortranReader
 from psyclone.psyir.nodes import Container, Routine, CodeBlock, FileContainer
 from psyclone.psyir.symbols import (
     DataSymbol, UnresolvedType, NoType, RoutineSymbol, ScalarType,
@@ -622,3 +623,32 @@ def test_module_contains_subroutine_contains_subroutine(
         psyir.children[0].symbol_table.lookup("s")
     out = fortran_writer(psyir)
     assert "subroutine func_a" not in out
+
+
+def test_module_contains_comment_before_subroutine(
+    fortran_writer
+):
+    '''Test to check that subroutines contained in a module are
+    correctly handled when there are comments before the subroutine
+    statement after the contains.'''
+    code = """MODULE tsltde
+CONTAINS
+! Here is a comment
+   SUBROUTINE tsl_tde_osc()
+   END SUBROUTINE tsl_tde_osc
+END MODULE tsltde"""
+    fortran_reader = FortranReader(ignore_comments=False)
+    psyir = fortran_reader.psyir_from_source(code)
+    out = fortran_writer(psyir)
+    assert """module tsltde
+  implicit none
+  public
+
+  contains
+  ! Here is a comment
+  subroutine tsl_tde_osc()
+
+
+  end subroutine tsl_tde_osc
+
+end module tsltde""" in out


### PR DESCRIPTION
@schreiberx This worked for the reproducer you gave us - if you have time to try it on NEMO itself it'd be appreciated.

Otherwise ready for a look from @arporter or @sergisiso. I will set ITs running in the mean time.