### PR TITLE
(Towards #3463) Reverse the order of operations to build the region in reverse

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+   2) PR #3464 towards #3463. Reverse the order to build maximal regions.
+
    1) PR #3472 for #3471. Let the transformations get_options method
    account for sub-transformation options.
   

--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   5) PR #3464 towards #3463. Reverse the construction order of maximal
+   regions and use the full-region as starting candidate.
+
    4) PR #3465 for #2757. Adds the --script-kwargs command line
    option to pass arguments to transformation scripts.
  

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -164,22 +164,22 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
         # Find the largest sections we can surround with the transformation.
         all_blocks = []
         current_block = []
-        for child in node_list:
+        for child in node_list[::-1]:
             # If the child can be added to a transformed region then add it
             # to the current block of nodes.
             if self._can_be_in_region(child):
                 # Check that validation still succeeds if we add this child
                 # to the current block.
                 try:
-                    trans.validate(current_block + [child], **trans_kwargs)
-                    current_block.append(child)
+                    trans.validate([child] + current_block, **trans_kwargs)
+                    current_block.insert(0, child)
                 except TransformationError:
                     # If validation now fails, then don't add this to the
                     # current block and add the block to the allowed blocks
                     # if allowed.
                     if current_block:
                         if self._satisfies_minimum_region_rules(current_block):
-                            all_blocks.append(current_block)
+                            all_blocks.insert(0, current_block)
                         current_block = []
             else:
                 # Otherwise, if the current_block contains any children,
@@ -187,29 +187,29 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
                 # the current_block.
                 if current_block:
                     if self._satisfies_minimum_region_rules(current_block):
-                        all_blocks.append(current_block)
+                        all_blocks.insert(0, current_block)
                     current_block = []
                 # Need to recurse on some node types
                 if isinstance(child, IfBlock):
-                    if_blocks = self._compute_transformable_sections(
-                            child.if_body, trans, trans_kwargs
-                    )
-                    all_blocks.extend(if_blocks)
                     if child.else_body:
                         else_blocks = self._compute_transformable_sections(
                             child.else_body, trans, trans_kwargs
                         )
-                        all_blocks.extend(else_blocks)
+                        all_blocks = else_blocks + all_blocks
+                    if_blocks = self._compute_transformable_sections(
+                            child.if_body, trans, trans_kwargs
+                    )
+                    all_blocks = if_blocks + all_blocks
                 if isinstance(child, (Loop, WhileLoop)):
                     loop_blocks = self._compute_transformable_sections(
                         child.loop_body, trans, trans_kwargs
                     )
-                    all_blocks.extend(loop_blocks)
+                    all_blocks = loop_blocks + all_blocks
         # If any nodes are left in the current block at the end of the
         # node_list, then add them to a transformed region
         if current_block:
             if self._satisfies_minimum_region_rules(current_block):
-                all_blocks.append(current_block)
+                all_blocks.insert(0, current_block)
 
         return all_blocks
 

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -149,7 +149,7 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
     def _compute_transformable_sections(
             self, node_list: Union[list[Node], Schedule],
             trans: Transformation,
-            trans_kwargs: dict[str, Any]
+            trans_kwargs: dict[str, Any],
     ) -> list[list[Node]]:
         '''
         Computes the sections of the input node_list to apply the
@@ -165,6 +165,22 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
         all_blocks = []
         current_block = []
         n_list = self.get_node_list(node_list)
+        # Initially test if the entire region can be transformed without
+        # breaking it up into pieces.
+        for child in n_list:
+            if not self._can_be_in_region(child):
+                break
+        else:
+            try:
+                # Test validation for the whole region, and if successful
+                # then we can finish.
+                trans.validate(n_list)
+                all_blocks.insert(n_list)
+                return all_blocks
+            except TransformationError:
+                pass
+        # Otherwise, loop over the region backwards and create the largest
+        # blocks possible.
         for child in reversed(n_list):
             # If the child can be added to a transformed region then add it
             # to the current block of nodes.

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -175,7 +175,7 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
                 # Test validation for the whole region, and if successful
                 # then we can finish.
                 trans.validate(n_list)
-                all_blocks.insert(n_list)
+                all_blocks.append(n_list)
                 return all_blocks
             except TransformationError:
                 pass

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -164,7 +164,7 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
         # Find the largest sections we can surround with the transformation.
         all_blocks = []
         current_block = []
-        for child in node_list[::-1]:
+        for child in reversed(node_list):
             # If the child can be added to a transformed region then add it
             # to the current block of nodes.
             if self._can_be_in_region(child):

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -147,7 +147,7 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
         return False
 
     def _compute_transformable_sections(
-            self, node_list: list[Node],
+            self, node_list: Union[list[Node], Schedule],
             trans: Transformation,
             trans_kwargs: dict[str, Any]
     ) -> list[list[Node]]:
@@ -164,7 +164,8 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
         # Find the largest sections we can surround with the transformation.
         all_blocks = []
         current_block = []
-        for child in reversed(node_list):
+        n_list = self.get_node_list(node_list)
+        for child in reversed(n_list):
             # If the child can be added to a transformed region then add it
             # to the current block of nodes.
             if self._can_be_in_region(child):

--- a/src/psyclone/psyir/transformations/maximal_region_trans.py
+++ b/src/psyclone/psyir/transformations/maximal_region_trans.py
@@ -175,7 +175,8 @@ class MaximalRegionTrans(RegionTrans, metaclass=abc.ABCMeta):
                 # Test validation for the whole region, and if successful
                 # then we can finish.
                 trans.validate(n_list)
-                all_blocks.append(n_list)
+                if self._satisfies_minimum_region_rules(n_list):
+                    all_blocks.append(n_list)
                 return all_blocks
             except TransformationError:
                 pass

--- a/src/psyclone/tests/psyir/transformations/maximal_region_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/maximal_region_trans_test.py
@@ -45,6 +45,7 @@ from psyclone.psyir.nodes import (
     Routine,
     Loop,
     OMPParallelDirective,
+    Node,
 )
 from psyclone.psyir.transformations import (
     MaximalRegionTrans,
@@ -386,3 +387,67 @@ def test_apply_force_private(fortran_reader):
     assert isinstance(nodes[0], OMPParallelDirective) is True
     pdir = nodes[0]
     assert len(pdir.explicitly_private_symbols) == 5
+
+
+def test_full_region_doesnt_meet_minimum_rules_compute_transformable_section(
+    fortran_reader
+):
+    '''Test that if the full region validates but doesn't meet the
+    requirements for _satisfies_minimum_region_rules then the returned
+    list is empty.'''
+    code = """subroutine x
+    integer :: i, ii, k, l, block
+    integer :: array_l(8)
+    block = 2
+    do ii = 1, 4
+        do k = 4, 1, -1
+            l = 0
+            do i = ii, min(ii+block -1, 4)
+                l = l + 1
+                array_l(l) = 1 + 2
+            end do
+        end do
+    end do
+    end subroutine x
+    """
+    psyir = fortran_reader.psyir_from_source(code)
+    # Apply loop_trans to all the loops possible.
+    ltrans = OMPLoopTrans(omp_schedule="static")
+    ltrans.apply(
+        psyir.walk(Loop)[0],
+        ignore_dependencies_for=["array_l"],
+        nowait=True)
+
+    # Create a transformation that always validates correctly
+    class testTrans(Transformation):
+        '''Dummy transformation that never fails validation.'''
+
+        def validate(self, nodes, **kwargs):
+            pass
+
+        def apply(self, nodes, **kwargs):
+            pass
+
+    # Create a region transformation that has a custom
+    # _satisfies_minimum_region_rules function that the
+    # input code will fail.
+    class TestRegTrans(MaximalRegionTrans):
+        ''' Dummy class to test MaxParallelRegionTrans' functionality. '''
+        # The apply function will do OMPParallelTrans around allowed regions.
+        _transformation = testTrans
+        _SUB_TRANSFORMATIONS = [testTrans]
+        # We're allowing any Node.
+        _allowed_contiguous_statements = (Node, )
+        # Should parallelise any found region.
+        _required_nodes = (Node, )
+
+        def _satisfies_minimum_region_rules(self, node_list):
+            ''' Arbitrarily the node list needs to be size 100 for this
+            MaximalRegionTrans.'''
+            return len(node_list) > 100
+
+    mtrans = TestRegTrans()
+    routine = psyir.walk(Routine)[0]
+    rval = mtrans._compute_transformable_sections(routine.children[:],
+                                                  testTrans(), {})
+    assert len(rval) == 0

--- a/src/psyclone/tests/psyir/transformations/maximal_region_trans_test.py
+++ b/src/psyclone/tests/psyir/transformations/maximal_region_trans_test.py
@@ -419,7 +419,7 @@ def test_full_region_doesnt_meet_minimum_rules_compute_transformable_section(
         nowait=True)
 
     # Create a transformation that always validates correctly
-    class testTrans(Transformation):
+    class TestTrans(Transformation):
         '''Dummy transformation that never fails validation.'''
 
         def validate(self, nodes, **kwargs):
@@ -434,8 +434,8 @@ def test_full_region_doesnt_meet_minimum_rules_compute_transformable_section(
     class TestRegTrans(MaximalRegionTrans):
         ''' Dummy class to test MaxParallelRegionTrans' functionality. '''
         # The apply function will do OMPParallelTrans around allowed regions.
-        _transformation = testTrans
-        _SUB_TRANSFORMATIONS = [testTrans]
+        _transformation = TestTrans
+        _SUB_TRANSFORMATIONS = [TestTrans]
         # We're allowing any Node.
         _allowed_contiguous_statements = (Node, )
         # Should parallelise any found region.
@@ -449,5 +449,5 @@ def test_full_region_doesnt_meet_minimum_rules_compute_transformable_section(
     mtrans = TestRegTrans()
     routine = psyir.walk(Routine)[0]
     rval = mtrans._compute_transformable_sections(routine.children[:],
-                                                  testTrans(), {})
+                                                  TestTrans(), {})
     assert len(rval) == 0


### PR DESCRIPTION
Simple PR to reverse the order in which maximal parallel region trans build their regions. I expect to need this to work out if assignments can be in parallel regions and its probably a more sensible default way to build these regions.

Ready for a review from @arporter or @sergisiso . I considered using a `deque`, however I would have ended up needing to cast the `deque` to a `list` enough times I didn't think it would save anything.