### PR TITLE
Control over Fortran file extensions recognised by `ModuleManager`

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   1) PR #3469. Extends the Module manager to have an extensible list
+   of file extensions and includes x95 and x03 suffixes by default.
+
 Release 3.3.0 29th June 2026
 
    35) PR #3476 for #3475. Fixes OMPParallelLoopTrans to support the

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -235,7 +235,8 @@ class ModuleManager:
         if not isinstance(exts, set):
             raise TypeError(
                 f"'fortran_file_exts' must be a set, but found "
-                f"{type(exts).__name__}")
+                f"{type(exts).__name__}"
+            )
         self._fortran_file_exts = exts
 
     # ------------------------------------------------------------------------

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -524,8 +524,10 @@ class ModuleManager:
         # with '.x'. (The latter condition is present to preserve
         # previous behaviour, although it's unclear if that behavior
         # is indeed desired.)
-        base, ext = os.path.splittext(filename)
-        return ext.islower() and not ext.beginswith(".x")
+        base, ext = os.path.splitext(filename)
+        return (ext in self._fortran_file_exts and
+                ext.islower() and
+                not ext.startswith(".x"))
 
     def get_module_info(self, module_name: str) -> Optional[ModuleInfo]:
         """This function returns the ModuleInfo for the specified

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -520,10 +520,12 @@ class ModuleManager:
         """Returns True if the file with the given filename
         doesn't need preprocessing."""
         # The current method is just to check that the file extension
-        # is a lower-case Fortran file extension.
-        return any([filename.endswith(ext)
-                    for ext in self._fortran_file_exts
-                    if ext.islower()])
+        # is a lower-case Fortran file extension and doesn't begin
+        # with '.x'. (The latter condition is present to preserve
+        # previous behaviour, although it's unclear if that behavior
+        # is indeed desired.)
+        base, ext = os.path.splittext(filename)
+        return ext.islower() and not ext.beginswith(".x")
 
     def get_module_info(self, module_name: str) -> Optional[ModuleInfo]:
         """This function returns the ModuleInfo for the specified

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -141,6 +141,10 @@ class ModuleManager:
         self._module_pattern = re.compile(r"^\s*module\s+([a-z]\S*)\s*$",
                                           flags=re.IGNORECASE | re.MULTILINE)
 
+        # Files with an extension from this set will be considered
+        # when searching for Fortran files
+        self._fortran_file_exts = {".F90", ".f90", ".X90", ".x90"}
+
     @property
     def cache_active(self) -> bool:
         '''
@@ -210,6 +214,27 @@ class ModuleManager:
                         f"str, but found an item of {type(x)}")
         self._resolve_indirect_imports = value
 
+    @property
+    def fortran_file_exts(self) -> set[str]:
+        '''
+        :returns: the set of file extensions that are considered when
+            searching for Fortran files.
+        '''
+        return self._fortran_file_exts
+
+    @fortran_file_exts.setter
+    def fortran_file_exts(self, exts: set[str]):
+        '''
+        :param exts: the set of file extensions that are considered when
+            searching for Fortran files.
+
+        :raises TypeError: if the provided value is not a set.
+        '''
+        if not isinstance(exts, set):
+            raise TypeError(
+                f"'fortran_file_exts' must be a set, but found {type(exts)}")
+        self._fortran_file_exts = exts
+
     # ------------------------------------------------------------------------
     def add_search_path(self,
                         directories: Union[str, Path,
@@ -254,7 +279,7 @@ class ModuleManager:
     # ------------------------------------------------------------------------
     def _add_all_files_from_dir(self, directory: str) -> list[FileInfo]:
         '''This function creates (and caches) FileInfo objects for all files
-        with an extension of (F/f/X/x)90 in the given directory that have
+        with a Fortran file extension in the given directory that have
         not previously been visited. The new FileInfo objects are returned.
 
         :param directory: the directory containing Fortran files
@@ -269,7 +294,7 @@ class ModuleManager:
             for entry in all_entries:
                 _, ext = os.path.splitext(entry.name)
                 if (not entry.is_file() or
-                        ext not in [".F90", ".f90", ".X90", ".x90"]):
+                        ext not in self._fortran_file_exts):
                     continue
                 full_path = os.path.join(directory, entry.name)
                 if full_path in self._visited_files:
@@ -321,7 +346,7 @@ class ModuleManager:
                     self._modules[name] = mod_info
                     # A file that has been (or does not require)
                     # preprocessing always takes precedence.
-                    if finfo.filename.endswith(".f90"):
+                    if self._doesnt_need_preprocessing(finfo.filename):
                         return mod_info
         return mod_info
 
@@ -490,6 +515,15 @@ class ModuleManager:
         """
         return list(self._filepath_to_file_info.values())
 
+    def _doesnt_need_preprocessing(self, filename: str) -> bool:
+        """Returns True if the file with the given filename
+        doesn't need preprocessing."""
+        # The current method is just to check that the file extension
+        # is a lower-case Fortran file extension.
+        return any([filename.endswith(ext)
+                    for ext in self._fortran_file_exts
+                    if ext.islower()])
+
     def get_module_info(self, module_name: str) -> Optional[ModuleInfo]:
         """This function returns the ModuleInfo for the specified
         module.
@@ -509,16 +543,15 @@ class ModuleManager:
             return None
 
         # First check if we have already seen this module. We only end the
-        # search early if the file we've found does not require pre-processing
-        # (i.e. has a .f90 suffix).
+        # search early if the file we've found does not require pre-processing.
         mod_info = self._modules.get(mod_lower, None)
-        if mod_info and mod_info.filename.endswith(".f90"):
+        if mod_info and self._doesnt_need_preprocessing(mod_info.filename):
             return mod_info
         old_mod_info = mod_info
         # Are any of the files that we've already seen a good match?
         mod_info = self._find_module_in_files(mod_lower,
                                               self._visited_files.values())
-        if mod_info and mod_info.filename.endswith(".f90"):
+        if mod_info and self._doesnt_need_preprocessing(mod_info.filename):
             return mod_info
         old_mod_info = mod_info
 

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -32,6 +32,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 # -----------------------------------------------------------------------------
 # Author J. Henrichs, Bureau of Meteorology
+# Modifications: M. Naylor, University of Cambridge, UK
 
 '''This module contains a singleton class that manages information about
 which module is contained in which file (including full location). '''
@@ -143,7 +144,8 @@ class ModuleManager:
 
         # Files with an extension from this set will be considered
         # when searching for Fortran files
-        self._fortran_file_exts = {".F90", ".f90", ".X90", ".x90"}
+        self._fortran_file_exts = {".F90", ".f90", ".X90", ".x90",
+                                   ".F95", ".f95", ".F03", ".f03"}
 
     @property
     def cache_active(self) -> bool:

--- a/src/psyclone/parse/module_manager.py
+++ b/src/psyclone/parse/module_manager.py
@@ -232,7 +232,8 @@ class ModuleManager:
         '''
         if not isinstance(exts, set):
             raise TypeError(
-                f"'fortran_file_exts' must be a set, but found {type(exts)}")
+                f"'fortran_file_exts' must be a set, but found "
+                f"{type(exts).__name__}")
         self._fortran_file_exts = exts
 
     # ------------------------------------------------------------------------

--- a/src/psyclone/tests/parse/module_manager_test.py
+++ b/src/psyclone/tests/parse/module_manager_test.py
@@ -568,3 +568,9 @@ def test_mod_manager_fortran_file_exts() -> None:
     assert '.f90' in mod_man.fortran_file_exts
     mod_man.fortran_file_exts = {".f95"}
     assert mod_man.fortran_file_exts == {".f95"}
+
+    # Check that type errors are spotted
+    with pytest.raises(TypeError) as err:
+        mod_man.fortran_file_exts = True
+    assert ("'fortran_file_exts' must be a set, but found bool"
+            in str(err.value))

--- a/src/psyclone/tests/parse/module_manager_test.py
+++ b/src/psyclone/tests/parse/module_manager_test.py
@@ -547,3 +547,24 @@ def test_mod_manager_load_all_module_trigger_error_file_read_twice() -> None:
         mod_man.load_all_module_infos(error_if_file_already_processed=True)
 
     assert "File 't_mod.f90' already processed" in str(einfo.value)
+
+
+@pytest.mark.usefixtures("clear_module_manager_instance")
+def test_mod_manager_fortran_file_exts() -> None:
+    '''Tests functionality for modifying managing Fortran file etensions.'''
+    mod_man = ModuleManager.get()
+
+    # Check that the default extensions include '.f90' and '.F90'
+    assert '.f90' in mod_man.fortran_file_exts
+    assert '.F90' in mod_man.fortran_file_exts
+
+    # Check that we can add and remove a new Fortran file extension
+    assert '.foo' not in mod_man.fortran_file_exts
+    mod_man.fortran_file_exts.add(".foo")
+    assert '.foo' in mod_man.fortran_file_exts
+    assert '.f90' in mod_man.fortran_file_exts
+    mod_man.fortran_file_exts.remove(".foo")
+    assert '.foo' not in mod_man.fortran_file_exts
+    assert '.f90' in mod_man.fortran_file_exts
+    mod_man.fortran_file_exts = {".f95"}
+    assert mod_man.fortran_file_exts == {".f95"}

--- a/src/psyclone/version.py
+++ b/src/psyclone/version.py
@@ -46,7 +46,7 @@ __MINOR__ = 3
 __MICRO__ = 0
 
 # Version suffix e.g. "-rc1", "-dev" or "" (for a full release)
-_VERSION_SUFFIX = ""
+_VERSION_SUFFIX = "-dev"
 
 __SHORT_VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}{_VERSION_SUFFIX}"
 __VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}.{__MICRO__:d}{_VERSION_SUFFIX}"


### PR DESCRIPTION
Basic stuff, but I started using PSyclone in a code base with `.f95` files and wondered why imports were not getting resolved. Turns out that `ModuleManager` has a limited set of harded coded file extensions that doesn't include `.f95` so this PR adds the ability to add/remove Fortran file extensions recognised by `ModuleManager`. It also abstracts out a commonly used "doesn't need preprocessing" check into a method, which makes the code a bit cleaner.

Edit: I believe these changes preserve existing behaviour exactly; they just introduce methods to allow modification of the default settings.