### PR TITLE
(Closes #3364) Prepare for release 3.3.0

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,5 @@
+Release 3.3.0 29th June 2026
+
    34) PR #3440. Update to use release 0.2.4 of fparser.
  
    33) PR #3467. Update CI compilers.

--- a/doc/reference_guide/doxygen.config
+++ b/doc/reference_guide/doxygen.config
@@ -48,7 +48,7 @@ PROJECT_NAME           = "Reference Guide"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.3.1-dev
+PROJECT_NUMBER         = 3.3.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewers a

--- a/examples/nemo/scripts/README.md
+++ b/examples/nemo/scripts/README.md
@@ -62,7 +62,7 @@ wget https://gws-access.jasmin.ac.uk/public/nemo/sette_inputs/r5.0.0/ORCA2_ICE_v
 tar -xzf ORCA2_ICE_v5.0.0.tar.gz
 ```
 
-The examples have been tested with NEMOv4.0.2 (SPLITZ configuration) and
+The examples have been tested with NEMOv4.0.2 (SPITZ configuration) and
 NEMOv5.0 (BENCH and ORCA_ICE_PISCIES configuration), but we aim to support
 any version of NEMO. If you encounter any issue applying these examples
 please report to the authors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ authors = [
     { name = "Aidan Chalk", email = "aidan.chalk@stfc.ac.uk" },
     { name = "Joerg Henrichs", email = "joerg.henrichs@bom.gov.au" }
 ]
-license = { text = "BSD 3-Clause License" }
+license = "BSD-3-Clause"
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "pyparsing",
     "fparser==0.2.4",
     "configparser",
-    "sympy",
+    "sympy<=1.13.3",  # TODO #3474: Adjoint fails with sympy >= 1.14
     "Jinja2",
     "termcolor",
     "graphviz"

--- a/src/psyclone/version.py
+++ b/src/psyclone/version.py
@@ -37,14 +37,16 @@
 
 ''' Single location for the current version number of PSyclone. This is
     used in setup.py and
-    doc/{user_guide,developer_guide,reference_guide/source}/conf.py '''
+    doc/{user_guide,developer_guide,reference_guide/source}/conf.py
+
+    It is NOT used in doc/reference_guide/doxygen.config'''
 
 __MAJOR__ = 3
 __MINOR__ = 3
-__MICRO__ = 1
+__MICRO__ = 0
 
-# Version suffix (e.g. -rc1 or -dev)
-_VERSION_SUFFIX = "-dev"
+# Version suffix e.g. "-rc1", "-dev" or "" (for a full release)
+_VERSION_SUFFIX = ""
 
 __SHORT_VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}{_VERSION_SUFFIX}"
 __VERSION__ = f"{__MAJOR__:d}.{__MINOR__:d}.{__MICRO__:d}{_VERSION_SUFFIX}"


### PR DESCRIPTION
Just updates the version number in the two locations.
At merge time we'll need to update the changelog too.
As the 'update to fparser 0.2.4' has just gone on, we know that all of the fparser settings in the various workflow files are correct already.