### PR TITLE
(closes #3475) Make OMPParallelLoopTrans respect the force_private kwarg

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   35) PR #3476 for #3475. Fixes OMPParallelLoopTrans to support the
+   force_private keyword argument.
+
    34) PR #3440. Update to use release 0.2.4 of fparser.
  
    33) PR #3467. Update CI compilers.

--- a/src/psyclone/psyir/transformations/omp_parallel_loop_trans.py
+++ b/src/psyclone/psyir/transformations/omp_parallel_loop_trans.py
@@ -40,12 +40,16 @@
 #          J. Dendy, Met Office
 
 
+import logging
+from typing import Iterable
 from psyclone.psyir.nodes import (
     OMPParallelDoDirective, OMPReductionClause)
 from psyclone.psyir.nodes.omp_directives import MAP_REDUCTION_OP_TO_OMP
 from psyclone.psyir.transformations.omp_loop_trans import OMPLoopTrans
+from psyclone.utils import transformation_documentation_wrapper
 
 
+@transformation_documentation_wrapper(inherit=False)
 class OMPParallelLoopTrans(OMPLoopTrans):
     ''' Adds an OpenMP PARALLEL DO directive to a loop.
 
@@ -69,7 +73,9 @@ class OMPParallelLoopTrans(OMPLoopTrans):
     def __str__(self):
         return "Add an 'OpenMP PARALLEL DO' directive"
 
-    def apply(self, node, options=None, **kwargs):
+    def apply(self, node,
+              force_private: Iterable[str] = tuple(),
+              options=None, **kwargs):
         ''' Apply an OMPParallelLoop Transformation to the supplied node
         (which must be a Loop). In the generated code this corresponds to
         wrapping the Loop with directives:
@@ -84,6 +90,8 @@ class OMPParallelLoopTrans(OMPLoopTrans):
 
         :param node: the node (loop) to which to apply the transformation.
         :type node: :py:class:`psyclone.psyir.nodes.Loop`
+        :param Iterable[str] force_private: specify a list of symbol names
+            explicitly requested to be private.
         :param options: a dictionary with options for transformations
             and validation.
         :type options: Optional[Dict[str, Any]]
@@ -93,7 +101,8 @@ class OMPParallelLoopTrans(OMPLoopTrans):
             local_options["reduction_ops"] = \
                 list(MAP_REDUCTION_OP_TO_OMP.keys())
 
-        self.validate(node, options=local_options, **kwargs)
+        self.validate(node, options=local_options, force_private=force_private,
+                      **kwargs)
 
         # keep a reference to the node's original parent and its index as these
         # are required and will change when we change the node's location
@@ -113,6 +122,22 @@ class OMPParallelLoopTrans(OMPLoopTrans):
 
         # add the OpenMP loop directive as a child of the node's parent
         node_parent.addchild(directive, index=node_position)
+
+        # Add explicit private variables
+        logger = logging.getLogger(__name__)
+        explicitly_private_symbols = set()
+        for symbol_name in force_private:
+            try:
+                sym = node.scope.symbol_table.lookup(symbol_name)
+                explicitly_private_symbols.add(sym)
+            except KeyError:
+                # This is not an error, but we will log the missed string
+                logger.warning(
+                    "%s has been provided with the '%s' symbol name in "
+                    "the 'force_private' option, but there is no such "
+                    "symbol in this scope.", self.name, symbol_name)
+        directive.explicitly_private_symbols.update(
+            explicitly_private_symbols)
 
 
 # For Sphinx AutoAPI documentation generation

--- a/src/psyclone/psyir/transformations/parallel_loop_trans.py
+++ b/src/psyclone/psyir/transformations/parallel_loop_trans.py
@@ -478,13 +478,13 @@ class ParallelLoopTrans(LoopTrans, AsyncTransMixin, metaclass=abc.ABCMeta):
         for symbol_name in force_private:
             try:
                 sym = node.scope.symbol_table.lookup(symbol_name)
+                explicitly_private_symbols.add(sym)
             except KeyError:
                 # This is not an error, but we will log the missed string
                 logger.warning(
                     "%s has been provided with the '%s' symbol name in "
                     "the 'force_private' option, but there is no such "
                     "symbol in this scope.", self.name, symbol_name)
-            explicitly_private_symbols.add(sym)
 
         list_of_signatures = [Signature(name) for name in list_of_names]
         dtools = DependencyTools()

--- a/src/psyclone/tests/psyir/transformations/transformations_test.py
+++ b/src/psyclone/tests/psyir/transformations/transformations_test.py
@@ -41,6 +41,7 @@
 API-agnostic tests for various transformation classes.
 '''
 
+import logging
 import sys
 import os
 import pytest
@@ -509,6 +510,53 @@ def test_omplooptrans_properties():
         omplooptrans.omp_schedule = "dynamic,"
     assert ("Supplied OpenMP schedule 'dynamic,' has an invalid chunk-size."
             in str(err.value))
+
+
+def test_omplooptrans_apply_force_private(fortran_reader, fortran_writer,
+                                          tmpdir, caplog):
+    ''' Test applying the OMPParallelLoopTrans in cases where a list of
+    explicit private variables is given. '''
+
+    psyir = fortran_reader.psyir_from_source('''
+        module my_mod
+            contains
+            subroutine my_subroutine()
+                integer :: ji, jj, jk, jpkm1, jpjm1, jpim1, scalar1
+                real, dimension(10, 10, 10) :: array1, array2
+                array2 = 1
+                do jk = 2, jpkm1, 1
+                  do jj = 2, jpjm1, 1
+                    do ji = 2, jpim1, 1
+                       array2(ji,jj,jk) = array2(ji,jj,jk) + 1
+                       array1(ji,jj,jk) = array2(ji,jj,jk)
+                    enddo
+                  enddo
+                enddo
+            end subroutine
+        end module my_mod''')
+    omplooptrans = OMPParallelLoopTrans()
+    loop = psyir.walk(Loop)[0]
+
+    caplog.clear()
+    with caplog.at_level(logging.WARNING,
+                         logger="psyclone.psyir.transformations"):
+        omplooptrans.apply(loop, force_private=['array2', 'other'])
+
+    # 'other' is not used, but this is logged
+    assert ("OMPParallelLoopTrans has been provided with the 'other' symbol "
+            "name in the 'force_private' option, but there is no such symbol "
+            "in this scope." in caplog.text)
+
+    # array2 is requested private, the shared_attibute_inference promotes it to
+    # firstprivate because it is read first
+    expected = '''\
+    !$omp parallel do default(shared) private(ji,jj,jk) firstprivate(array2) \
+schedule(auto)
+    do jk = 2, jpkm1, 1\n'''
+
+    gen = fortran_writer(psyir)
+    assert expected in gen
+    assert Compile(tmpdir).string_compiles(gen)
 
 
 def test_omplooptrans_apply_firstprivate(fortran_reader, fortran_writer,

--- a/src/psyclone/transformations.py
+++ b/src/psyclone/transformations.py
@@ -117,6 +117,7 @@ def check_intergrid(node):
                 f" is such a kernel.")
 
 
+@transformation_documentation_wrapper
 class LFRicOMPParallelLoopTrans(OMPParallelLoopTrans):
 
     ''' LFRic-specific OpenMP loop transformation. Adds LFRic specific
@@ -137,7 +138,7 @@ class LFRicOMPParallelLoopTrans(OMPParallelLoopTrans):
     def __str__(self):
         return "Add an OpenMP Parallel Do directive to an LFRic loop"
 
-    def validate(self, node, options=None):
+    def validate(self, node, options=None, **kwargs):
         '''
         Perform LFRic-specific loop validity checks then call the `validate`
         method of the base class.
@@ -175,7 +176,20 @@ class LFRicOMPParallelLoopTrans(OMPParallelLoopTrans):
         # correct sharing attributes).
         local_options = options.copy() if options else {}
         local_options["force"] = True
-        super().validate(node, options=local_options)
+        super().validate(node, options=local_options, **kwargs)
+
+    def apply(self, node, options=None, **kwargs):
+        '''
+        Add OpenMP Parallel for LFRic PSy-layer loops.
+
+        :param node: the given loop node.
+        :type node: :py:class:`psyclone.psyir.nodes.Loop`
+        :param options: a dictionary with options for transformations
+            and validation.
+        :type options: Optional[Dict[str, Any]]
+
+        '''
+        super().apply(node, options=options, **kwargs)
 
 
 class GOceanOMPParallelLoopTrans(OMPParallelLoopTrans):


### PR DESCRIPTION
This fixes one of the issues that LFRic_apps is having to adopt psyclone 3.3.

@LonelyCat124 I got a bit nervous about modifying the existing 'enable_reductions' option because it does a local `options.copy()` that I don't understand. So for the time being I left it as an option. I propose we unify this after the release. 