### PR TITLE
(Closes #3506) added fparser ref detection to util script + cleanup

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ feature that the Issue is intended to tackle.
 During development work please use the Issue to make notes of any design decisions or
 problems encountered. Please also tag all commit messages with the Issue number e.g.:
 
-    git commit -m "#111 make an amazing change" some/modified/file.py
+    git commit -m "#<issue_number> make an amazing change" some/modified/file.py
     
 so that all related commits will show up in the Issue.
 

--- a/changelog
+++ b/changelog
@@ -1,6 +1,8 @@
+   34) PR #3561 for #3506. Remove or replace remaining TODOs of closed issues.
+
    33) PR #3555 for #3553. Fix issues with line_length breaking comments.
 
-   32) PR #3535 towards #3506. Remove or replaces TODOS of closed issues.
+   32) PR #3535 towards #3506. Remove or replace TODOs of closed issues.
 
    31) PR #3556 for #3547. Add a utility to report TODOs to closed issues
    still in the code.

--- a/doc/developer_guide/psykal.rst
+++ b/doc/developer_guide/psykal.rst
@@ -242,7 +242,7 @@ is because `fparser2` does not currently support a symbol table,
 therefore there is no link between variables names and their types. In
 the future, the algorithm layer will be translated into PSyIR, which
 does have a symbol table, so this dictionary will no longer be
-required (see issue #753).
+required (see issue #1618).
 
 All declarations that specify variables or types are stored in the
 dictionary, including those specified within locally defined
@@ -265,7 +265,7 @@ As the current implementation only stores variable names and does not
 know about variable scope there is a restriction that any variables
 within an algorithm code with the same name must have the same
 precision/type. This restriction will be removed when the algorithm
-layer is translated to PSyIR (see issue #753). The current
+layer is translated to PSyIR (see issue #1618). The current
 implementation could be improved but in practice the lfric code does
 not fall foul of this restriction.
 
@@ -300,7 +300,7 @@ via use association. Potential solutions to this problem are 1)
 disallow this in the algorithm layer, 2) use a naming convention for
 the module and/or variable to determine its precision, or 3) search the
 modules for datatype information. At the moment only 1) or 2) will be
-feasible solutions. When we move to using the PSyIR (see issue #753),
+feasible solutions. When we move to using the PSyIR (see issue #1618),
 it may be possible to support 3).
 
 	  

--- a/src/psyclone/domain/common/algorithm/psyir.py
+++ b/src/psyclone/domain/common/algorithm/psyir.py
@@ -64,7 +64,7 @@ class AlgorithmInvokeCall(Call):
         self._index = index
         # Keep the root names as these will also be needed by the
         # PSy-layer to use as tags to pull out the actual names from
-        # the algorithm symbol table, once issue #753 is complete.
+        # the algorithm symbol table, once issue #1618 is complete.
         # They are public properties because they are needed in
         # AlgInvoke2PSyCallTrans.
         self.psylayer_routine_root_name = None

--- a/src/psyclone/domain/common/algorithm/psyir.py
+++ b/src/psyclone/domain/common/algorithm/psyir.py
@@ -159,8 +159,9 @@ class AlgorithmInvokeCall(Call):
             if routine_root_name[0] == '"' and routine_root_name[-1] == '"' \
                or \
                routine_root_name[0] == "'" and routine_root_name[-1] == "'":
-                # fparser2 (issue #295) currently includes quotes as
-                # part of a string, so strip them out.
+                # fparser2 issue https://github.com/stfc/fparser/issues/295
+                # currently includes quotes as part of a string, so strip
+                # them out.
                 routine_root_name = routine_root_name[1:-1].strip()
             routine_root_name = routine_root_name.replace(" ", "_")
             # Check that the name is a valid routine name

--- a/src/psyclone/domain/common/transformations/alg_invoke_2_psy_call_trans.py
+++ b/src/psyclone/domain/common/transformations/alg_invoke_2_psy_call_trans.py
@@ -190,7 +190,7 @@ class AlgInvoke2PSyCallTrans(Transformation, abc.ABC):
         # Remove functor symbols that are no longer used.
         self.remove_imported_symbols(node)
 
-        # TODO #753. At the moment the container and routine names
+        # TODO #1618. At the moment the container and routine names
         # produced here will differ from the PSy-layer routine name if
         # there is a name clash in the algorithm layer.
         container_tag = node.psylayer_container_root_name

--- a/src/psyclone/domain/lfric/kernel/common_arg_metadata.py
+++ b/src/psyclone/domain/lfric/kernel/common_arg_metadata.py
@@ -143,8 +143,8 @@ class CommonArgMetadata(CommonMetadata):
                 text = child.children[1].tostr()
                 if isinstance(child.children[1],
                               Fortran2003.Char_Literal_Constant):
-                    # TODO fparser/#295 - fparser keeps the quotation marks
-                    # in character strings.
+                    # TODO https://github.com/stfc/fparser/issues/295 -
+                    # fparser keeps the quotation marks in character strings.
                     return text[1:-1].lower()
                 return text
         return None

--- a/src/psyclone/lfric.py
+++ b/src/psyclone/lfric.py
@@ -5051,7 +5051,7 @@ class HaloReadAccess(HaloDepth):
                 # Stencil_depth is provided by the algorithm layer.
                 # It is currently not possible to specify kind for an
                 # integer literal stencil depth in a kernel call. This
-                # will be enabled when addressing issue #753.
+                # will be enabled when addressing issue #1618.
                 if field.stencil.extent_arg.is_literal():
                     # a literal is specified
                     value_str = field.stencil.extent_arg.text
@@ -5662,7 +5662,7 @@ class LFRicKernelArgument(KernelArgument):
                 f"type '{arg_meta_data.data_type}' in the kernel argument "
                 f"descriptor '{arg_meta_data}'.") from err
 
-        # Addressing issue #753 will allow us to perform static checks
+        # Addressing issue #1618 will allow us to perform static checks
         # for consistency between the algorithm and the kernel
         # metadata. This will include checking that a field on a read
         # only function space is not passed to a kernel that modifies

--- a/src/psyclone/line_length.py
+++ b/src/psyclone/line_length.py
@@ -74,7 +74,8 @@ class FortLineLength():
         One known situation that could cause an instance of the
         :class:`line_length.FortLineLength` class to fail is when an *inline*
         comment at the end of a line containing a *directive* takes it over
-        the 132-character limit. (TODO fparser/#468)
+        the 132-character limit.
+        (TODO https://github.com/stfc/fparser/issues/468)
 
     '''
     # pylint: disable=too-many-instance-attributes
@@ -164,7 +165,8 @@ class FortLineLength():
                     fline = freader.next()
                     # This won't work for a directive with an in-line comment
                     # as FortranStringReader returns a single Comment object
-                    # for the whole thing (TODO fparser/#468).
+                    # for the whole thing:
+                    # (TODO https://github.com/stfc/fparser/issues/468).
                     if ((break_point - indent_size) > len(fline.line) and
                             isinstance(freader.next(), Comment)):
                         # Breakpoint is inside a comment so change the chars

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -3190,8 +3190,8 @@ class Fparser2Reader():
         # them.
         if not self._ignore_directives and len(preceding_comments) != 0:
             for comment in preceding_comments[:]:
-                # TODO: fparser #469. This only captures some free-form
-                # directives.
+                # TODO: https://github.com/stfc/fparser/issues/469
+                # This only captures some free-form directives.
                 if comment.tostr().startswith("!$"):
                     self.nodes_to_code_block(parent, [comment])
                     preceding_comments.remove(comment)

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -5559,9 +5559,10 @@ class Fparser2Reader():
         '''
         character_type = ScalarType(ScalarType.Intrinsic.CHARACTER,
                                     get_literal_precision(node, parent))
-        # fparser issue #295 - the value of the character string currently
-        # contains the quotation symbols themselves. Once that's fixed this
-        # check will need to be changed.
+        # fparser issue https://github.com/stfc/fparser/issues/295 - the
+        # value of the character string currently contains the quotation
+        # symbols themselves. Once that's fixed this check will need to
+        # be changed.
         char_value = str(node.items[0])
         if not ((char_value.startswith("'") and char_value.endswith("'")) or
                 (char_value.startswith('"') and char_value.endswith('"'))):

--- a/src/psyclone/psyir/nodes/codeblock.py
+++ b/src/psyclone/psyir/nodes/codeblock.py
@@ -289,7 +289,8 @@ class Fparser2CodeBlock(CodeBlock):
                 # Need to make sure we include any Symbol in the conditional
                 # part but not a label (which would be the second child in the
                 # parse tree). We cannot simply do
-                # `node.parent.children.index(node)` because of fparser #174.
+                # `node.parent.children.index(node)` because of fparser issue
+                # https://github.com/stfc/fparser/issues/174
                 if (len(node.parent.children) == 1 or
                         node is node.parent.children[0]):
                     result.append(node.string)

--- a/src/psyclone/tests/line_length_test.py
+++ b/src/psyclone/tests/line_length_test.py
@@ -200,8 +200,9 @@ def test_inline_comment():
     output = fll.process(input_code)
     if "long  \n!$ long long" not in output:
         pytest.xfail(
-            reason="TODO fparser/#468 - fparser.common.FortranReader "
-            "represents directives as Comments.")
+            reason="TODO https://github.com/stfc/fparser/issues/468- "
+            "fparser.common.FortranReader represents directives as "
+            "Comments.")
 
 
 def test_exception_line_too_long():

--- a/src/psyclone/tests/parse/algorithm_test.py
+++ b/src/psyclone/tests/parse/algorithm_test.py
@@ -325,7 +325,7 @@ def test_parser_invokeinfo_datatypes_clash():
     is simply a limitation of the current implementation as we do not
     capture the context of a symbol so do not deal with variable
     scope. This limitation will disappear when the PSyIR is used to
-    determine datatypes, see issue #753.
+    determine datatypes, see issue #1618.
 
     '''
     alg_filename = os.path.join(

--- a/src/psyclone/tests/psyir/frontend/fparser2_literals_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_literals_test.py
@@ -39,9 +39,9 @@ def test_handling_literal(code, dtype):
     supported datatypes. Note that signed literals are represented in the
     PSyIR as a Unary operation on an unsigned literal.
 
-    Note that because of fparser issue #295 we must include the quotation marks
-    with supplied character literals. Once that issue is done, these can
-    be removed.
+    Note that because of issue https://github.com/stfc/fparser/issues/295
+    we must include the quotation marks with supplied character literals.
+    Once that issue is done, these can be removed.
 
     '''
     reader = FortranStringReader("x=" + code)
@@ -96,8 +96,8 @@ end program my_prog
 @pytest.mark.usefixtures("f2008_parser")
 def test_literal_char_without_quotes_error():
     ''' Test that the check in the handler that the provided string is quoted
-    works as expected. This will need to be changed once fparser #295 is
-    done. '''
+    works as expected. This will need to be changed once fparser issue
+    https://github.com/stfc/fparser/issues/295 is done. '''
     reader = FortranStringReader("x = 'hello'")
     astmt = Fortran2003.Assignment_Stmt(reader)
     # Edit the resulting parse tree to remove the quotes

--- a/src/psyclone/tests/test_files/lfric/14.11_halo_required_clean_multi.f90
+++ b/src/psyclone/tests/test_files/lfric/14.11_halo_required_clean_multi.f90
@@ -17,7 +17,7 @@ program halo_different_stencils
   ! information at the moment in any case.
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use constants_mod,                  only: i_def, r_def
   use field_mod,                      only: field_type
   use flux_direction_mod,             only: y_direction

--- a/src/psyclone/tests/test_files/lfric/19.15_stencils_same_field_literal_extent.f90
+++ b/src/psyclone/tests/test_files/lfric/19.15_stencils_same_field_literal_extent.f90
@@ -11,7 +11,7 @@ program multiple_stencils
   ! one case and a different value in another.
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use field_mod,            only: field_type
   use testkern_stencil_mod, only: testkern_stencil_type
 

--- a/src/psyclone/tests/test_files/lfric/19.16_stencils_same_field_literal_direction.f90
+++ b/src/psyclone/tests/test_files/lfric/19.16_stencils_same_field_literal_direction.f90
@@ -10,7 +10,7 @@ program multiple_stencils
   ! provided in two cases and a different direction in the third.
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use field_mod,                   only: field_type
   use flux_direction_mod,          only: x_direction, y_direction
   use testkern_stencil_xory1d_mod, only: testkern_stencil_xory1d_type

--- a/src/psyclone/tests/test_files/lfric/19.25_multiple_stencils_int_field.f90
+++ b/src/psyclone/tests/test_files/lfric/19.25_multiple_stencils_int_field.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! and different values of stencil extents for integer fields.
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use constants_mod,       only: i_def
   use integer_field_mod,   only: integer_field_type
   use flux_direction_mod,  only: x_direction

--- a/src/psyclone/tests/test_files/lfric/19.4_single_stencil_literal.f90
+++ b/src/psyclone/tests/test_files/lfric/19.4_single_stencil_literal.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! literal value passed for the extent value
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use field_mod,            only: field_type
   use testkern_stencil_mod, only: testkern_stencil_type
 

--- a/src/psyclone/tests/test_files/lfric/19.5.1_single_stencil_xory1d_literal.f90
+++ b/src/psyclone/tests/test_files/lfric/19.5.1_single_stencil_xory1d_literal.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! argument being passed as a mixed case literal
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use field_mod,                   only: field_type
   use flux_direction_mod,          only: x_direction
   use testkern_stencil_xory1d_mod, only: testkern_stencil_xory1d_type

--- a/src/psyclone/tests/test_files/lfric/19.5_single_stencil_xory1d_literal.f90
+++ b/src/psyclone/tests/test_files/lfric/19.5_single_stencil_xory1d_literal.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! as a literal.
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use field_mod,                   only: field_type
   use flux_direction_mod,          only: x_direction
   use testkern_stencil_xory1d_mod, only: testkern_stencil_xory1d_type

--- a/src/psyclone/tests/test_files/lfric/19.6_single_stencil_xory1d_value.f90
+++ b/src/psyclone/tests/test_files/lfric/19.6_single_stencil_xory1d_value.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! as direction can not be a literal scalar
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use constants_mod,               only: i_def
   use field_mod,                   only: field_type
   use flux_direction_mod,          only: x_direction

--- a/src/psyclone/tests/test_files/lfric/19.7_multiple_stencils.f90
+++ b/src/psyclone/tests/test_files/lfric/19.7_multiple_stencils.f90
@@ -10,7 +10,7 @@ program single_stencil
   ! values
   ! Note: it is currently not possible to specify kind for an integer
   ! literal stencil depth in a kernel call. This will be enabled when
-  ! addressing issue #753.
+  ! addressing issue #1618.
   use constants_mod,              only: i_def
   use field_mod,                  only: field_type
   use flux_direction_mod,         only: y_direction

--- a/utils/check_closed_issue_refs.py
+++ b/utils/check_closed_issue_refs.py
@@ -36,7 +36,6 @@ import json
 import fnmatch
 
 DEFAULT_REPOSITORY = "stfc/PSyclone"
-FPARSER_REPOSITORY = "stfc/fparser"
 
 # File types searched
 DEFAULT_INCLUDES = ["*.py", "*.md", "*.rst", "Makefile"]
@@ -51,14 +50,7 @@ DEFAULT_EXCLUDE_DIRS = [
 ]
 
 # Regular expression to find references to GitHub issues in the codebase
-REFERENCE_PATTERN = re.compile(
-    r"(?:"
-    r"(?P<fparser>fparser)/? *(?:issue *)?#"
-    r"|"
-    r"(?<![A-Za-z0-9/])#"
-    r")"
-    r"(?P<number>[0-9]+)\b(?![a-zA-Z])"
-)
+REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9/])#([0-9]+)\b(?![a-zA-Z])")
 
 
 def run_git(root: str, *arguments: str) -> str | None:
@@ -82,20 +74,14 @@ def run_git(root: str, *arguments: str) -> str | None:
 
 
 def find_references(
-    root: str,
-    includes: list[str],
-    exclude_dirs: list[str],
-    repository: str,
-    fparser_repository: str,
-) -> dict[tuple[str, int], list[tuple[str, int, str]]]:
+    root: str, includes: list[str], exclude_dirs: list[str]
+) -> dict[int, list[tuple[str, int, str]]]:
     '''Walk the directory tree starting at root and find all references to
     GitHub issues.
 
     :param root: the starting directory.
     :param includes: name patterns of filenames to include.
     :param exclude_dirs: name patterns of directories to exclude.
-    :param repository: the default GitHub repository.
-    :param fparser_repository: the fparser GitHub repository.
 
     :returns: a dictionary mapping issue numbers to their (path, line no,
         line text) occurrences.
@@ -127,12 +113,9 @@ def find_references(
 
             for number, line in enumerate(lines, start=1):
                 for found in REFERENCE_PATTERN.finditer(line):
-                    if found.group("fparser"):
-                        repo = fparser_repository
-                    else:
-                        repo = repository
-                    key = (repo, int(found.group("number")))
-                    references[key].append((path, number, line.strip()))
+                    references[int(found.group(1))].append(
+                        (path, number, line.strip())
+                    )
     return dict(references)
 
 
@@ -177,12 +160,13 @@ def fetch_issue(
 
 
 def classify(
-    references: list[tuple[str, int]], token: str | None, workers: int
-) -> tuple[dict[tuple[str, int], tuple[str, str]], list[tuple[str, int]]]:
+    repository: str, numbers: list[int], token: str | None, workers: int
+) -> tuple[dict[int, tuple[str, str]], list[int]]:
     '''Sort the given issue numbers into ones that are closed and those which
     don't exist.
 
-    :param references: list of (repository, number) tuples to lookup.
+    :param repository: the GitHub repository in the form "owner/name".
+    :param numbers: the issue or PR numbers to lookup.
     :param token: the GitHub API token, or None.
     :param workers: the number of concurrent workers to use for API requests
 
@@ -192,20 +176,19 @@ def classify(
 
     closed = {}
     missing = []
+    done = 0
 
-    def lookup(
-        reference: tuple[str, int]
-    ) -> tuple[tuple[str, int], dict | None]:
-        repository, number = reference
-        return reference, fetch_issue(repository, number, token)
+    def lookup(number: int) -> tuple[int, dict | None]:
+        return number, fetch_issue(repository, number, token)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
-        for reference, issue in pool.map(lookup, references):
+        for number, issue in pool.map(lookup, numbers):
+            done += 1
             if issue is None:
-                missing.append(reference)
+                missing.append(number)
             elif issue.get("state") == "closed":
                 kind = "PR" if "pull_request" in issue else "issue"
-                closed[reference] = (kind, issue.get("title", ""))
+                closed[number] = (kind, issue.get("title", ""))
     return closed, missing
 
 
@@ -277,8 +260,7 @@ def main(argv: list[str] | None = None) -> int:
     exclude_dirs = arguments.exclude or DEFAULT_EXCLUDE_DIRS
     repository = arguments.repository
 
-    references = find_references(arguments.root, includes, exclude_dirs,
-                                 repository, FPARSER_REPOSITORY)
+    references = find_references(arguments.root, includes, exclude_dirs)
     if not references:
         print("No references to GitHub issues found in the codebase.")
         return 0
@@ -329,6 +311,7 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         closed, missing = classify(
+            repository,
             sorted(references),
             token,
             arguments.workers,
@@ -340,8 +323,10 @@ def main(argv: list[str] | None = None) -> int:
     print()
     if missing:
         print(
-            "Not real closed issues: "
-            + ", ".join(repo + "#" + str(n) for repo, n in sorted(missing))
+            "Not found in "
+            + repository
+            + ": "
+            + ", ".join("#" + str(n) for n in missing)
         )
         print()
 
@@ -350,12 +335,10 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print("References to closed issues: ")
-    for repo, number in sorted(closed):
-        kind, title = closed[(repo, number)]
-        print(
-            repo + "#" + str(number) + " (" + kind + ", closed): " + title
-        )
-        for path, line, text in references[(repo, number)]:
+    for number in sorted(closed):
+        kind, title = closed[number]
+        print("#" + str(number) + " (" + kind + ", closed): " + title)
+        for path, line, text in references[number]:
             print("  " + link(path, line) + ": " + text)
     print()
     print(
@@ -373,17 +356,15 @@ def main(argv: list[str] | None = None) -> int:
 def test_reference_pattern_matches_genuine_references():
     """Genuine "#<number>" references are matched."""
     assert REFERENCE_PATTERN.findall("# TODO #9999999: fix this") == [
-        ("", "9999999")
+        "9999999"
     ]
     assert REFERENCE_PATTERN.findall("see (#9999999) for details") == [
-        ("", "9999999")
+        "9999999"
     ]
-    assert REFERENCE_PATTERN.findall("#9999999 at line start") == \
-        [("", "9999999")]
-    assert REFERENCE_PATTERN.findall("closes #9999999 and #8888888") \
-        == [
-        ("", "9999999"),
-        ("", "8888888"),
+    assert REFERENCE_PATTERN.findall("#9999999 at line start") == ["9999999"]
+    assert REFERENCE_PATTERN.findall("closes #9999999 and #8888888") == [
+        "9999999",
+        "8888888",
     ]
 
 
@@ -391,27 +372,13 @@ def test_reference_pattern_rejects_false_positives():
     """Things that look like references but are not."""
     assert REFERENCE_PATTERN.findall('colour = "#123abc"') == []
     assert REFERENCE_PATTERN.findall("proc#1 (1 procs)") == []
-
-
-def test_reference_pattern_captures_fparser():
-    """References prefixed with fparser are captured."""
-    assert REFERENCE_PATTERN.findall("when fparser#211 is fixed") == [
-        ("fparser", "211")
-    ]
-    assert REFERENCE_PATTERN.findall("once fparser/#211 is fixed") == [
-        ("fparser", "211")
-    ]
-    assert REFERENCE_PATTERN.findall("see fparser #295 for this") == [
-        ("fparser", "295")
-    ]
-    assert REFERENCE_PATTERN.findall("fparser issue #295 covers it") == [
-        ("fparser", "295")
-    ]
+    assert REFERENCE_PATTERN.findall("when fparser#211 is fixed") == []
+    assert REFERENCE_PATTERN.findall("once fparser/#211 is fixed") == []
 
 
 def test_reference_pattern_full_number():
     """ "#9999999" must not be matched inside "#99999999"."""
-    assert REFERENCE_PATTERN.findall("see #9999999 here") == [("", "9999999")]
+    assert REFERENCE_PATTERN.findall("see #9999999 here") == ["9999999"]
 
 
 def test_find_references_collects_numbers_and_locations(tmp_path):
@@ -419,25 +386,16 @@ def test_find_references_collects_numbers_and_locations(tmp_path):
     (tmp_path / "a.py").write_text("x = 1  # TODO #9999999: do the thing\n")
     docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / "b.rst").write_text(
-        "See issue #9999999 and fparser #8888888.\n"
-    )
+    (docs / "b.rst").write_text("See issue #9999999 and issue #8888888.\n")
 
     refs = find_references(
-        str(tmp_path),
-        DEFAULT_INCLUDES,
-        set(DEFAULT_EXCLUDE_DIRS),
-        "stfc/PSyclone",
-        "stfc/fparser",
+        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
     )
 
-    assert set(refs) == {
-        ("stfc/PSyclone", 9999999),
-        ("stfc/fparser", 8888888),
-    }
-    assert len(refs[("stfc/PSyclone", 9999999)]) == 2
-    assert len(refs[("stfc/fparser", 8888888)]) == 1
-    _, lineno, text = refs[("stfc/PSyclone", 9999999)][0]
+    assert set(refs) == {9999999, 8888888}
+    assert len(refs[9999999]) == 2
+    assert len(refs[8888888]) == 1
+    _, lineno, text = refs[9999999][0]
     assert lineno == 1
     assert "#9999999" in text
 
@@ -450,14 +408,10 @@ def test_find_references_skips_excluded_dirs(tmp_path):
     (git / "config.py").write_text("# TODO #8888888 ignore\n")
 
     refs = find_references(
-        str(tmp_path),
-        DEFAULT_INCLUDES,
-        set(DEFAULT_EXCLUDE_DIRS),
-        "stfc/PSyclone",
-        "stfc/fparser",
+        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
     )
 
-    assert set(refs) == {("stfc/PSyclone", 9999999)}
+    assert set(refs) == {9999999}
 
 
 def test_find_references_ignores_unlisted_extensions(tmp_path):
@@ -466,22 +420,18 @@ def test_find_references_ignores_unlisted_extensions(tmp_path):
     (tmp_path / "ignored.log").write_text("# TODO #8888888 \n")
 
     refs = find_references(
-        str(tmp_path),
-        DEFAULT_INCLUDES,
-        set(DEFAULT_EXCLUDE_DIRS),
-        "stfc/PSyclone",
-        "stfc/fparser",
+        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
     )
 
-    assert set(refs) == {("stfc/PSyclone", 9999999)}
+    assert set(refs) == {9999999}
 
 
 def _fake_api(states):
-    """Build a stand-in for fetch_issue from a {(repository, number):
-    response} mapping. A response of None represents a 404."""
+    """Build a stand-in for fetch_issue from a {number: response} mapping.
+    A response of None represents a 404."""
 
     def fetch(repository, number, token):
-        return states.get((repository, number))
+        return states.get(number)
 
     return fetch
 
@@ -492,49 +442,40 @@ def test_classify_separates_closed_from_missing(monkeypatch):
 
     module = _sys.modules[__name__]
     states = {
-        ("stfc/PSyclone", 9999999):
-            {"state": "closed", "title": "Closed issue"},
-        ("stfc/PSyclone", 8888888): {"state": "open", "title": "Still open"},
-        ("stfc/PSyclone", 7777777): None,
-        ("stfc/fparser", 6666666): {
+        9999999: {"state": "closed", "title": "Closed issue"},
+        8888888: {"state": "open", "title": "Still open"},
+        7777777: None,
+        6666666: {
             "state": "closed",
-            "title": "Closed fparser PR",
+            "title": "Closed PR",
             "pull_request": {},
         },
     }
     monkeypatch.setattr(module, "fetch_issue", _fake_api(states))
 
     closed, missing = classify(
-        [
-            ("stfc/PSyclone", 9999999),
-            ("stfc/PSyclone", 8888888),
-            ("stfc/PSyclone", 7777777),
-            ("stfc/fparser", 6666666),
-        ],
+        "owner/repo",
+        [9999999, 8888888, 7777777, 6666666],
         token=None,
         workers=2,
     )
 
-    assert set(closed) == {
-        ("stfc/PSyclone", 9999999),
-        ("stfc/fparser", 6666666),
-    }
-    assert closed[("stfc/PSyclone", 9999999)] == ("issue", "Closed issue")
-    assert closed[("stfc/fparser", 6666666)] == ("PR", "Closed fparser PR")
-    assert missing == [("stfc/PSyclone", 7777777)]
+    assert set(closed) == {9999999, 6666666}
+    assert closed[9999999] == ("issue", "Closed issue")
+    assert closed[6666666] == ("PR", "Closed PR")
+    assert missing == [7777777]
 
 
 def test_main_returns_1_when_closed_reference_found(monkeypatch, tmp_path):
     """A reference to a closed issue gives exit code 1."""
     import sys as _sys
+
     module = _sys.modules[__name__]
     (tmp_path / "a.py").write_text("# TODO #9999999 remove me\n")
     monkeypatch.setattr(
         module,
         "fetch_issue",
-        _fake_api(
-            {("stfc/PSyclone", 9999999): {"state": "closed", "title": "x"}}
-        ),
+        _fake_api({9999999: {"state": "closed", "title": "x"}}),
     )
     monkeypatch.setattr(module, "run_git", lambda root, *a: "deadbeef")
 
@@ -550,9 +491,7 @@ def test_main_returns_0_when_all_open(monkeypatch, tmp_path):
     monkeypatch.setattr(
         module,
         "fetch_issue",
-        _fake_api(
-            {("stfc/PSyclone", 9999999): {"state": "open", "title": "x"}}
-        ),
+        _fake_api({9999999: {"state": "open", "title": "x"}}),
     )
     monkeypatch.setattr(module, "run_git", lambda root, *a: "deadbeef")
 

--- a/utils/check_closed_issue_refs.py
+++ b/utils/check_closed_issue_refs.py
@@ -36,6 +36,7 @@ import json
 import fnmatch
 
 DEFAULT_REPOSITORY = "stfc/PSyclone"
+FPARSER_REPOSITORY = "stfc/fparser"
 
 # File types searched
 DEFAULT_INCLUDES = ["*.py", "*.md", "*.rst", "Makefile"]
@@ -50,7 +51,14 @@ DEFAULT_EXCLUDE_DIRS = [
 ]
 
 # Regular expression to find references to GitHub issues in the codebase
-REFERENCE_PATTERN = re.compile(r"(?<![A-Za-z0-9/])#([0-9]+)\b(?![a-zA-Z])")
+REFERENCE_PATTERN = re.compile(
+    r"(?:"
+    r"(?P<fparser>fparser)/? *(?:issue *)?#"
+    r"|"
+    r"(?<![A-Za-z0-9/])#"
+    r")"
+    r"(?P<number>[0-9]+)\b(?![a-zA-Z])"
+)
 
 
 def run_git(root: str, *arguments: str) -> str | None:
@@ -74,14 +82,20 @@ def run_git(root: str, *arguments: str) -> str | None:
 
 
 def find_references(
-    root: str, includes: list[str], exclude_dirs: list[str]
-) -> dict[int, list[tuple[str, int, str]]]:
+    root: str,
+    includes: list[str],
+    exclude_dirs: list[str],
+    repository: str,
+    fparser_repository: str,
+) -> dict[tuple[str, int], list[tuple[str, int, str]]]:
     '''Walk the directory tree starting at root and find all references to
     GitHub issues.
 
     :param root: the starting directory.
     :param includes: name patterns of filenames to include.
     :param exclude_dirs: name patterns of directories to exclude.
+    :param repository: the default GitHub repository.
+    :param fparser_repository: the fparser GitHub repository.
 
     :returns: a dictionary mapping issue numbers to their (path, line no,
         line text) occurrences.
@@ -113,9 +127,12 @@ def find_references(
 
             for number, line in enumerate(lines, start=1):
                 for found in REFERENCE_PATTERN.finditer(line):
-                    references[int(found.group(1))].append(
-                        (path, number, line.strip())
-                    )
+                    if found.group("fparser"):
+                        repo = fparser_repository
+                    else:
+                        repo = repository
+                    key = (repo, int(found.group("number")))
+                    references[key].append((path, number, line.strip()))
     return dict(references)
 
 
@@ -160,13 +177,12 @@ def fetch_issue(
 
 
 def classify(
-    repository: str, numbers: list[int], token: str | None, workers: int
-) -> tuple[dict[int, tuple[str, str]], list[int]]:
+    references: list[tuple[str, int]], token: str | None, workers: int
+) -> tuple[dict[tuple[str, int], tuple[str, str]], list[tuple[str, int]]]:
     '''Sort the given issue numbers into ones that are closed and those which
     don't exist.
 
-    :param repository: the GitHub repository in the form "owner/name".
-    :param numbers: the issue or PR numbers to lookup.
+    :param references: list of (repository, number) tuples to lookup.
     :param token: the GitHub API token, or None.
     :param workers: the number of concurrent workers to use for API requests
 
@@ -176,19 +192,20 @@ def classify(
 
     closed = {}
     missing = []
-    done = 0
 
-    def lookup(number: int) -> tuple[int, dict | None]:
-        return number, fetch_issue(repository, number, token)
+    def lookup(
+        reference: tuple[str, int]
+    ) -> tuple[tuple[str, int], dict | None]:
+        repository, number = reference
+        return reference, fetch_issue(repository, number, token)
 
     with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
-        for number, issue in pool.map(lookup, numbers):
-            done += 1
+        for reference, issue in pool.map(lookup, references):
             if issue is None:
-                missing.append(number)
+                missing.append(reference)
             elif issue.get("state") == "closed":
                 kind = "PR" if "pull_request" in issue else "issue"
-                closed[number] = (kind, issue.get("title", ""))
+                closed[reference] = (kind, issue.get("title", ""))
     return closed, missing
 
 
@@ -260,7 +277,8 @@ def main(argv: list[str] | None = None) -> int:
     exclude_dirs = arguments.exclude or DEFAULT_EXCLUDE_DIRS
     repository = arguments.repository
 
-    references = find_references(arguments.root, includes, exclude_dirs)
+    references = find_references(arguments.root, includes, exclude_dirs,
+                                 repository, FPARSER_REPOSITORY)
     if not references:
         print("No references to GitHub issues found in the codebase.")
         return 0
@@ -311,7 +329,6 @@ def main(argv: list[str] | None = None) -> int:
 
     try:
         closed, missing = classify(
-            repository,
             sorted(references),
             token,
             arguments.workers,
@@ -323,10 +340,8 @@ def main(argv: list[str] | None = None) -> int:
     print()
     if missing:
         print(
-            "Not found in "
-            + repository
-            + ": "
-            + ", ".join("#" + str(n) for n in missing)
+            "Not real closed issues: "
+            + ", ".join(repo + "#" + str(n) for repo, n in sorted(missing))
         )
         print()
 
@@ -335,10 +350,12 @@ def main(argv: list[str] | None = None) -> int:
         return 0
 
     print("References to closed issues: ")
-    for number in sorted(closed):
-        kind, title = closed[number]
-        print("#" + str(number) + " (" + kind + ", closed): " + title)
-        for path, line, text in references[number]:
+    for repo, number in sorted(closed):
+        kind, title = closed[(repo, number)]
+        print(
+            repo + "#" + str(number) + " (" + kind + ", closed): " + title
+        )
+        for path, line, text in references[(repo, number)]:
             print("  " + link(path, line) + ": " + text)
     print()
     print(
@@ -356,15 +373,17 @@ def main(argv: list[str] | None = None) -> int:
 def test_reference_pattern_matches_genuine_references():
     """Genuine "#<number>" references are matched."""
     assert REFERENCE_PATTERN.findall("# TODO #9999999: fix this") == [
-        "9999999"
+        ("", "9999999")
     ]
     assert REFERENCE_PATTERN.findall("see (#9999999) for details") == [
-        "9999999"
+        ("", "9999999")
     ]
-    assert REFERENCE_PATTERN.findall("#9999999 at line start") == ["9999999"]
-    assert REFERENCE_PATTERN.findall("closes #9999999 and #8888888") == [
-        "9999999",
-        "8888888",
+    assert REFERENCE_PATTERN.findall("#9999999 at line start") == \
+        [("", "9999999")]
+    assert REFERENCE_PATTERN.findall("closes #9999999 and #8888888") \
+        == [
+        ("", "9999999"),
+        ("", "8888888"),
     ]
 
 
@@ -372,13 +391,27 @@ def test_reference_pattern_rejects_false_positives():
     """Things that look like references but are not."""
     assert REFERENCE_PATTERN.findall('colour = "#123abc"') == []
     assert REFERENCE_PATTERN.findall("proc#1 (1 procs)") == []
-    assert REFERENCE_PATTERN.findall("when fparser#211 is fixed") == []
-    assert REFERENCE_PATTERN.findall("once fparser/#211 is fixed") == []
+
+
+def test_reference_pattern_captures_fparser():
+    """References prefixed with fparser are captured."""
+    assert REFERENCE_PATTERN.findall("when fparser#211 is fixed") == [
+        ("fparser", "211")
+    ]
+    assert REFERENCE_PATTERN.findall("once fparser/#211 is fixed") == [
+        ("fparser", "211")
+    ]
+    assert REFERENCE_PATTERN.findall("see fparser #295 for this") == [
+        ("fparser", "295")
+    ]
+    assert REFERENCE_PATTERN.findall("fparser issue #295 covers it") == [
+        ("fparser", "295")
+    ]
 
 
 def test_reference_pattern_full_number():
     """ "#9999999" must not be matched inside "#99999999"."""
-    assert REFERENCE_PATTERN.findall("see #9999999 here") == ["9999999"]
+    assert REFERENCE_PATTERN.findall("see #9999999 here") == [("", "9999999")]
 
 
 def test_find_references_collects_numbers_and_locations(tmp_path):
@@ -386,16 +419,25 @@ def test_find_references_collects_numbers_and_locations(tmp_path):
     (tmp_path / "a.py").write_text("x = 1  # TODO #9999999: do the thing\n")
     docs = tmp_path / "docs"
     docs.mkdir()
-    (docs / "b.rst").write_text("See issue #9999999 and issue #8888888.\n")
-
-    refs = find_references(
-        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
+    (docs / "b.rst").write_text(
+        "See issue #9999999 and fparser #8888888.\n"
     )
 
-    assert set(refs) == {9999999, 8888888}
-    assert len(refs[9999999]) == 2
-    assert len(refs[8888888]) == 1
-    _, lineno, text = refs[9999999][0]
+    refs = find_references(
+        str(tmp_path),
+        DEFAULT_INCLUDES,
+        set(DEFAULT_EXCLUDE_DIRS),
+        "stfc/PSyclone",
+        "stfc/fparser",
+    )
+
+    assert set(refs) == {
+        ("stfc/PSyclone", 9999999),
+        ("stfc/fparser", 8888888),
+    }
+    assert len(refs[("stfc/PSyclone", 9999999)]) == 2
+    assert len(refs[("stfc/fparser", 8888888)]) == 1
+    _, lineno, text = refs[("stfc/PSyclone", 9999999)][0]
     assert lineno == 1
     assert "#9999999" in text
 
@@ -408,10 +450,14 @@ def test_find_references_skips_excluded_dirs(tmp_path):
     (git / "config.py").write_text("# TODO #8888888 ignore\n")
 
     refs = find_references(
-        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
+        str(tmp_path),
+        DEFAULT_INCLUDES,
+        set(DEFAULT_EXCLUDE_DIRS),
+        "stfc/PSyclone",
+        "stfc/fparser",
     )
 
-    assert set(refs) == {9999999}
+    assert set(refs) == {("stfc/PSyclone", 9999999)}
 
 
 def test_find_references_ignores_unlisted_extensions(tmp_path):
@@ -420,18 +466,22 @@ def test_find_references_ignores_unlisted_extensions(tmp_path):
     (tmp_path / "ignored.log").write_text("# TODO #8888888 \n")
 
     refs = find_references(
-        str(tmp_path), DEFAULT_INCLUDES, set(DEFAULT_EXCLUDE_DIRS)
+        str(tmp_path),
+        DEFAULT_INCLUDES,
+        set(DEFAULT_EXCLUDE_DIRS),
+        "stfc/PSyclone",
+        "stfc/fparser",
     )
 
-    assert set(refs) == {9999999}
+    assert set(refs) == {("stfc/PSyclone", 9999999)}
 
 
 def _fake_api(states):
-    """Build a stand-in for fetch_issue from a {number: response} mapping.
-    A response of None represents a 404."""
+    """Build a stand-in for fetch_issue from a {(repository, number):
+    response} mapping. A response of None represents a 404."""
 
     def fetch(repository, number, token):
-        return states.get(number)
+        return states.get((repository, number))
 
     return fetch
 
@@ -442,40 +492,49 @@ def test_classify_separates_closed_from_missing(monkeypatch):
 
     module = _sys.modules[__name__]
     states = {
-        9999999: {"state": "closed", "title": "Closed issue"},
-        8888888: {"state": "open", "title": "Still open"},
-        7777777: None,
-        6666666: {
+        ("stfc/PSyclone", 9999999):
+            {"state": "closed", "title": "Closed issue"},
+        ("stfc/PSyclone", 8888888): {"state": "open", "title": "Still open"},
+        ("stfc/PSyclone", 7777777): None,
+        ("stfc/fparser", 6666666): {
             "state": "closed",
-            "title": "Closed PR",
+            "title": "Closed fparser PR",
             "pull_request": {},
         },
     }
     monkeypatch.setattr(module, "fetch_issue", _fake_api(states))
 
     closed, missing = classify(
-        "owner/repo",
-        [9999999, 8888888, 7777777, 6666666],
+        [
+            ("stfc/PSyclone", 9999999),
+            ("stfc/PSyclone", 8888888),
+            ("stfc/PSyclone", 7777777),
+            ("stfc/fparser", 6666666),
+        ],
         token=None,
         workers=2,
     )
 
-    assert set(closed) == {9999999, 6666666}
-    assert closed[9999999] == ("issue", "Closed issue")
-    assert closed[6666666] == ("PR", "Closed PR")
-    assert missing == [7777777]
+    assert set(closed) == {
+        ("stfc/PSyclone", 9999999),
+        ("stfc/fparser", 6666666),
+    }
+    assert closed[("stfc/PSyclone", 9999999)] == ("issue", "Closed issue")
+    assert closed[("stfc/fparser", 6666666)] == ("PR", "Closed fparser PR")
+    assert missing == [("stfc/PSyclone", 7777777)]
 
 
 def test_main_returns_1_when_closed_reference_found(monkeypatch, tmp_path):
     """A reference to a closed issue gives exit code 1."""
     import sys as _sys
-
     module = _sys.modules[__name__]
     (tmp_path / "a.py").write_text("# TODO #9999999 remove me\n")
     monkeypatch.setattr(
         module,
         "fetch_issue",
-        _fake_api({9999999: {"state": "closed", "title": "x"}}),
+        _fake_api(
+            {("stfc/PSyclone", 9999999): {"state": "closed", "title": "x"}}
+        ),
     )
     monkeypatch.setattr(module, "run_git", lambda root, *a: "deadbeef")
 
@@ -491,7 +550,9 @@ def test_main_returns_0_when_all_open(monkeypatch, tmp_path):
     monkeypatch.setattr(
         module,
         "fetch_issue",
-        _fake_api({9999999: {"state": "open", "title": "x"}}),
+        _fake_api(
+            {("stfc/PSyclone", 9999999): {"state": "open", "title": "x"}}
+        ),
     )
     monkeypatch.setattr(module, "run_git", lambda root, *a: "deadbeef")
 


### PR DESCRIPTION
This PR extends the manual reference checker in the utils folder `check_closed_issue_refs.py` (follow up from #3556) to catch references to closed issues in the fparser directory.
Now after running the audit these are the final issues which need cleaning up:

## Needs removal:

- #753 (PSyclone) missed in the previous PR. Issue [#3506](https://github.com/stfc/PSyclone/issues/3506)
- https://github.com/stfc/fparser/issues/468 (fparser) is closed and needs cleanup
- https://github.com/stfc/fparser/issues/469 (fparser) is closed and needs cleanup

## Needs changes:
- https://github.com/stfc/fparser/issues/295 (fparser2) flags on the audit due to the comment format being: 
`# fparser2 (issue #295)` so the regex does not catch this as an fparser issue. Instead of changing the regex (which would be risky and may lead to false positives), would it be better to change the comment format to `#TODO fparser #295` and standardise these practices when adding todos in the future?

## Accepted formats:
 - `fparser #295`
 - `fparser#295`
 - `fparser/#295`
 - `fparser issue #295`
