### PR TITLE
Codestyle doc updates and a few small fixes to misuse of Optional

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   41) PR #3573. Improves Developer Guide description of coding style
+   and fixes a few incorrect type-hints.
+ 
    40) PR #3499 towards #2905. Moves lfric symbol creation into the
    LFRicInvoke constructor.
 

--- a/doc/developer_guide/coding-style.rst
+++ b/doc/developer_guide/coding-style.rst
@@ -243,35 +243,25 @@ Some important details:
                                a capital letter, and end with a full stop.
          parameter description Start the parameter description with a lowercase 
                                letter and end with a full stop. The parameter type
-                               declaration must follow `PEP 483
-			       <https://peps.python.org/pep-0483/>`_ with no
-			       punctuation at the end. References to other
-                               classes within PSyclone should be written as
-                               ``:py:class:`psyclone.filename.Class```.
+                               hints must follow `PEP 484
+			       <https://peps.python.org/pep-0484/>`_ .
          return value          The description of the return value should start with
                                a lowercase letter, and end with a full stop. The type
-                               must follow `PEP 483
-			       <https://peps.python.org/pep-0483/>`_.
+                               must follow `PEP 484
+			       <https://peps.python.org/pep-0484/>`_.
          exceptions            These must start with a lower case letter, and end
                                with a full stop.
          ===================== ======================================================
 
 
-  #) If a parameter description, type, return value or exception is continued
-     to the next line, there must be a '\\\\' continuation symbol at the end of
-     each line. Align each continued line with the column at which the
-     description begins on the previous line. If this would create lines that
-     are too short then the first continued line may be indented less, e.g.::
+  #) If a parameter description, return value or exception is continued
+     to the next line, the next line should be indented, e.g.::
 
          '''
-         :param some_very_long_variable_name: this is some argument that has \
-		a very long name and therefore it does not make sense to indent \
-		continued lines to align with the start of the description.
+         :param some_very_long_variable_name: this is some argument that has
+		     a very long name and description that requires multiple lines of
+		     description.
 	 '''
-  #) If an argument type is a Python built-in (e.g. str, int or bool) then the
-     type can be specified in-line with the argument description. However, if it
-     is of a derived type then, for clarity, it should be specified in a
-     separate :type my_arg: line.
   #) The closing \\'\\'\\' of the interface description can be at the end of a
      text line if the overall description is short. Otherwise it should be on a
      separate line. An optional empty line between interface description and

--- a/doc/developer_guide/coding-style.rst
+++ b/doc/developer_guide/coding-style.rst
@@ -244,7 +244,7 @@ Some important details:
          parameter description Start the parameter description with a lowercase 
                                letter and end with a full stop. The parameter type
                                hints must follow `PEP 484
-			       <https://peps.python.org/pep-0484/>`_ .
+			       <https://peps.python.org/pep-0484/>`_. 
          return value          The description of the return value should start with
                                a lowercase letter, and end with a full stop. The type
                                must follow `PEP 484
@@ -257,21 +257,39 @@ Some important details:
   #) If a parameter description, return value or exception is continued
      to the next line, the next line should be indented, e.g.::
 
-         '''
-         :param some_very_long_variable_name: this is some argument that has
-		     a very long name and description that requires multiple lines of
-		     description.
-	 '''
-  #) The closing \\'\\'\\' of the interface description can be at the end of a
+        '''
+        :param some_very_long_variable_name: this is some argument that has
+            a very long name and description that requires multiple lines of
+            description.
+	'''
+
+  #) The closing \'\'\' of the interface description can be at the end of a
      text line if the overall description is short. Otherwise it should be on a
      separate line. An optional empty line between interface description and
      code should be included in the comment section.
 
-  #) Standard Python functions like `__str__` etc. need only be documented with a
+  #) Standard Python functions like ``__str__`` etc. need only be documented with a
      simple informal comment.
 
   #) Only document exceptions that are raised directly by a method, not exceptions
      that might be raised in base classes.
+
+  #) If a type hint refers to a class that is defined only after its use
+     in a given module, use ``from __future__ import annotations`` to ensure the
+     type hint is compatible with Python 3.9 (or other earlier version of Python
+     that PSyclone still supports).
+
+  #) If importing a class required for a type hint is not possible due to circular
+     imports then its import should be protected by a ``if TYPE_CHECKING:`` block,
+     and its actualy use should be put in double quotes, e.g.::
+
+        if TYPE_CHECKING:
+            from psyclone.somepath.class import SomeClass
+
+        def my_func(my_arg: "SomeClass") -> None:
+        ...
+
+
 
 File Names and Directory Layout
 ################################

--- a/doc/developer_guide/interface_example.py
+++ b/doc/developer_guide/interface_example.py
@@ -5,7 +5,11 @@
 # See the full LICENSE file in the project root for details.
 # -----------------------------------------------------------------------------
 
-def some_function(filename, kernel_path, node=None):
+from typing import Union
+from psyclone.psyir.nodes import Node
+
+def some_function(filename: str, kernel_path: str,
+                  node: Union[Node, None] = None) -> Node:
     '''The description starts with a capital letter and must have
     proper punctuation. Use for example :func:`parse.algorithm.parse`
     to reference functions, or :py:class:`psyclone.psyir.nodes.Node` for
@@ -13,33 +17,25 @@ def some_function(filename, kernel_path, node=None):
     by an empty line before the parameters start, but it is not necessary
     to escape each new line with a backslash here.
 
-    :param str filename: start lower case, but add full stop. This\
-                         line also shows the type declarations part of\
-                         the parameter declaration, which can be used for\
-                         any standard Python data type like str, bool, \
-                         int, float.
-    :param str kernel_path: no empty line between different parameters.\
-                            If you need more than one line, add a backslash\
-                            to the end of each line, otherwise sphinx\
-                            will not layout the text correctly.
-    :param node: the parameter type can also be declared in a stand-alone\
-                 line which follows immediately after the corresponding\
-                 :param: line. The actual type should only contain the\
-                 type, no filler words like 'return type is integer'.\
-                 Type information should be specified according to PEP 483\
-                 (https://peps.python.org/pep-0483/).\
-                 Notice the empty line between parameter and return\
-                 documentation.
-    :type node: Optional[:py:class:`psyclone.psyir.nodes.Node`]
+    :param str filename: start lower case, but add full stop.
+    :param str kernel_path: no empty line between different parameters.
+        If you need more than one line, continue the following lines with
+        an indentation, otherwise sphinx will not layout the text correctly.
+    :param node: the parameter type should be declared using Python 3.9
+        compatible type hints, i.e. Union[X, Y] rather than X | Y.
+        Type hints should be specified according to PEP 484
+        (https://peps.python.org/pep-0483/). Notice the empty line between
+        parameter and return documentation. Optional[Node] would also be a
+        valid type hint for this node.
 
-    :returns: a new node in the PSyIR. The return type must always be\
-              specified in a separate line with an :rtype: entry. An empty\
-              line separates the return documentation and the exceptions.
-    :rtype: :py:class:`psyclone.psyir.nodes.Node`
+    :returns: a new node in the PSyIR. The return type must always be
+              specified as a typehint, with -> None used for functions with
+              no return value. An empty line separates the return
+              documentation and the exceptions.
 
     :raises IOError: lower case start with punctuation at the end.
-    :raises GenerationError: list the same exception more than once if\
-                             it can be raised by different errors.
+    :raises GenerationError: list the same exception more than once if
+        it can be raised by different errors.
     :raises GenerationError: same exception, raised by a different error.
 
     '''

--- a/doc/developer_guide/interface_example.py
+++ b/doc/developer_guide/interface_example.py
@@ -8,6 +8,7 @@
 from typing import Union
 from psyclone.psyir.nodes import Node
 
+
 def some_function(filename: str, kernel_path: str,
                   node: Union[Node, None] = None) -> Node:
     '''The description starts with a capital letter and must have

--- a/doc/developer_guide/interface_example.py
+++ b/doc/developer_guide/interface_example.py
@@ -18,21 +18,22 @@ def some_function(filename: str, kernel_path: str,
     by an empty line before the parameters start, but it is not necessary
     to escape each new line with a backslash here.
 
-    :param str filename: start lower case, but add full stop.
-    :param str kernel_path: no empty line between different parameters.
+    :param filename: start lower case, but add full stop.
+    :param kernel_path: no empty line between different parameters.
         If you need more than one line, continue the following lines with
         an indentation, otherwise sphinx will not layout the text correctly.
     :param node: the parameter type should be declared using Python 3.9
-        compatible type hints, i.e. Union[X, Y] rather than X | Y.
+        compatible type hints, i.e. ``Union[X, Y]`` rather than ``X | Y``.
         Type hints should be specified according to PEP 484
         (https://peps.python.org/pep-0483/). Notice the empty line between
-        parameter and return documentation. Optional[Node] would also be a
-        valid type hint for this node.
+        parameter and return documentation. ``Optional[Node]`` would also be a
+        valid type hint for this node, and the Sphinx docstring may
+        automatically adjust it to ``Optional[Node]``.
 
     :returns: a new node in the PSyIR. The return type must always be
-              specified as a typehint, with -> None used for functions with
-              no return value. An empty line separates the return
-              documentation and the exceptions.
+        specified as a typehint, with -> None used for functions with
+        no return value. An empty line separates the return
+        documentation and the exceptions.
 
     :raises IOError: lower case start with punctuation at the end.
     :raises GenerationError: list the same exception more than once if

--- a/src/psyclone/domain/lfric/kernel/field_arg_metadata.py
+++ b/src/psyclone/domain/lfric/kernel/field_arg_metadata.py
@@ -51,7 +51,7 @@ class FieldArgMetadata(ScalarArgMetadata):
     def __init__(self, datatype: str, access: str, function_space: str,
                  stencil: Optional[str] = None,
                  nlevels: Optional[str] = None,
-                 ndata: Optional[str] = "1"):
+                 ndata: str = "1"):
         super().__init__(datatype, access)
         self.function_space = function_space
         self.stencil = stencil

--- a/src/psyclone/generator.py
+++ b/src/psyclone/generator.py
@@ -882,8 +882,8 @@ def code_transformation_mode(input_file: str,
                              keep_directives: bool,
                              keep_conditional_openmp_statements: bool,
                              kwargs_str: Optional[str] = None,
-                             free_form: Optional[bool] = True,
-                             line_length: Optional[str] = "off"):
+                             free_form: bool = True,
+                             line_length: str = "off"):
     '''
     Process the input_file with the transformations script specified in
     `script_name` and store it in the output_file.

--- a/src/psyclone/lfric.py
+++ b/src/psyclone/lfric.py
@@ -5255,7 +5255,7 @@ class LFRicKernelArguments(Arguments):
     def __init__(self,
                  call: KernelCall,
                  parent_call: LFRicKern,
-                 check: Optional[bool] = True):
+                 check: bool = True):
         # pylint: disable=too-many-branches
         super().__init__(parent_call)
 
@@ -5601,7 +5601,7 @@ class LFRicKernelArgument(KernelArgument):
                  arg_meta_data: LFRicArgDescriptor,
                  arg_info: Arg,
                  call: LFRicKern,
-                 check: Optional[bool] = True):
+                 check: bool = True):
         # Keep a reference to LFRicKernelArguments object that contains
         # this argument. This permits us to manage name-mangling for
         # any-space function spaces.

--- a/src/psyclone/parse/file_info.py
+++ b/src/psyclone/parse/file_info.py
@@ -72,7 +72,7 @@ class FileInfo:
     """
     def __init__(self,
                  filepath: str,
-                 cache_active: Optional[bool] = False,
+                 cache_active: bool = False,
                  cache_path: Optional[str] = None,
                  resolve_imports: Union[bool, Iterable[str]] = False
                  ):


### PR DESCRIPTION
Tiny PR just following up on things I've seen previously. In general I do much prefer `Union[X, None]` over `Optional[None]`, as I think the `Optional` typehint is poorly named (and likely led to the mistakes in this PR).

I only checked for uses on actual type hints. There were some where currently ` = None` is the default, but I suspect could use `= ""`, but I didn't try those modifications as they may need more substantial code changes.

Also just changing some of the docs to update our coding style as it seems very out of date.