### PR TITLE
(closes #3392) Preserve order of common block sequences

### DIFF
--- a/changelog
+++ b/changelog
@@ -1,3 +1,6 @@
+   46) PR #3582 for #3392. Fixes PSyclone reordering the declarations in
+   common blocks.
+
    45) PR #3563 for #2642. Adds support for PSyclone handling structures
    with extends and contains.
 

--- a/src/psyclone/psyir/backend/fortran.py
+++ b/src/psyclone/psyir/backend/fortran.py
@@ -726,7 +726,7 @@ class FortranWriter(LanguageWriter):
                 name = symbol.interface.name.lower()
                 common_blocks.setdefault(name, []).append(symbol)
 
-        # Order the symbols by their commonblock interface possition
+        # Order the symbols by their commonblock interface position
         declarations = ""
         for name, members in common_blocks.items():
             positions = [symbol.interface.position for symbol in members]

--- a/src/psyclone/psyir/backend/fortran.py
+++ b/src/psyclone/psyir/backend/fortran.py
@@ -657,13 +657,43 @@ class FortranWriter(LanguageWriter):
         if symbol.inline_comment != "":
             result += f" {self._COMMENT_PREFIX}{symbol.inline_comment}"
 
-        if isinstance(symbol, Symbol) and symbol.is_commonblock:
-            result += (
-                f"\n{self._nindent}common /{symbol.interface.name}/ "
-                f"{symbol.name}"
-            )
-
         return result + "\n"
+
+    def _gen_common_block_decls(self, symbols: list[Symbol]) -> str:
+        '''Generate declarations for all common blocks represented by the
+        supplied Symbols. Members of each block are ordered by the position
+        stored in their CommonBlockInterface.
+
+        :param symbols: symbols that may belong to common blocks.
+
+        :returns: the common-block declarations.
+
+        :raises VisitorError: if two Symbols in the same common block have
+            the same position.
+
+        '''
+        # Create a dict of common block names and the symbols that belong to
+        # that common block
+        common_blocks = {}
+        for symbol in symbols:
+            if symbol.is_commonblock:
+                name = symbol.interface.name.lower()
+                common_blocks.setdefault(name, []).append(symbol)
+
+        # Order the symbols by their commonblock interface possition
+        declarations = ""
+        for name, members in common_blocks.items():
+            positions = [symbol.interface.position for symbol in members]
+            if len(positions) != len(set(positions)):
+                raise VisitorError(
+                    f"Common block '{members[0].interface.name}' has Symbols "
+                    f"with duplicate positions: {positions}.")
+            members.sort(key=lambda symbol: symbol.interface.position)
+            declarations += (
+                f"{self._nindent}common /{name}/ "
+                f"{', '.join(symbol.name for symbol in members)}\n")
+
+        return declarations
 
     def gen_interfacedecl(self, symbol):
         '''
@@ -1073,6 +1103,8 @@ class FortranWriter(LanguageWriter):
         for symbol in all_symbols:
             declarations += self.gen_vardecl(
                 symbol, include_visibility=is_module_scope)
+
+        declarations += self._gen_common_block_decls(all_symbols)
 
         return declarations
 

--- a/src/psyclone/psyir/frontend/fparser2.py
+++ b/src/psyclone/psyir/frontend/fparser2.py
@@ -2929,6 +2929,19 @@ class Fparser2Reader():
             been declared yet or when it is not just the symbol name).
 
         '''
+        # This method may be called more than once for the same common block:
+        # common /name/ var1, var2
+        # common /name/ var3, var4
+        # So we initialise the next position for each block from any interfaces
+        # that have already been created in this symbol table.
+        next_positions = {}
+        for symbol in psyir_parent.symbol_table.symbols:
+            if symbol.is_commonblock:
+                block_name = symbol.interface.name.lower()
+                next_positions[block_name] = max(
+                    next_positions.get(block_name, 0),
+                    symbol.interface.position + 1)
+
         for node in nodes:
             if isinstance(node, Fortran2003.Common_Stmt):
                 # Get the names of the symbols accessed with the commonblock,
@@ -2939,7 +2952,7 @@ class Fparser2Reader():
                     for cb_object in node.children[0]:
                         # Get the name of the common block
                         name = cb_object[0]
-                        name_str = name.string if name is not None else ""
+                        nstr = name.string.lower() if name is not None else ""
 
                         for symbol_name in cb_object[1].items:
                             sym = psyir_parent.symbol_table.lookup(
@@ -2951,7 +2964,9 @@ class Fparser2Reader():
                                     f" ({sym.initial_value.debug_string()}) "
                                     f"but appears in a common block. This is "
                                     f"not valid Fortran.")
-                            sym.interface = CommonBlockInterface(name_str)
+                            sym.interface = CommonBlockInterface(
+                                nstr, next_positions.get(nstr, 0))
+                            next_positions[nstr] = (sym.interface.position + 1)
                 except KeyError as error:
                     raise NotImplementedError(
                         f"The symbol interface of a common block variable "

--- a/src/psyclone/psyir/symbols/interfaces.py
+++ b/src/psyclone/psyir/symbols/interfaces.py
@@ -71,17 +71,29 @@ class CommonBlockInterface(SymbolInterface):
     can be accessed by any scope referencing the same CommonBlock name.
 
     :param common_block_name: the name of the common block.
+    :param position: the position of the Symbol in the common block.
 
-    :raises TypeError: if the common_block_name is not a str
+    :raises TypeError: if the common_block_name is not a str or position is
+        not an int.
+    :raises ValueError: if position is negative.
     '''
 
-    def __init__(self, common_block_name: str):
+    def __init__(self, common_block_name: str, position: int):
         super().__init__()
         if not isinstance(common_block_name, str):
             raise TypeError(
                 f"The common block name should be a valid string, but"
                 f" found '{type(common_block_name).__name__}'")
+        if not isinstance(position, int):
+            raise TypeError(
+                f"The common block position should be an int, but found "
+                f"'{type(position).__name__}'")
+        if position < 0:
+            raise ValueError(
+                f"The common block position should be non-negative, but "
+                f"found '{position}'")
         self._name = common_block_name
+        self._position = position
 
     def __str__(self):
         return f"CommonBlock '{self._name}'"
@@ -89,7 +101,8 @@ class CommonBlockInterface(SymbolInterface):
     def __eq__(self, other: Any) -> bool:
         return (
             super().__eq__(other) and
-            self._name.lower() == other.name.lower()
+            self._name.lower() == other.name.lower() and
+            self._position == other.position
         )
 
     @property
@@ -100,11 +113,19 @@ class CommonBlockInterface(SymbolInterface):
         '''
         return self._name
 
+    @property
+    def position(self) -> int:
+        '''
+        :returns: the position of the Symbol in the common block.
+
+        '''
+        return self._position
+
     def copy(self) -> 'CommonBlockInterface':
         '''
         :returns: a copy of this object.
         '''
-        return self.__class__(self._name)
+        return self.__class__(self._name, self._position)
 
 
 class UnresolvedInterface(SymbolInterface):

--- a/src/psyclone/psyir/symbols/symbol_table.py
+++ b/src/psyclone/psyir/symbols/symbol_table.py
@@ -1322,6 +1322,8 @@ class SymbolTable():
         :raises KeyError: if the supplied symbol is not in the symbol table.
         :raises ValueError: if the supplied container symbol is referenced
                             by one or more DataSymbols.
+        :raises ValueError: if the supplied symbol belongs to a common block
+                            and is not its final member.
         :raises InternalError: if the supplied symbol is not the same as the
                                entry with that name in this SymbolTable.
         '''
@@ -1343,6 +1345,22 @@ class SymbolTable():
                 f"The Symbol with name '{symbol.name}' in this symbol table "
                 f"is not the same Symbol object as the one that has been "
                 f"supplied to the remove() method.")
+
+        # Removing a member from within a common block would shift every
+        # subsequent member to a different storage position. Only removal
+        # from the end preserves the existing storage sequence.
+        if symbol.is_commonblock:
+            block_name = symbol.interface.name.lower()
+            for other_symbol in self.symbols:
+                if (other_symbol.is_commonblock and
+                        other_symbol.interface.name.lower() == block_name and
+                        other_symbol.interface.position >
+                        symbol.interface.position):
+                    raise ValueError(
+                        f"Cannot remove Symbol '{symbol.name}' from common "
+                        f"block '{symbol.interface.name}' because it has a "
+                        f"subsequent member. Only the final member of a "
+                        f"common block may be removed.")
 
         # We can only remove a ContainerSymbol if no DataSymbols are
         # being imported from it

--- a/src/psyclone/tests/psyir/backend/fortran_common_block_test.py
+++ b/src/psyclone/tests/psyir/backend/fortran_common_block_test.py
@@ -7,13 +7,19 @@
 
 '''Performs pytest tests on PSyIR Fortran Backend for CommonBlocks '''
 
+import pytest
+
+from psyclone.psyir.backend.visitor import VisitorError
 from psyclone.psyir.nodes import Routine
+from psyclone.psyir.symbols import (
+    CommonBlockInterface, DataSymbol, ScalarType)
 from psyclone.tests.utilities import Compile
 
 
 def test_fw_common_blocks(fortran_reader, fortran_writer, tmpdir):
     '''Test that declarations with common blocks are maintained in the
-    generated Fortran.
+    generated Fortran. Note that some declarations are purposely out of order
+    but the common block symbol sequence should remain the same.
 
     '''
     # Generate PSyIR from Fortran code.
@@ -21,7 +27,7 @@ def test_fw_common_blocks(fortran_reader, fortran_writer, tmpdir):
         "module test\n"
         "  contains\n"
         "  subroutine sub()\n"
-        "    integer :: a, b, c\n"
+        "    integer :: c, b, a\n"
         "    real :: d, e, f\n"
         "    common /name1/ a, b\n"
         "    common /name1/ c /name2/ d\n"
@@ -36,17 +42,32 @@ def test_fw_common_blocks(fortran_reader, fortran_writer, tmpdir):
     code = fortran_writer(routine)
     assert code == (
         "subroutine sub()\n"
-        "  integer :: a\n"
-        "  common /name1/ a\n"
-        "  integer :: b\n"
-        "  common /name1/ b\n"
         "  integer :: c\n"
-        "  common /name1/ c\n"
+        "  integer :: b\n"
+        "  integer :: a\n"
         "  real :: d\n"
-        "  common /name2/ d\n"
         "  real :: e\n"
-        "  common // e\n"
         "  real :: f\n"
-        "  common // f\n\n\n"
+        "  common /name1/ a, b, c\n"
+        "  common /name2/ d\n"
+        "  common // e, f\n\n\n"
         "end subroutine sub\n")
     assert Compile(tmpdir).string_compiles(fortran_writer(psyir))
+
+
+def test_fw_common_block_duplicate_positions(fortran_writer):
+    '''Test that the backend is case-insensitibe to common block names and
+    duplicate positions within one common block are rejected.'''
+    routine = Routine.create("sub")
+    routine.symbol_table.add(DataSymbol(
+        "var1", ScalarType.integer_type(),
+        interface=CommonBlockInterface("somegroup", 0)))
+    routine.symbol_table.add(DataSymbol(
+        "var2", ScalarType.integer_type(),
+        interface=CommonBlockInterface("SOMEGROUP", 0)))
+
+    with pytest.raises(VisitorError) as err:
+        _ = fortran_writer(routine)
+
+    assert ("Common block 'somegroup' has Symbols with duplicate positions: "
+            "[0, 0]." in str(err.value))

--- a/src/psyclone/tests/psyir/frontend/fparser2_common_block_test.py
+++ b/src/psyclone/tests/psyir/frontend/fparser2_common_block_test.py
@@ -33,10 +33,9 @@ def test_named_common_block():
     processor.process_declarations(routine, fparser2spec.content, [])
 
     # The variables have been updated to a common block interface
-    name1_cb = CommonBlockInterface('name1')
-    assert symtab.lookup("a").interface == name1_cb
-    assert symtab.lookup("b").interface == name1_cb
-    assert symtab.lookup("c").interface == name1_cb
+    assert symtab.lookup("a").interface == CommonBlockInterface('name1', 0)
+    assert symtab.lookup("b").interface == CommonBlockInterface('name1', 1)
+    assert symtab.lookup("c").interface == CommonBlockInterface('name1', 2)
 
     # The same common block can also bring other variables in a separate
     # statement
@@ -47,10 +46,10 @@ def test_named_common_block():
     fparser2spec = Specification_Part(reader)
     processor.process_declarations(routine, fparser2spec.content, [])
 
-    assert symtab.lookup("d").interface == name1_cb
-    assert symtab.lookup("e").interface == name1_cb
+    assert symtab.lookup("d").interface == CommonBlockInterface('name1', 3)
+    assert symtab.lookup("e").interface == CommonBlockInterface('name1', 4)
     fsym = symtab.lookup("f")
-    assert isinstance(fsym.interface, CommonBlockInterface)
+    assert fsym.interface == CommonBlockInterface('name1', 5)
     assert fsym.datatype.intrinsic is ScalarType.Intrinsic.REAL
 
 
@@ -71,10 +70,9 @@ def test_unnamed_commonblock():
     processor.process_declarations(routine, fparser2spec.content, [])
 
     # The variables have been updated to the unnamed common block interface
-    unnamed_cb = CommonBlockInterface("")
-    assert symtab.lookup("a").interface == unnamed_cb
-    assert symtab.lookup("b").interface == unnamed_cb
-    assert symtab.lookup("c").interface == unnamed_cb
+    assert symtab.lookup("a").interface == CommonBlockInterface("", 0)
+    assert symtab.lookup("b").interface == CommonBlockInterface("", 1)
+    assert symtab.lookup("c").interface == CommonBlockInterface("", 2)
 
 
 @pytest.mark.usefixtures("f2008_parser")
@@ -101,12 +99,10 @@ def test_multiple_commonblocks_and_comments():
     processor.process_declarations(routine, fparser2spec.content, [])
 
     # The variables have been updated to a common block interface
-    name1_cb = CommonBlockInterface('name1')
-    name2_cb = CommonBlockInterface('name2')
-    assert symtab.lookup("a").interface == name1_cb
-    assert symtab.lookup("b").interface == name1_cb
-    assert symtab.lookup("c").interface == name2_cb
-    assert symtab.lookup("d").interface == name2_cb
+    assert symtab.lookup("a").interface == CommonBlockInterface('name1', 0)
+    assert symtab.lookup("b").interface == CommonBlockInterface('name1', 1)
+    assert symtab.lookup("c").interface == CommonBlockInterface('name2', 0)
+    assert symtab.lookup("d").interface == CommonBlockInterface('name2', 1)
 
     # The comments are currently discarded
     assert symtab.lookup("a").preceding_comment == ""

--- a/src/psyclone/tests/psyir/symbols/interfaces_test.py
+++ b/src/psyclone/tests/psyir/symbols/interfaces_test.py
@@ -63,26 +63,38 @@ def test_commonblockinterface():
     __str__, __eq__, copy, and property methods.
 
     '''
-    interface = CommonBlockInterface("name")
-    interface.name == "name"
+    interface = CommonBlockInterface("name", 1)
+    assert interface.name == "name"
+    assert interface.position == 1
     assert str(interface) == "CommonBlock 'name'"
 
     # Interfaces can be unnamed
-    interface2 = CommonBlockInterface("")
-    interface2.name == ""
+    interface2 = CommonBlockInterface("", 0)
+    assert interface2.name == ""
     assert str(interface2) == "CommonBlock ''"
 
     # Check that they only accept strings
     with pytest.raises(TypeError) as err:
-        _ = CommonBlockInterface(3)
+        _ = CommonBlockInterface(3, 0)
     assert ("The common block name should be a valid string, but found 'int'"
             in str(err.value))
+
+    with pytest.raises(TypeError) as err:
+        _ = CommonBlockInterface("name", "first")
+    assert ("The common block position should be an int, but found 'str'"
+            in str(err.value))
+
+    with pytest.raises(ValueError) as err:
+        _ = CommonBlockInterface("name", -1)
+    assert ("The common block position should be non-negative, but found "
+            "'-1'" in str(err.value))
 
     # Test copy and equality
     assert interface != interface2
     copy = interface.copy()
     assert interface is not copy
     assert interface == copy
+    assert interface != CommonBlockInterface("name", 2)
 
 
 def test_unresolvedinterface():

--- a/src/psyclone/tests/psyir/symbols/symbol_table_test.py
+++ b/src/psyclone/tests/psyir/symbols/symbol_table_test.py
@@ -2886,7 +2886,7 @@ def test_rename_symbol_errors():
 
     # Cannot rename a common block symbol
     asym = symbols.DataSymbol("a", symbols.ScalarType.integer_type(),
-                              interface=symbols.CommonBlockInterface(""))
+                              interface=symbols.CommonBlockInterface("", 0))
     table.add(asym)
     with pytest.raises(symbols.SymbolError) as err:
         table.rename_symbol(asym, "b")

--- a/src/psyclone/tests/psyir/symbols/symbol_table_test.py
+++ b/src/psyclone/tests/psyir/symbols/symbol_table_test.py
@@ -632,6 +632,43 @@ def test_remove_case_insensitive(sym_name):
     assert "var1" not in sym_table
 
 
+@pytest.mark.parametrize("block_name", ["some_block", ""])
+def test_remove_commonblock_symbols_from_tail(block_name):
+    '''Check that common-block members may only be removed from the end of
+    their storage sequence. This applies to named and blank common blocks.
+
+    '''
+    sym_table = symbols.SymbolTable()
+    symbol1 = symbols.DataSymbol(
+        "var1", symbols.ScalarType.integer_type(),
+        interface=symbols.CommonBlockInterface(block_name, 0))
+    symbol2 = symbols.DataSymbol(
+        "var2", symbols.ScalarType.integer_type(),
+        interface=symbols.CommonBlockInterface(block_name.upper(), 1))
+    symbol3 = symbols.DataSymbol(
+        "var3", symbols.ScalarType.integer_type(),
+        interface=symbols.CommonBlockInterface(block_name, 3))
+    sym_table.add(symbol1)
+    sym_table.add(symbol2)
+    sym_table.add(symbol3)
+
+    with pytest.raises(ValueError) as err:
+        sym_table.remove(symbol2)
+
+    assert (f"Cannot remove Symbol 'var2' from common block "
+            f"'{symbol2.interface.name}' because it has a subsequent member. "
+            f"Only the final member of a common block may be removed." in
+            str(err.value))
+    assert symbol2 in sym_table.symbols
+
+    # Removing members from the tail inwards is permitted. Gaps in the
+    # positions do not affect which member is last.
+    sym_table.remove(symbol3)
+    sym_table.remove(symbol2)
+    sym_table.remove(symbol1)
+    assert not sym_table.symbols
+
+
 def test_swap_symbol():
     ''' Test the SymbolTable.swap() method. '''
     symbol1 = symbols.Symbol("var1")

--- a/src/psyclone/tests/psyir/symbols/symbol_test.py
+++ b/src/psyclone/tests/psyir/symbols/symbol_test.py
@@ -131,7 +131,7 @@ def test_symbol_interface_setter_and_is_properties():
     assert not symbol.is_commonblock
     assert not symbol.is_unknown_interface
 
-    symbol.interface = CommonBlockInterface("")
+    symbol.interface = CommonBlockInterface("", 0)
     assert not symbol.is_automatic
     assert not symbol.is_import
     assert not symbol.is_argument


### PR DESCRIPTION
We do it by keeping a index in the CommonBlockInterface:
- the frontend will keep track of the index number when inserting multiple symbols to the same common interface looking at the previous inserted symbols.
- the backend will order them using this value

I also tweaked symbol removal to ensure we don't remove symbols that would leave a gap in the sequence.