### PR TITLE
#3583 Preserve Symbol tag when swapping symbols in a SymbolTable

### DIFF
--- a/src/psyclone/psyir/symbols/symbol_table.py
+++ b/src/psyclone/psyir/symbols/symbol_table.py
@@ -1253,13 +1253,20 @@ class SymbolTable():
             raise SymbolError(
                 f"Cannot swap symbols that have different names, got: "
                 f"'{old_symbol.name}' and '{new_symbol.name}'")
+        # Preserve any tag associated with old_symbol so that it is carried
+        # over to new_symbol rather than being silently dropped.
+        old_tag = None
+        for tag, symbol in self._tags.items():
+            if symbol is old_symbol:
+                old_tag = tag
+                break
         for sym in self.symbols:
             sym.replace_symbols_using(new_symbol)
         if self.node:
             # Update the PSyIR tree associated with this table.
             self.node.replace_symbols_using(new_symbol)
         self.remove(old_symbol)
-        self.add(new_symbol)
+        self.add(new_symbol, tag=old_tag)
 
     def _validate_remove_routinesymbol(self, symbol):
         '''

--- a/src/psyclone/psyir/symbols/symbol_table.py
+++ b/src/psyclone/psyir/symbols/symbol_table.py
@@ -1228,16 +1228,15 @@ class SymbolTable():
         return [symbol for symbol in self.imported_symbols if
                 symbol.interface.container_symbol is csymbol]
 
-    def swap(self, old_symbol, new_symbol):
+    def swap(self, old_symbol: Symbol, new_symbol: Symbol) -> None:
         '''
         Remove the `old_symbol` from the table and replace it with the
         `new_symbol`. Any references to `old_symbol` in the PSyIR tree
-        associated with this table (if any) will also be updated.
+        associated with this table (if any) will also be updated. Any tag
+        associated with `old_symbol` is moved to `new_symbol`.
 
         :param old_symbol: the symbol to remove from the table.
-        :type old_symbol: :py:class:`psyclone.psyir.symbols.Symbol`
         :param new_symbol: the symbol to add to the table.
-        :type new_symbol: :py:class:`psyclone.psyir.symbols.Symbol`
 
         :raises TypeError: if either old/new_symbol are not Symbols.
         :raises SymbolError: if `old_symbol` and `new_symbol` don't have

--- a/src/psyclone/tests/psyir/symbols/symbol_table_test.py
+++ b/src/psyclone/tests/psyir/symbols/symbol_table_test.py
@@ -699,6 +699,21 @@ def test_swap_symbol():
     assert symbol1 not in sym_table._symbols
 
 
+def test_swap_symbol_preserves_tag():
+    ''' Test that SymbolTable.swap() preserves any tag associated with the
+    old symbol by re-associating it with the new symbol. '''
+    sym_table = symbols.SymbolTable()
+    symbol1 = symbols.Symbol("var1")
+    sym_table.add(symbol1, tag="var1_tag")
+    symbol2 = symbols.Symbol("Var1")
+
+    sym_table.swap(symbol1, symbol2)
+
+    assert sym_table.lookup("var1") is symbol2
+    # The tag must follow the new symbol rather than being dropped.
+    assert sym_table.lookup_with_tag("var1_tag") is symbol2
+
+
 def test_check_for_clashes_imports():
     '''Test the check_for_clashes method for two tables that import the same
     symbol from different tables.'''

--- a/src/psyclone/tests/psyir/symbols/symbol_table_test.py
+++ b/src/psyclone/tests/psyir/symbols/symbol_table_test.py
@@ -710,7 +710,7 @@ def test_swap_symbol_preserves_tag():
     sym_table.swap(symbol1, symbol2)
 
     assert sym_table.lookup("var1") is symbol2
-    # The tag must follow the new symbol rather than being dropped.
+    # Search for tag must find the new symbol rather than being dropped.
     assert sym_table.lookup_with_tag("var1_tag") is symbol2
 
 


### PR DESCRIPTION
## Summary

Fixes #3583: `SymbolTable.swap()` silently drops any tag associated with the
old symbol.

## Root cause

`swap()` calls `remove(old_symbol)` — which disassociates any tag pointing at
the symbol — and then `add(new_symbol)` without a `tag` argument, so the tag is
never re-established on the new symbol.

## Changes

`src/psyclone/psyir/symbols/symbol_table.py`:
- Before removal, record the tag associated with `old_symbol` (at most one
  exists per symbol, per the `get_reverse_tags_dict()` invariant), then pass it
  to `add(new_symbol, tag=old_tag)` so the tag follows the replacement.

`src/psyclone/tests/psyir/symbols/symbol_table_test.py`:
- Added `test_swap_symbol_preserves_tag`, which swaps a tagged symbol and
  asserts the tag now resolves to the new symbol via `lookup_with_tag`.

## Verification

- `flake8 --count --show-source --statistics src/psyclone/psyir/symbols/symbol_table.py` — 0 issues
- `pylint src/psyclone/psyir/symbols/symbol_table.py` — only pre-existing
  warnings (TODO comments, `too-many-branches`/`too-many-statements` in `add`
  and other existing methods); the changed `swap` method is clean
- `pytest src/psyclone/tests/psyir/symbols/symbol_table_test.py -q` — 105 passed, 1 xfailed

## AI assistance disclosure

This change was implemented with AI assistance (Pi coding agent). The author
reviewed and verified every line, reproduced the bug by reading the
`remove`/`add`/`swap` code paths, and ran the checks above to confirm the
reported results.
